### PR TITLE
Execute alert route actions and recovery automation

### DIFF
--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/commands/AlertGroupCommands.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/commands/AlertGroupCommands.kt
@@ -4,6 +4,7 @@
 
 package com.moneat.enterprise.alertroutes.commands
 
+import com.moneat.enterprise.incidents.models.NativeIncidentStatus
 import kotlin.uuid.Uuid
 
 data class AlertGroupActor(val organizationId: Int, val userId: Int, val origin: String)
@@ -61,6 +62,9 @@ data class CreateAlertGroupTriageCommand(
     override val expectedVersion: Int,
     val title: String? = null,
     val summary: String? = null,
+    val initialStatus: NativeIncidentStatus = NativeIncidentStatus.TRIAGE,
+    val severity: String? = null,
+    val incidentType: String? = null,
 ) : AlertGroupCommand {
     override val type = AlertGroupCommandType.CREATE_TRIAGE
 }

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/models/AlertGroupModels.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/models/AlertGroupModels.kt
@@ -48,6 +48,7 @@ enum class AlertGroupDecisionType(val wire: String) {
     ATTACHED("ATTACHED"),
     AUTOMATICALLY_ATTACHED("AUTOMATICALLY_ATTACHED"),
     TRIAGE_CREATED("TRIAGE_CREATED"),
+    RECOVERY_COMPLETED("RECOVERY_COMPLETED"),
 }
 
 object EnterpriseAlertGroups : IntIdTable("enterprise_alert_groups") {

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertGroupCommandService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertGroupCommandService.kt
@@ -159,7 +159,10 @@ class AlertGroupCommandService(
                 title = title,
                 description = null,
                 summary = command.summary?.trim()?.takeIf(String::isNotEmpty) ?: snapshot.text("summary"),
-                initialStatus = NativeIncidentStatus.TRIAGE,
+                severity = command.severity?.trim()?.takeIf(String::isNotEmpty) ?: snapshot.text("severity"),
+                incidentType =
+                    command.incidentType?.trim()?.takeIf(String::isNotEmpty) ?: snapshot.text("incidentType"),
+                initialStatus = command.initialStatus,
             ),
         )
         val attach = AttachAlertGroupIncidentCommand(
@@ -336,6 +339,9 @@ class AlertGroupCommandService(
             is CreateAlertGroupTriageCommand -> {
                 parts.add(command.title.orEmpty())
                 parts.add(command.summary.orEmpty())
+                parts.add(command.initialStatus.wire)
+                parts.add(command.severity.orEmpty())
+                parts.add(command.incidentType.orEmpty())
             }
         }
         return sha256(parts.joinToString("\u001F"))

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertGroupRecords.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertGroupRecords.kt
@@ -90,5 +90,6 @@ data class AlertGroupEscalationRecord(
     val escalationKey: String,
     val onCallAlertId: Uuid?,
     val state: AlertGroupEscalationState,
+    /** Timestamp observed on the persisted record; write operations assign their own transition time. */
     val updatedAt: Instant? = null,
 )

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertGroupRecords.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertGroupRecords.kt
@@ -75,6 +75,14 @@ data class AlertGroupPagingCompletion(
     val succeeded: Boolean,
 )
 
+data class AlertGroupPagingClaim(
+    val organizationId: Int,
+    val groupId: Uuid,
+    val episodeId: Uuid,
+    val commandKey: String,
+    val now: Instant = kotlin.time.Clock.System.now(),
+)
+
 data class AlertGroupEscalationRecord(
     val organizationId: Int,
     val groupId: Uuid,
@@ -82,4 +90,5 @@ data class AlertGroupEscalationRecord(
     val escalationKey: String,
     val onCallAlertId: Uuid?,
     val state: AlertGroupEscalationState,
+    val updatedAt: Instant? = null,
 )

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertGroupService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertGroupService.kt
@@ -10,6 +10,7 @@ import com.moneat.enterprise.alertroutes.context.AlertRouteContext
 import com.moneat.enterprise.alertroutes.evaluation.AlertRouteDecision
 import com.moneat.enterprise.alertroutes.evaluation.CanonicalAlertGrouping
 import com.moneat.enterprise.alertroutes.models.AlertGroupDecisionType
+import com.moneat.enterprise.alertroutes.models.AlertGroupEscalationState
 import com.moneat.enterprise.alertroutes.models.AlertGroupMemberState
 import com.moneat.enterprise.alertroutes.models.AlertGroupPagingState
 import com.moneat.enterprise.alertroutes.models.AlertGroupState
@@ -31,19 +32,27 @@ import com.moneat.shared.models.Organizations
 import com.moneat.shared.models.EscalationPolicies
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
+import org.jetbrains.exposed.v1.core.Exists
+import org.jetbrains.exposed.v1.core.JoinType
+import org.jetbrains.exposed.v1.core.NotExists
 import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.greater
 import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.core.isNull
 import org.jetbrains.exposed.v1.core.lessEq
+import org.jetbrains.exposed.v1.core.like
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
 import org.jetbrains.exposed.v1.jdbc.insertIgnore
+import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 import kotlin.uuid.Uuid
@@ -57,6 +66,36 @@ private const val MAX_GROUP_PAGE_SIZE = 200
 
 /** Transactional grouping persistence used by route execution and responder commands. */
 class AlertGroupService(private val policy: AlertGroupPolicy = AlertGroupPolicy()) {
+    fun findCandidateIncident(
+        organizationId: Int,
+        routeId: Uuid,
+        identityHash: String,
+    ): Uuid? {
+        policy.requireEnabled(organizationId)
+        return transaction {
+            EnterpriseAlertGroups
+                .selectAll()
+                .where {
+                    (EnterpriseAlertGroups.organizationId eq organizationId) and
+                        (EnterpriseAlertGroups.routeResourceId eq routeId) and
+                        (EnterpriseAlertGroups.identityHash eq identityHash)
+                }.orderBy(EnterpriseAlertGroups.updatedAt to SortOrder.DESC)
+                .mapNotNull { it[EnterpriseAlertGroups.incidentId] }
+                .distinct()
+                .firstNotNullOfOrNull { incidentId ->
+                    OnCallIncidents
+                        .selectAll()
+                        .where {
+                            (OnCallIncidents.organizationId eq organizationId) and
+                                (OnCallIncidents.id eq incidentId) and
+                                (OnCallIncidents.status inList ELIGIBLE_INCIDENT_STATUSES.map { it.wire })
+                        }.limit(1)
+                        .firstOrNull()
+                        ?.get(OnCallIncidents.resourceId)
+                }
+        }
+    }
+
     fun list(
         organizationId: Int,
         limit: Int = DEFAULT_GROUP_PAGE_SIZE,
@@ -71,6 +110,68 @@ class AlertGroupService(private val policy: AlertGroupPolicy = AlertGroupPolicy(
     fun get(organizationId: Int, groupId: Uuid): AlertGroupRecord {
         policy.requireEnabled(organizationId)
         return AlertGroupReader.get(organizationId, groupId)
+    }
+
+    internal fun recoveryCandidates(limit: Int = 100): List<Pair<Int, Uuid>> = transaction {
+        val activeMembers = EnterpriseAlertGroupMembers
+            .select(EnterpriseAlertGroupMembers.id)
+            .where {
+                (EnterpriseAlertGroupMembers.groupId eq EnterpriseAlertGroups.id) and
+                    (EnterpriseAlertGroupMembers.state eq AlertGroupMemberState.ACTIVE.wire)
+            }
+        val unresolvedMembers = EnterpriseAlertGroupMembers
+            .select(EnterpriseAlertGroupMembers.id)
+            .where {
+                (EnterpriseAlertGroupMembers.groupId eq EnterpriseAlertGroups.id) and
+                    (EnterpriseAlertGroupMembers.state eq AlertGroupMemberState.ACTIVE.wire) and
+                    EnterpriseAlertGroupMembers.resolvedAt.isNull()
+            }
+        EnterpriseAlertGroups
+            .join(
+                EnterpriseAlertGroupDecisions,
+                JoinType.LEFT,
+                EnterpriseAlertGroups.id,
+                EnterpriseAlertGroupDecisions.groupId,
+                additionalConstraint = {
+                    EnterpriseAlertGroupDecisions.decisionType eq AlertGroupDecisionType.RECOVERY_COMPLETED.wire
+                },
+            )
+            .selectAll()
+            .where {
+                EnterpriseAlertGroupDecisions.id.isNull() and
+                    Exists(activeMembers) and
+                    NotExists(unresolvedMembers)
+            }
+            .orderBy(EnterpriseAlertGroups.updatedAt to SortOrder.ASC)
+            .limit(limit)
+            .map { group ->
+                val organizationId = group[EnterpriseAlertGroups.organizationId]
+                val record = AlertGroupReader.load(organizationId, group)
+                organizationId to record.id
+            }
+    }
+
+    internal fun completeRecovery(organizationId: Int, groupId: Uuid) {
+        policy.requireEnabled(organizationId)
+        transaction {
+            val group = AlertGroupReader.requireGroup(organizationId, groupId, lock = true)
+            EnterpriseAlertGroups.update({ EnterpriseAlertGroups.id eq group[EnterpriseAlertGroups.id] }) {
+                it[state] = AlertGroupState.CLOSED.wire
+                it[updatedAt] = Clock.System.now()
+            }
+            EnterpriseAlertGroupDecisions.insertIgnore {
+                it[resourceId] = Uuid.random()
+                it[EnterpriseAlertGroupDecisions.organizationId] = organizationId
+                it[EnterpriseAlertGroupDecisions.groupId] = group[EnterpriseAlertGroups.id].value
+                it[decisionType] = AlertGroupDecisionType.RECOVERY_COMPLETED.wire
+                it[alertEpisodeId] = null
+                it[incidentId] = group[EnterpriseAlertGroups.incidentId]
+                it[actorUserId] = null
+                it[commandKey] = "group-recovery:$groupId"
+                it[details] = emptyMap()
+                it[createdAt] = Clock.System.now()
+            }
+        }
     }
 
     fun recordFiring(
@@ -134,36 +235,65 @@ class AlertGroupService(private val policy: AlertGroupPolicy = AlertGroupPolicy(
         groupId: Uuid,
         episodeId: Uuid,
         commandKey: String,
-    ): Boolean {
+    ): Boolean = claimPaging(AlertGroupPagingClaim(organizationId, groupId, episodeId, commandKey))
+
+    fun claimPaging(claim: AlertGroupPagingClaim): Boolean {
+        val organizationId = claim.organizationId
+        val groupId = claim.groupId
+        val episodeId = claim.episodeId
+        val commandKey = claim.commandKey
         policy.requireEnabled(organizationId)
         return transaction {
             lockOrganization(organizationId)
             val group = AlertGroupReader.requireGroup(organizationId, groupId, lock = true)
             when (AlertRoutePagingMode.valueOf(group[EnterpriseAlertGroups.pagingMode])) {
                 AlertRoutePagingMode.NONE -> false
-                AlertRoutePagingMode.FIRST_EPISODE_PER_GROUP ->
-                    EnterpriseAlertGroups.update({
-                        (EnterpriseAlertGroups.id eq group[EnterpriseAlertGroups.id]) and
-                            (EnterpriseAlertGroups.pagingState inList retryablePagingStates)
-                    }) {
+                AlertRoutePagingMode.FIRST_EPISODE_PER_GROUP -> {
+                    val state = AlertGroupPagingState.valueOf(group[EnterpriseAlertGroups.pagingState])
+                    if (!canClaimPaging(state, group[EnterpriseAlertGroups.id].value, claim)) {
+                        return@transaction false
+                    }
+                    EnterpriseAlertGroups.update({ EnterpriseAlertGroups.id eq group[EnterpriseAlertGroups.id] }) {
                         it[pagingState] = AlertGroupPagingState.CLAIMED.wire
                         it[pagingCommandKey] = commandKey
-                        it[updatedAt] = Clock.System.now()
+                        it[updatedAt] = claim.now
                     } == 1
+                }
                 AlertRoutePagingMode.EVERY_EPISODE -> {
                     val member = requireMember(organizationId, group[EnterpriseAlertGroups.id].value, episodeId)
+                    val state = AlertGroupPagingState.valueOf(member[EnterpriseAlertGroupMembers.pagingState])
+                    if (!canClaimPaging(state, group[EnterpriseAlertGroups.id].value, claim)) {
+                        return@transaction false
+                    }
                     EnterpriseAlertGroupMembers.update({
-                        (EnterpriseAlertGroupMembers.id eq member[EnterpriseAlertGroupMembers.id]) and
-                            (EnterpriseAlertGroupMembers.pagingState inList retryablePagingStates)
+                        EnterpriseAlertGroupMembers.id eq member[EnterpriseAlertGroupMembers.id]
                     }) {
                         it[pagingState] = AlertGroupPagingState.CLAIMED.wire
                         it[pagingCommandKey] = commandKey
-                        it[updatedAt] = Clock.System.now()
+                        it[updatedAt] = claim.now
                     } == 1
                 }
             }
         }
     }
+
+    private fun canClaimPaging(
+        state: AlertGroupPagingState,
+        internalGroupId: Int,
+        claim: AlertGroupPagingClaim,
+    ): Boolean = state.wire in retryablePagingStates ||
+        (state == AlertGroupPagingState.CLAIMED && reclaimStalePaging(internalGroupId, claim))
+
+    private fun reclaimStalePaging(internalGroupId: Int, claim: AlertGroupPagingClaim): Boolean =
+        EnterpriseAlertGroupEscalations.update({
+            (EnterpriseAlertGroupEscalations.organizationId eq claim.organizationId) and
+                (EnterpriseAlertGroupEscalations.groupId eq internalGroupId) and
+                (EnterpriseAlertGroupEscalations.escalationKey like "${claim.commandKey}:%") and
+                (EnterpriseAlertGroupEscalations.state eq AlertGroupEscalationState.PENDING.wire) and
+                (EnterpriseAlertGroupEscalations.updatedAt lessEq claim.now - PAGING_CLAIM_TIMEOUT)
+        }) {
+            it[updatedAt] = claim.now
+        } > 0
 
     fun completePaging(completion: AlertGroupPagingCompletion) {
         policy.requireEnabled(completion.organizationId)
@@ -200,13 +330,12 @@ class AlertGroupService(private val policy: AlertGroupPolicy = AlertGroupPolicy(
     }
 
     /** Persist the concrete on-call alert created for one escalation target. */
-    fun recordEscalation(record: AlertGroupEscalationRecord) {
+    fun recordEscalation(record: AlertGroupEscalationRecord, now: Instant = Clock.System.now()) {
         policy.requireEnabled(record.organizationId)
         transaction {
             val group = AlertGroupReader.requireGroup(record.organizationId, record.groupId)
             requireEscalationPolicy(record.organizationId, record.escalationPolicyId)
             val alertInternalId = record.onCallAlertId?.let { requireOnCallAlert(record.organizationId, it) }
-            val now = Clock.System.now()
             EnterpriseAlertGroupEscalations.insertIgnore {
                 it[resourceId] = Uuid.random()
                 it[EnterpriseAlertGroupEscalations.organizationId] = record.organizationId
@@ -226,6 +355,29 @@ class AlertGroupService(private val policy: AlertGroupPolicy = AlertGroupPolicy(
                 it[state] = record.state.wire
                 it[updatedAt] = now
             }
+        }
+    }
+
+    fun escalations(organizationId: Int, groupId: Uuid): List<AlertGroupEscalationRecord> {
+        policy.requireEnabled(organizationId)
+        return transaction {
+            val group = AlertGroupReader.requireGroup(organizationId, groupId)
+            (EnterpriseAlertGroupEscalations leftJoin OnCallAlerts)
+                .selectAll()
+                .where {
+                    (EnterpriseAlertGroupEscalations.organizationId eq organizationId) and
+                        (EnterpriseAlertGroupEscalations.groupId eq group[EnterpriseAlertGroups.id].value)
+                }.map { row ->
+                    AlertGroupEscalationRecord(
+                        organizationId = organizationId,
+                        groupId = groupId,
+                        escalationPolicyId = row[EnterpriseAlertGroupEscalations.escalationPolicyId],
+                        escalationKey = row[EnterpriseAlertGroupEscalations.escalationKey],
+                        onCallAlertId = row.getOrNull(OnCallAlerts.resourceId),
+                        state = AlertGroupEscalationState.valueOf(row[EnterpriseAlertGroupEscalations.state]),
+                        updatedAt = row[EnterpriseAlertGroupEscalations.updatedAt],
+                    )
+                }
         }
     }
 
@@ -517,6 +669,7 @@ class AlertGroupService(private val policy: AlertGroupPolicy = AlertGroupPolicy(
 
     private companion object {
         const val MAX_COMMAND_KEY_LENGTH = 160
+        val PAGING_CLAIM_TIMEOUT = 5.minutes
         val ELIGIBLE_INCIDENT_STATUSES = setOf(NativeIncidentStatus.TRIAGE, NativeIncidentStatus.ACTIVE)
     }
 }

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteEvaluationService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteEvaluationService.kt
@@ -64,15 +64,26 @@ class AlertRouteEvaluationService(
     private val ownershipResolver: AlertRouteOwnershipResolver = DatabaseAlertRouteOwnershipResolver(),
     private val evaluator: AlertRouteEvaluator = AlertRouteEvaluator(DatabaseAlertRouteTeamEscalationResolver()),
 ) {
+    data class LiveEvaluation(
+        val context: AlertRouteContext,
+        val result: AlertRouteEvaluationResult,
+    )
+
     /** Evaluate the routes of the event's organization against a live alert. */
     fun evaluate(
         event: AlertLifecycleEvent,
         episode: AlertRouteEpisodeIdentity = AlertRouteEpisodeIdentity.UNKNOWN,
-    ): AlertRouteEvaluationResult {
+    ): AlertRouteEvaluationResult = evaluateLive(event, episode).result
+
+    fun evaluateLive(
+        event: AlertLifecycleEvent,
+        episode: AlertRouteEpisodeIdentity = AlertRouteEpisodeIdentity.UNKNOWN,
+    ): LiveEvaluation {
         policy.requireReadAllowed(event.organizationId)
         val approved = AlertRouteMetadataPolicy.approve(event.metadata)
         val ownership = ownershipResolver.resolve(event.organizationId, approved.values)
-        return evaluateContext(AlertRouteContextFactory.fromLifecycleEvent(event, episode, ownership))
+        val context = AlertRouteContextFactory.fromLifecycleEvent(event, episode, ownership)
+        return LiveEvaluation(context, evaluateContext(context))
     }
 
     /** Explain match and non-match for a supplied alert sample. */

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteExecutionService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteExecutionService.kt
@@ -18,6 +18,7 @@ import com.moneat.enterprise.alertroutes.models.AlertRoutePagingMode
 import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRoutes
 import com.moneat.enterprise.incidents.commands.DeclineIncidentCommand
 import com.moneat.enterprise.incidents.commands.IncidentCommandActor
+import com.moneat.enterprise.incidents.commands.IncidentCommandNotFoundException
 import com.moneat.enterprise.incidents.commands.IncidentCommandService
 import com.moneat.enterprise.incidents.models.NativeIncidentStatus
 import com.moneat.enterprise.incidents.models.NativeIncidentSourceLinks
@@ -326,7 +327,11 @@ class AlertRouteExecutionService(
         } ?: Memberships.selectAll().where { Memberships.organization_id eq organizationId }
             .orderBy(Memberships.user_id to SortOrder.ASC)
             .limit(1)
-            .single()[Memberships.user_id]
+            .firstOrNull()
+            ?.get(Memberships.user_id)
+            ?: throw IncidentCommandNotFoundException(
+                "No organization member is available for alert-route automation",
+            )
         AlertGroupActor(organizationId, userId, ROUTE_AUTOMATION_ORIGIN)
     }
 

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteExecutionService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteExecutionService.kt
@@ -1,0 +1,412 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.services
+
+import com.moneat.alerts.models.AlertStatus
+import com.moneat.alerts.services.AlertFanoutContext
+import com.moneat.enterprise.FeatureRegistry
+import com.moneat.enterprise.alertroutes.commands.AlertGroupActor
+import com.moneat.enterprise.alertroutes.commands.AttachAlertGroupIncidentCommand
+import com.moneat.enterprise.alertroutes.commands.CreateAlertGroupTriageCommand
+import com.moneat.enterprise.alertroutes.models.AlertGroupEscalationState
+import com.moneat.enterprise.alertroutes.models.AlertGroupMemberState
+import com.moneat.enterprise.alertroutes.models.AlertRouteGroupingBehavior
+import com.moneat.enterprise.alertroutes.models.AlertRouteIncidentMode
+import com.moneat.enterprise.alertroutes.models.AlertRoutePagingMode
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRoutes
+import com.moneat.enterprise.incidents.commands.DeclineIncidentCommand
+import com.moneat.enterprise.incidents.commands.IncidentCommandActor
+import com.moneat.enterprise.incidents.commands.IncidentCommandService
+import com.moneat.enterprise.incidents.models.NativeIncidentStatus
+import com.moneat.enterprise.incidents.models.NativeIncidentSourceLinks
+import com.moneat.enterprise.incidents.models.IncidentSourceType
+import com.moneat.enterprise.oncall.models.OnCallIncidents
+import com.moneat.enterprise.oncall.models.OnCallAlerts
+import com.moneat.shared.models.Memberships
+import com.moneat.utils.suspendRunCatching
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import mu.KotlinLogging
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+private const val ROUTE_ALERT_SOURCE = "alert-route"
+private const val ROUTE_AUTOMATION_ORIGIN = "ALERT_ROUTE"
+private val executionLogger = KotlinLogging.logger {}
+
+/** Executes the selected route without coupling it to workflow or provider delivery. */
+class AlertRouteExecutionService(
+    private val evaluationService: AlertRouteEvaluationService = AlertRouteEvaluationService(),
+    private val groupService: AlertGroupService = AlertGroupService(),
+    private val groupCommands: AlertGroupCommandService = AlertGroupCommandService(),
+    private val incidentCommands: IncidentCommandService = IncidentCommandService(),
+    private val onCallGateway: AlertRouteOnCallGateway = FeatureRegistryAlertRouteOnCallGateway,
+    private val now: () -> Instant = { Clock.System.now() },
+) {
+    suspend fun execute(context: AlertFanoutContext) {
+        val episode = context.episode ?: return
+        val episodeId = episode.resourceId
+        if (context.event.status == AlertStatus.RESOLVED) {
+            recover(context.event.organizationId, episodeId)
+            return
+        }
+        executeFiring(context, episode)
+    }
+
+    private suspend fun executeFiring(
+        context: AlertFanoutContext,
+        episode: com.moneat.alerts.services.AlertEpisodeContext,
+    ) {
+        val episodeId = episode.resourceId
+        val live = evaluationService.evaluateLive(
+            context.event,
+            com.moneat.enterprise.alertroutes.context.AlertRouteEpisodeIdentity.from(episode),
+        )
+        val decision = live.result.decision ?: return
+        val candidate = if (decision.grouping.behavior in CORRELATING_GROUPING_BEHAVIORS) {
+            groupService.findCandidateIncident(
+                context.event.organizationId,
+                decision.routeId,
+                decision.grouping.groupKey,
+            )
+        } else {
+            null
+        }
+        val group = groupService.recordFiring(live.context, decision, episodeId, candidate, now())
+        val incidentResult = runCatching { applyIncidentActions(context, episodeId, group) }
+        val pagingResult = suspendRunCatching {
+            if (!context.deliverySilenced) page(context, group, decision.paging.escalationPolicies.map { it.id })
+        }
+        incidentResult.exceptionOrNull()?.let { throw it }
+        pagingResult.getOrThrow()
+    }
+
+    private fun applyIncidentActions(
+        context: AlertFanoutContext,
+        episodeId: Uuid,
+        initialGroup: AlertGroupRecord,
+    ): AlertGroupRecord {
+        var group = initialGroup
+        val actor by lazy { resolveActor(context.event.organizationId, group.routeId) }
+        if (!context.deliverySilenced && group.incidentId == null) {
+            group = when {
+                group.candidateIncidentId != null && group.behavior == AlertRouteGroupingBehavior.AUTOMATIC ->
+                    groupCommands.execute(
+                        AttachAlertGroupIncidentCommand(
+                            commandKey = "route-auto-attach:${group.id}",
+                            actor = actor,
+                            groupId = group.id,
+                            expectedVersion = group.version,
+                            incidentId = group.candidateIncidentId,
+                            automatic = true,
+                        ),
+                    ).group
+                group.candidateIncidentId == null && group.incidentTemplateSnapshot.boolean("create") == true ->
+                    groupCommands.execute(
+                        CreateAlertGroupTriageCommand(
+                            commandKey = "route-create-incident:${group.id}",
+                            actor = actor,
+                            groupId = group.id,
+                            expectedVersion = group.version,
+                            initialStatus = group.incidentTemplateSnapshot.incidentStatus(),
+                        ),
+                    ).group
+                else -> group
+            }
+        }
+        val attachedIncident = group.incidentId
+        if (attachedIncident != null && isIncidentEligible(attachedIncident) &&
+            !isEpisodeLinked(attachedIncident, episodeId)
+        ) {
+            group = groupCommands.execute(
+                AttachAlertGroupIncidentCommand(
+                    commandKey = "route-link-episode:${group.id}:$episodeId",
+                    actor = actor,
+                    groupId = group.id,
+                    expectedVersion = group.version,
+                    incidentId = attachedIncident,
+                ),
+            ).group
+        }
+        return group
+    }
+
+    suspend fun recoverDue(enabled: (Int) -> Boolean = FeatureRegistry::isNativeIncidentResponseEnabled) {
+        groupService.recoveryCandidates().forEach { (organizationId, groupId) ->
+            if (!enabled(organizationId)) return@forEach
+            try {
+                recoverGroup(organizationId, groupService.get(organizationId, groupId))
+            } catch (error: kotlinx.coroutines.CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                executionLogger.error(error) {
+                    "Alert-route recovery failed for organization $organizationId and group $groupId"
+                }
+            }
+        }
+    }
+
+    private suspend fun page(context: AlertFanoutContext, group: AlertGroupRecord, policyIds: List<Int>) {
+        if (policyIds.isEmpty()) return
+        val episodeId = requireNotNull(context.episode).resourceId
+        val commandKey = pagingCommandKey(group, episodeId) ?: return
+        val attemptTime = now()
+        val existingByKey = groupService.escalations(context.event.organizationId, group.id)
+            .associateBy(AlertGroupEscalationRecord::escalationKey)
+        policyIds.distinct().forEach { policyId ->
+            val escalationKey = "$commandKey:$policyId"
+            if (existingByKey[escalationKey] == null) {
+                groupService.recordEscalation(
+                    AlertGroupEscalationRecord(
+                        context.event.organizationId,
+                        group.id,
+                        policyId,
+                        escalationKey,
+                        null,
+                        AlertGroupEscalationState.PENDING,
+                    ),
+                    attemptTime,
+                )
+            }
+        }
+        val persisted = groupService.escalations(context.event.organizationId, group.id)
+        if (!groupService.claimPaging(
+                AlertGroupPagingClaim(
+                    context.event.organizationId,
+                    group.id,
+                    episodeId,
+                    commandKey,
+                    attemptTime,
+                ),
+            )
+        ) {
+            return
+        }
+        var succeeded = true
+        policyIds.distinct().forEach { policyId ->
+            val escalationKey = "$commandKey:$policyId"
+            val existing = persisted.firstOrNull { it.escalationKey == escalationKey }
+            if (existing?.state == AlertGroupEscalationState.TRIGGERED) return@forEach
+            try {
+                val alertId = onCallGateway.trigger(
+                        AlertRouteEscalationRequest(
+                            organizationId = context.event.organizationId,
+                            escalationPolicyId = policyId,
+                            title = context.event.title,
+                            description = context.event.description,
+                            priority = context.event.priority.wire,
+                            alertSource = ROUTE_ALERT_SOURCE,
+                            deduplicationKey = escalationKey,
+                            metadata = Json.encodeToString(context.event.metadata),
+                        ),
+                    ) ?: existingOpenAlertId(context.event.organizationId, escalationKey)
+                    ?: error("Alert-route escalation did not create or locate an on-call alert")
+                groupService.recordEscalation(
+                    AlertGroupEscalationRecord(
+                        context.event.organizationId,
+                        group.id,
+                        policyId,
+                        escalationKey,
+                        Uuid.parse(alertId),
+                        AlertGroupEscalationState.TRIGGERED,
+                    ),
+                    now(),
+                )
+            } catch (error: kotlinx.coroutines.CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                succeeded = false
+                groupService.recordEscalation(
+                    AlertGroupEscalationRecord(
+                        context.event.organizationId,
+                        group.id,
+                        policyId,
+                        escalationKey,
+                        null,
+                        AlertGroupEscalationState.FAILED,
+                    ),
+                    now(),
+                )
+            }
+        }
+        groupService.completePaging(
+            AlertGroupPagingCompletion(
+                context.event.organizationId,
+                group.id,
+                episodeId,
+                commandKey,
+                succeeded,
+            ),
+        )
+        check(succeeded) { "One or more alert-route paging targets failed" }
+    }
+
+    private fun pagingCommandKey(group: AlertGroupRecord, episodeId: Uuid): String? =
+        when (group.pagingMode) {
+            AlertRoutePagingMode.FIRST_EPISODE_PER_GROUP -> "route-page:${group.id}"
+            AlertRoutePagingMode.EVERY_EPISODE -> "route-page:${group.id}:$episodeId"
+            AlertRoutePagingMode.NONE -> null
+        }
+
+    private suspend fun recover(organizationId: Int, episodeId: Uuid) {
+        val group = groupService.recordResolution(organizationId, episodeId, now()) ?: return
+        recoverGroup(organizationId, group)
+    }
+
+    private suspend fun recoverGroup(organizationId: Int, group: AlertGroupRecord) {
+        if (group.members.any { it.state == AlertGroupMemberState.ACTIVE && it.resolvedAt == null }) return
+        val recovery = group.routeSnapshot["route"]?.jsonObject?.get("recovery")?.jsonObject ?: JsonObject(emptyMap())
+        val grace = recovery["graceSeconds"]?.jsonPrimitive?.intOrNull ?: 0
+        val lastResolution = group.members.mapNotNull { it.resolvedAt }.maxOrNull() ?: return
+        if (now() < lastResolution + grace.seconds) return
+        if (recovery["cancelEscalations"]?.jsonPrimitive?.booleanOrNull == true) {
+            cancelEscalations(organizationId, group)
+        }
+        if (recovery["declineUnacceptedTriage"]?.jsonPrimitive?.booleanOrNull == true) declineTriage(group)
+        groupService.completeRecovery(organizationId, group.id)
+    }
+
+    private suspend fun cancelEscalations(organizationId: Int, group: AlertGroupRecord) {
+        groupService.escalations(organizationId, group.id)
+            .filter { it.state == AlertGroupEscalationState.TRIGGERED }
+            .forEach { escalation ->
+                onCallGateway.resolve(
+                    escalation.organizationId,
+                    ROUTE_ALERT_SOURCE,
+                    escalation.escalationKey,
+                )
+                groupService.recordEscalation(
+                    escalation.copy(state = AlertGroupEscalationState.CANCELLED),
+                )
+            }
+    }
+
+    private fun declineTriage(group: AlertGroupRecord) {
+        val incidentResourceId = group.incidentId ?: return
+        val incident = transaction {
+            OnCallIncidents.selectAll().where { OnCallIncidents.resourceId eq incidentResourceId }.singleOrNull()
+        } ?: return
+        if (NativeIncidentStatus.fromWire(incident[OnCallIncidents.status]) != NativeIncidentStatus.TRIAGE) return
+        val organizationId = incident[OnCallIncidents.organizationId]
+        val actor = resolveActor(organizationId, group.routeId)
+        incidentCommands.execute(
+            DeclineIncidentCommand(
+                commandKey = "route-auto-decline:${group.id}",
+                actor = IncidentCommandActor(organizationId, actor.userId, ROUTE_AUTOMATION_ORIGIN),
+                incidentId = incident[OnCallIncidents.id].value,
+                reason = "All linked alert episodes resolved",
+            ),
+        )
+    }
+
+    private fun resolveActor(organizationId: Int, routeId: Uuid): AlertGroupActor = transaction {
+        val creator = EnterpriseAlertRoutes.selectAll().where {
+            (EnterpriseAlertRoutes.organizationId eq organizationId) and
+                (EnterpriseAlertRoutes.resourceId eq routeId)
+        }.singleOrNull()?.get(EnterpriseAlertRoutes.createdBy)
+        val userId = creator?.takeIf { candidate ->
+            Memberships.selectAll().where {
+                (Memberships.organization_id eq organizationId) and (Memberships.user_id eq candidate)
+            }.limit(1).any()
+        } ?: Memberships.selectAll().where { Memberships.organization_id eq organizationId }
+            .orderBy(Memberships.user_id to SortOrder.ASC)
+            .limit(1)
+            .single()[Memberships.user_id]
+        AlertGroupActor(organizationId, userId, ROUTE_AUTOMATION_ORIGIN)
+    }
+
+    private fun isEpisodeLinked(incidentId: Uuid, episodeId: Uuid): Boolean = transaction {
+        val internalIncidentId = OnCallIncidents.selectAll().where { OnCallIncidents.resourceId eq incidentId }
+            .single()[OnCallIncidents.id].value
+        NativeIncidentSourceLinks.selectAll().where {
+            (NativeIncidentSourceLinks.incidentId eq internalIncidentId) and
+                (NativeIncidentSourceLinks.sourceType eq IncidentSourceType.ALERT_EPISODE.wire) and
+                (NativeIncidentSourceLinks.sourceKey eq episodeId.toString())
+        }.limit(1).any()
+    }
+
+    private fun isIncidentEligible(incidentId: Uuid): Boolean = transaction {
+        OnCallIncidents.selectAll().where { OnCallIncidents.resourceId eq incidentId }
+            .singleOrNull()
+            ?.get(OnCallIncidents.status)
+            ?.let(NativeIncidentStatus::fromWire)
+            ?.let { it == NativeIncidentStatus.TRIAGE || it == NativeIncidentStatus.ACTIVE }
+            ?: false
+    }
+
+    private fun existingOpenAlertId(organizationId: Int, escalationKey: String): String? = transaction {
+        OnCallAlerts.selectAll().where {
+            (OnCallAlerts.organizationId eq organizationId) and
+                (OnCallAlerts.alertSource eq ROUTE_ALERT_SOURCE) and
+                (OnCallAlerts.deduplicationKey eq escalationKey) and
+                (OnCallAlerts.status inList listOf("TRIGGERED", "ACKNOWLEDGED"))
+        }.singleOrNull()?.get(OnCallAlerts.resourceId)?.toString()
+    }
+
+    private fun Map<String, kotlinx.serialization.json.JsonElement>.boolean(key: String): Boolean? =
+        get(key)?.jsonPrimitive?.booleanOrNull
+
+    private fun Map<String, kotlinx.serialization.json.JsonElement>.incidentStatus(): NativeIncidentStatus =
+        when (get("mode")?.jsonPrimitive?.content) {
+            AlertRouteIncidentMode.ACTIVE.wire -> NativeIncidentStatus.ACTIVE
+            else -> NativeIncidentStatus.TRIAGE
+        }
+
+    private companion object {
+        val CORRELATING_GROUPING_BEHAVIORS = setOf(
+            AlertRouteGroupingBehavior.SUGGESTED,
+            AlertRouteGroupingBehavior.AUTOMATIC,
+        )
+    }
+}
+
+data class AlertRouteEscalationRequest(
+    val organizationId: Int,
+    val escalationPolicyId: Int,
+    val title: String,
+    val description: String?,
+    val priority: String,
+    val alertSource: String,
+    val deduplicationKey: String,
+    val metadata: String,
+)
+
+interface AlertRouteOnCallGateway {
+    suspend fun trigger(request: AlertRouteEscalationRequest): String?
+
+    suspend fun resolve(organizationId: Int, alertSource: String, deduplicationKey: String): Boolean
+}
+
+private object FeatureRegistryAlertRouteOnCallGateway : AlertRouteOnCallGateway {
+    override suspend fun trigger(request: AlertRouteEscalationRequest): String? =
+        requireNotNull(FeatureRegistry.getOnCallBridge()) { "On-call bridge is unavailable" }
+        .triggerEscalation(
+            request.organizationId,
+            request.escalationPolicyId,
+            request.title,
+            request.description,
+            request.priority,
+            request.alertSource,
+            request.deduplicationKey,
+            request.metadata,
+        )
+
+    override suspend fun resolve(organizationId: Int, alertSource: String, deduplicationKey: String): Boolean =
+        requireNotNull(FeatureRegistry.getOnCallBridge()) { "On-call bridge is unavailable" }
+            .resolveEscalation(organizationId, alertSource, deduplicationKey)
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteRecoveryWorker.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteRecoveryWorker.kt
@@ -1,0 +1,53 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.services
+
+import com.moneat.shared.services.TaskLock
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import mu.KotlinLogging
+import kotlin.time.Duration.Companion.minutes
+
+private val recoveryLogger = KotlinLogging.logger {}
+
+/** Replays due recovery after grace periods and process restarts. */
+class AlertRouteRecoveryWorker(private val executionService: AlertRouteExecutionService) {
+    private var job: Job? = null
+
+    fun start() {
+        if (job?.isActive == true) return
+        job = CoroutineScope(Dispatchers.IO + SupervisorJob()).launch {
+            while (isActive) {
+                try {
+                    TaskLock.tryWithLock(LOCK_NAME, lockAtMostFor = LOCK_DURATION) {
+                        executionService.recoverDue()
+                    }
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (error: Exception) {
+                    recoveryLogger.error(error) { "Alert-route recovery poll failed" }
+                }
+                delay(POLL_INTERVAL_MS)
+            }
+        }
+    }
+
+    fun stop() {
+        job?.cancel()
+        job = null
+    }
+
+    private companion object {
+        const val LOCK_NAME = "alert-route-recovery"
+        const val POLL_INTERVAL_MS = 30_000L
+        val LOCK_DURATION = 5.minutes
+    }
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/EnterpriseAlertRouteFanout.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/EnterpriseAlertRouteFanout.kt
@@ -7,16 +7,14 @@ package com.moneat.enterprise.alertroutes.services
 import com.moneat.alerts.services.AlertFanoutContext
 import com.moneat.alerts.services.AlertRouteFanout
 import com.moneat.enterprise.FeatureRegistry
-import com.moneat.enterprise.alertroutes.context.AlertRouteEpisodeIdentity
 
 /** Enterprise route-evaluation arm. Action execution is added by the downstream execution task. */
 class EnterpriseAlertRouteFanout(
-    private val evaluationService: AlertRouteEvaluationService = AlertRouteEvaluationService(),
+    private val executionService: AlertRouteExecutionService = AlertRouteExecutionService(),
     private val enabled: (Int) -> Boolean = FeatureRegistry::isNativeIncidentResponseEnabled,
 ) : AlertRouteFanout {
     override suspend fun process(context: AlertFanoutContext) {
         if (!enabled(context.event.organizationId)) return
-        val episode = context.episode?.let(AlertRouteEpisodeIdentity::from) ?: AlertRouteEpisodeIdentity.UNKNOWN
-        evaluationService.evaluate(context.event, episode)
+        executionService.execute(context)
     }
 }

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
@@ -15,6 +15,8 @@ import com.moneat.enterprise.PriorityInfo
 import com.moneat.enterprise.alertroutes.routes.alertRouteRoutes
 import com.moneat.enterprise.alertroutes.routes.alertGroupRoutes
 import com.moneat.enterprise.alertroutes.services.EnterpriseAlertRouteFanout
+import com.moneat.enterprise.alertroutes.services.AlertRouteExecutionService
+import com.moneat.enterprise.alertroutes.services.AlertRouteRecoveryWorker
 import com.moneat.enterprise.incidents.commands.DeclareIncidentCommand
 import com.moneat.enterprise.incidents.commands.IncidentCommandActor
 import com.moneat.enterprise.incidents.events.IncidentOutboxService
@@ -116,7 +118,9 @@ class OnCallModule :
             )
         }
     private val incidentOutboxWorker by incidentOutboxWorkerDelegate
-    private val alertRouteFanout = EnterpriseAlertRouteFanout()
+    private val alertRouteExecutionService = AlertRouteExecutionService()
+    private val alertRouteFanout = EnterpriseAlertRouteFanout(alertRouteExecutionService)
+    private val alertRouteRecoveryWorker = AlertRouteRecoveryWorker(alertRouteExecutionService)
 
     override val name: String = "On-Call"
     override val licenseFeature: String = "oncall"
@@ -147,6 +151,7 @@ class OnCallModule :
     override fun startBackgroundJobs(application: Application) {
         logger.info { "Starting on-call enterprise background jobs" }
         AlertRouteFanoutRegistry.register(alertRouteFanout)
+        alertRouteRecoveryWorker.start()
         escalationEngine.start()
         slackUserGroupSyncService.start()
         onCallHandoffService.start()
@@ -157,6 +162,7 @@ class OnCallModule :
     override fun stopBackgroundJobs() {
         logger.info { "Stopping on-call enterprise background jobs" }
         AlertRouteFanoutRegistry.unregister(alertRouteFanout)
+        alertRouteRecoveryWorker.stop()
         if (escalationEngineDelegate.isInitialized()) escalationEngine.stop()
         if (slackUserGroupSyncServiceDelegate.isInitialized()) slackUserGroupSyncService.stop()
         if (onCallHandoffServiceDelegate.isInitialized()) onCallHandoffService.stop()

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteExecutionServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteExecutionServiceTest.kt
@@ -28,16 +28,19 @@ import com.moneat.enterprise.alertroutes.models.AlertRouteGroupingBehavior
 import com.moneat.enterprise.alertroutes.models.AlertRouteIncidentMode
 import com.moneat.enterprise.alertroutes.models.AlertRoutePagingMode
 import com.moneat.enterprise.alertroutes.models.AlertRouteTargetKind
+import com.moneat.enterprise.incidents.commands.IncidentCommandNotFoundException
 import com.moneat.enterprise.incidents.commands.IncidentCommandPolicy
 import com.moneat.enterprise.incidents.commands.IncidentCommandService
 import com.moneat.enterprise.incidents.models.NativeIncidentStatus
 import com.moneat.enterprise.incidents.models.NativeIncidentSourceLinks
 import com.moneat.enterprise.oncall.models.OnCallIncidents
 import com.moneat.enterprise.oncall.models.OnCallAlerts
+import com.moneat.shared.models.Memberships
 import kotlinx.serialization.json.JsonObject
 import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
@@ -134,6 +137,28 @@ class AlertRouteExecutionServiceTest {
         val group = groupService.get(organization.organizationId, listed.id)
         assertEquals(null, group.incidentId)
         assertEquals(1, group.members.size)
+    }
+
+    @Test
+    fun `missing automation actor is explicit and does not block independent paging`() = runBlocking {
+        createRoute(
+            pagingTargets = 1,
+            incident = AlertRouteIncidentInput(create = true),
+        )
+        transaction {
+            Memberships.deleteWhere { Memberships.organization_id eq organization.organizationId }
+        }
+        val episodeId = AlertRouteTestDatabase.seedAlertEpisode(
+            organization.organizationId,
+            "HOST_ALERT",
+            "missing-actor",
+        )
+
+        assertFailsWith<IncidentCommandNotFoundException> {
+            executionService.execute(firingContext(episodeId))
+        }
+
+        assertEquals(1, gateway.triggered.size)
     }
 
     @Test

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteExecutionServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteExecutionServiceTest.kt
@@ -1,0 +1,592 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.services
+
+import com.moneat.alerts.models.AlertEpisodes
+import com.moneat.alerts.models.AlertLifecycleEvent
+import com.moneat.alerts.models.AlertPriority
+import com.moneat.alerts.models.AlertSource
+import com.moneat.alerts.models.AlertStatus
+import com.moneat.alerts.services.AlertEpisodeContext
+import com.moneat.alerts.services.AlertFanoutContext
+import com.moneat.enterprise.alertroutes.AlertRouteTestDatabase
+import com.moneat.enterprise.alertroutes.SeededAlertRouteOrganization
+import com.moneat.enterprise.alertroutes.commands.AlertGroupPolicy
+import com.moneat.enterprise.alertroutes.commands.AlertRouteActor
+import com.moneat.enterprise.alertroutes.commands.AlertRouteGroupingInput
+import com.moneat.enterprise.alertroutes.commands.AlertRouteIncidentInput
+import com.moneat.enterprise.alertroutes.commands.AlertRoutePagingInput
+import com.moneat.enterprise.alertroutes.commands.AlertRoutePolicy
+import com.moneat.enterprise.alertroutes.commands.AlertRouteRecoveryInput
+import com.moneat.enterprise.alertroutes.commands.AlertRouteSpecification
+import com.moneat.enterprise.alertroutes.commands.AlertRouteTargetInput
+import com.moneat.enterprise.alertroutes.commands.CreateAlertRouteCommand
+import com.moneat.enterprise.alertroutes.models.AlertGroupDecisionType
+import com.moneat.enterprise.alertroutes.models.AlertRouteGroupingBehavior
+import com.moneat.enterprise.alertroutes.models.AlertRouteIncidentMode
+import com.moneat.enterprise.alertroutes.models.AlertRoutePagingMode
+import com.moneat.enterprise.alertroutes.models.AlertRouteTargetKind
+import com.moneat.enterprise.incidents.commands.IncidentCommandPolicy
+import com.moneat.enterprise.incidents.commands.IncidentCommandService
+import com.moneat.enterprise.incidents.models.NativeIncidentStatus
+import com.moneat.enterprise.incidents.models.NativeIncidentSourceLinks
+import com.moneat.enterprise.oncall.models.OnCallIncidents
+import com.moneat.enterprise.oncall.models.OnCallAlerts
+import kotlinx.serialization.json.JsonObject
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+class AlertRouteExecutionServiceTest {
+    private lateinit var organization: SeededAlertRouteOrganization
+    private lateinit var routeService: AlertRouteCommandService
+    private lateinit var groupService: AlertGroupService
+    private lateinit var executionService: AlertRouteExecutionService
+    private lateinit var gateway: RecordingGateway
+    private lateinit var currentTime: AtomicReference<Instant>
+
+    @BeforeEach
+    fun setUp() {
+        AlertRouteTestDatabase.reset()
+        organization = AlertRouteTestDatabase.seedOrganization("route-execution")
+        routeService = AlertRouteCommandService(AlertRoutePolicy.allowForTests())
+        groupService = AlertGroupService(AlertGroupPolicy.allowForTests())
+        val incidentService = IncidentCommandService(policy = IncidentCommandPolicy.allowForTests())
+        gateway = RecordingGateway()
+        currentTime = AtomicReference(Instant.parse("2026-08-23T12:00:00Z"))
+        executionService = AlertRouteExecutionService(
+            evaluationService = AlertRouteEvaluationService(policy = AlertRoutePolicy.allowForTests()),
+            groupService = groupService,
+            groupCommands = AlertGroupCommandService(AlertGroupPolicy.allowForTests(), incidentService),
+            incidentCommands = incidentService,
+            onCallGateway = gateway,
+            now = currentTime::get,
+        )
+    }
+
+    @AfterEach
+    fun tearDown() = AlertRouteTestDatabase.clearReference()
+
+    @Test
+    fun `matched route pages every target once and creates one active incident across retries`() = runBlocking {
+        createRoute(
+            pagingTargets = 2,
+            incident = AlertRouteIncidentInput(
+                create = true,
+                mode = AlertRouteIncidentMode.ACTIVE,
+                titleTemplate = "{{alert.title}} incident",
+                severity = "SEV-1",
+            ),
+        )
+        val episodeId = AlertRouteTestDatabase.seedAlertEpisode(organization.organizationId, "DASHBOARD_ALERT", "retry")
+        val context = firingContext(episodeId)
+
+        executionService.execute(context)
+        executionService.execute(context)
+        val secondEpisode = AlertRouteTestDatabase.seedAlertEpisode(
+            organization.organizationId,
+            "DASHBOARD_ALERT",
+            "retry-second-member",
+        )
+        executionService.execute(firingContext(secondEpisode))
+
+        assertEquals(2, gateway.triggered.size)
+        val listed = groupService.list(organization.organizationId).single()
+        val group = groupService.get(organization.organizationId, listed.id)
+        assertEquals(2, groupService.escalations(organization.organizationId, group.id).size)
+        assertNotNull(group.incidentId)
+        transaction {
+            val incident = OnCallIncidents.selectAll().single()
+            assertEquals(NativeIncidentStatus.ACTIVE.wire, incident[OnCallIncidents.status])
+            assertEquals("Checkout latency incident", incident[OnCallIncidents.title])
+        }
+    }
+
+    @Test
+    fun `silence retains a group without paging or automatic incident creation`() = runBlocking {
+        createRoute(
+            pagingTargets = 1,
+            incident = AlertRouteIncidentInput(create = true),
+        )
+        val episodeId = AlertRouteTestDatabase.seedAlertEpisode(organization.organizationId, "HOST_ALERT", "silent")
+
+        executionService.execute(firingContext(episodeId).copy(deliverySilenced = true))
+
+        assertTrue(gateway.triggered.isEmpty())
+        val listed = groupService.list(organization.organizationId).single()
+        val group = groupService.get(organization.organizationId, listed.id)
+        assertEquals(null, group.incidentId)
+        assertEquals(1, group.members.size)
+    }
+
+    @Test
+    fun `resolution cancels route escalation and declines only unaccepted triage`() = runBlocking {
+        createRoute(
+            pagingTargets = 1,
+            incident = AlertRouteIncidentInput(create = true),
+            recovery = AlertRouteRecoveryInput(cancelEscalations = true, declineUnacceptedTriage = true),
+        )
+        val episodeId = AlertRouteTestDatabase.seedAlertEpisode(organization.organizationId, "HOST_ALERT", "recover")
+        executionService.execute(firingContext(episodeId))
+
+        gateway.resolveResult = false
+        currentTime.set(currentTime.get() + 1.seconds)
+        executionService.execute(firingContext(episodeId, AlertStatus.RESOLVED))
+
+        assertEquals(1, gateway.resolved.size)
+        val listed = groupService.list(organization.organizationId).single()
+        val group = groupService.get(organization.organizationId, listed.id)
+        assertTrue(group.decisions.any { it.type == AlertGroupDecisionType.TRIAGE_CREATED })
+        transaction {
+            assertEquals(
+                NativeIncidentStatus.DECLINED.wire,
+                OnCallIncidents.selectAll().single()[OnCallIncidents.status],
+            )
+        }
+    }
+
+    @Test
+    fun `dedup hit after a post-trigger crash reconciles the existing on-call alert`() = runBlocking {
+        createRoute(pagingTargets = 1, incident = AlertRouteIncidentInput())
+        gateway.returnNullAfterInsert = true
+        val episodeId = AlertRouteTestDatabase.seedAlertEpisode(organization.organizationId, "HOST_ALERT", "dedup")
+
+        executionService.execute(firingContext(episodeId))
+
+        val group = groupService.list(organization.organizationId).single()
+        assertEquals(1, gateway.triggered.size)
+        assertEquals(
+            com.moneat.enterprise.alertroutes.models.AlertGroupEscalationState.TRIGGERED,
+            groupService.escalations(organization.organizationId, group.id).single().state,
+        )
+    }
+
+    @Test
+    fun `stale paging claim is safely reclaimed after a process interruption`() = runBlocking {
+        createRoute(pagingTargets = 1, incident = AlertRouteIncidentInput())
+        gateway.cancelNext = true
+        val episodeId = AlertRouteTestDatabase.seedAlertEpisode(organization.organizationId, "HOST_ALERT", "claim")
+        val context = firingContext(episodeId)
+
+        assertFailsWith<kotlinx.coroutines.CancellationException> {
+            runBlocking { executionService.execute(context) }
+        }
+        currentTime.set(currentTime.get() + 5.minutes + 1.seconds)
+        executionService.execute(context)
+
+        assertEquals(1, gateway.triggered.size)
+    }
+
+    @Test
+    fun `stale every-episode claim cannot reclaim a fresh member claim`() = runBlocking {
+        createRoute(
+            pagingTargets = 1,
+            incident = AlertRouteIncidentInput(),
+            pagingMode = AlertRoutePagingMode.EVERY_EPISODE,
+        )
+        val staleEpisode = AlertRouteTestDatabase.seedAlertEpisode(
+            organization.organizationId,
+            "HOST_ALERT",
+            "stale-member",
+        )
+        gateway.cancelNext = true
+        assertFailsWith<kotlinx.coroutines.CancellationException> {
+            runBlocking { executionService.execute(firingContext(staleEpisode)) }
+        }
+
+        currentTime.set(currentTime.get() + 5.minutes + 1.seconds)
+        val freshEpisode = AlertRouteTestDatabase.seedAlertEpisode(
+            organization.organizationId,
+            "HOST_ALERT",
+            "fresh-member",
+        )
+        gateway.cancelNext = true
+        assertFailsWith<kotlinx.coroutines.CancellationException> {
+            runBlocking { executionService.execute(firingContext(freshEpisode)) }
+        }
+
+        executionService.execute(firingContext(freshEpisode))
+        assertTrue(gateway.triggered.isEmpty())
+        executionService.execute(firingContext(staleEpisode))
+        assertEquals(1, gateway.triggered.size)
+    }
+
+    @Test
+    fun `closed incident link does not prevent independent paging`() = runBlocking {
+        createRoute(
+            pagingTargets = 1,
+            incident = AlertRouteIncidentInput(create = true),
+            pagingMode = AlertRoutePagingMode.EVERY_EPISODE,
+        )
+        val first = AlertRouteTestDatabase.seedAlertEpisode(organization.organizationId, "HOST_ALERT", "closed-1")
+        executionService.execute(firingContext(first))
+        transaction {
+            OnCallIncidents.update({ OnCallIncidents.id eq OnCallIncidents.selectAll().single()[OnCallIncidents.id] }) {
+                it[status] = NativeIncidentStatus.RESOLVED.wire
+            }
+        }
+        val second = AlertRouteTestDatabase.seedAlertEpisode(organization.organizationId, "HOST_ALERT", "closed-2")
+
+        executionService.execute(firingContext(second))
+
+        assertEquals(2, gateway.triggered.size)
+        transaction { assertEquals(1, NativeIncidentSourceLinks.selectAll().count()) }
+    }
+
+    @Test
+    fun `failed multi-target paging retries only targets not already triggered`() = runBlocking {
+        createRoute(pagingTargets = 2, incident = AlertRouteIncidentInput())
+        gateway.failAfterSuccesses = 1
+        val episodeId = AlertRouteTestDatabase.seedAlertEpisode(organization.organizationId, "HOST_ALERT", "retry-page")
+        val context = firingContext(episodeId)
+
+        assertFailsWith<IllegalStateException> { runBlocking { executionService.execute(context) } }
+        executionService.execute(context)
+
+        assertEquals(3, gateway.attempted.size)
+        assertEquals(2, gateway.triggered.size)
+        assertEquals(2, gateway.triggered.distinct().size)
+    }
+
+    @Test
+    fun `automatic grouping reuses an eligible incident only after the first group window`() = runBlocking {
+        createRoute(
+            pagingTargets = 0,
+            incident = AlertRouteIncidentInput(create = true),
+            grouping = AlertRouteGroupingInput(
+                behavior = AlertRouteGroupingBehavior.AUTOMATIC,
+                keys = listOf("alert.source"),
+                windowSeconds = 60,
+            ),
+        )
+        val firstEpisode = AlertRouteTestDatabase.seedAlertEpisode(organization.organizationId, "HOST_ALERT", "first")
+        executionService.execute(firingContext(firstEpisode))
+        val firstGroup = groupService.list(organization.organizationId).single()
+
+        currentTime.set(currentTime.get() + 61.seconds)
+        val secondEpisode = AlertRouteTestDatabase.seedAlertEpisode(organization.organizationId, "HOST_ALERT", "second")
+        executionService.execute(firingContext(secondEpisode))
+
+        val groups = groupService.list(organization.organizationId)
+        assertEquals(2, groups.size)
+        val secondGroup = groupService.get(organization.organizationId, groups.single { it.id != firstGroup.id }.id)
+        assertEquals(firstGroup.incidentId, secondGroup.incidentId)
+        assertTrue(secondGroup.decisions.any { it.type == AlertGroupDecisionType.AUTOMATICALLY_ATTACHED })
+        transaction {
+            assertEquals(1, OnCallIncidents.selectAll().count())
+            assertEquals(2, NativeIncidentSourceLinks.selectAll().count())
+        }
+    }
+
+    @Test
+    fun `suggested grouping persists the candidate decision without attaching`() = runBlocking {
+        createRoute(
+            pagingTargets = 0,
+            incident = AlertRouteIncidentInput(create = true),
+            grouping = AlertRouteGroupingInput(
+                behavior = AlertRouteGroupingBehavior.SUGGESTED,
+                keys = listOf("alert.source"),
+                windowSeconds = 60,
+            ),
+        )
+        val firstEpisode = AlertRouteTestDatabase.seedAlertEpisode(
+            organization.organizationId,
+            "HOST_ALERT",
+            "suggest-1",
+        )
+        executionService.execute(firingContext(firstEpisode))
+        val firstGroup = groupService.list(organization.organizationId).single()
+
+        currentTime.set(currentTime.get() + 61.seconds)
+        val secondEpisode = AlertRouteTestDatabase.seedAlertEpisode(
+            organization.organizationId,
+            "HOST_ALERT",
+            "suggest-2",
+        )
+        executionService.execute(firingContext(secondEpisode))
+
+        val second = groupService.list(organization.organizationId).single { it.id != firstGroup.id }
+        val secondGroup = groupService.get(organization.organizationId, second.id)
+        assertEquals(null, secondGroup.incidentId)
+        assertEquals(firstGroup.incidentId, secondGroup.candidateIncidentId)
+        assertTrue(secondGroup.decisions.any { it.type == AlertGroupDecisionType.SUGGESTED })
+    }
+
+    @Test
+    fun `every episode paging pages each member in one durable group`() = runBlocking {
+        createRoute(
+            pagingTargets = 1,
+            incident = AlertRouteIncidentInput(),
+            pagingMode = AlertRoutePagingMode.EVERY_EPISODE,
+        )
+        val first = AlertRouteTestDatabase.seedAlertEpisode(organization.organizationId, "HOST_ALERT", "every-1")
+        val second = AlertRouteTestDatabase.seedAlertEpisode(organization.organizationId, "HOST_ALERT", "every-2")
+
+        executionService.execute(firingContext(first))
+        executionService.execute(firingContext(second))
+        executionService.execute(firingContext(second))
+
+        assertEquals(2, gateway.triggered.size)
+        assertEquals(1, groupService.list(organization.organizationId).size)
+    }
+
+    @Test
+    fun `recovery worker completes grace-delayed automation after restart`() = runBlocking {
+        createRoute(
+            pagingTargets = 1,
+            incident = AlertRouteIncidentInput(create = true),
+            recovery = AlertRouteRecoveryInput(
+                cancelEscalations = true,
+                declineUnacceptedTriage = true,
+                graceSeconds = 60,
+            ),
+        )
+        val episodeId = AlertRouteTestDatabase.seedAlertEpisode(organization.organizationId, "HOST_ALERT", "grace")
+        executionService.execute(firingContext(episodeId))
+        currentTime.set(currentTime.get() + 1.seconds)
+        executionService.execute(firingContext(episodeId, AlertStatus.RESOLVED))
+        transaction {
+            assertEquals(NativeIncidentStatus.TRIAGE.wire, OnCallIncidents.selectAll().single()[OnCallIncidents.status])
+        }
+
+        currentTime.set(currentTime.get() + 60.seconds)
+        executionService.recoverDue { true }
+
+        assertEquals(1, gateway.resolved.size)
+        transaction {
+            assertEquals(
+                NativeIncidentStatus.DECLINED.wire,
+                OnCallIncidents.selectAll().single()[OnCallIncidents.status],
+            )
+        }
+    }
+
+    @Test
+    fun `recovery isolates candidates and revisits groups closed by their window`() = runBlocking {
+        createRoute(
+            pagingTargets = 1,
+            incident = AlertRouteIncidentInput(create = true),
+            recovery = AlertRouteRecoveryInput(
+                cancelEscalations = true,
+                declineUnacceptedTriage = true,
+                graceSeconds = 60,
+            ),
+            grouping = AlertRouteGroupingInput(
+                keys = listOf("alert.deduplication_key"),
+                windowSeconds = 60,
+            ),
+        )
+        val first = AlertRouteTestDatabase.seedAlertEpisode(organization.organizationId, "HOST_ALERT", "isolate-1")
+        executionService.execute(firingContext(first))
+        currentTime.set(currentTime.get() + 61.seconds)
+        val second = AlertRouteTestDatabase.seedAlertEpisode(organization.organizationId, "HOST_ALERT", "isolate-2")
+        executionService.execute(firingContext(second))
+        currentTime.set(currentTime.get() + 1.seconds)
+        executionService.execute(firingContext(first, AlertStatus.RESOLVED))
+        currentTime.set(currentTime.get() + 1.seconds)
+        executionService.execute(firingContext(second, AlertStatus.RESOLVED))
+
+        gateway.throwResolveOnce = true
+        currentTime.set(currentTime.get() + 60.seconds)
+        executionService.recoverDue { true }
+
+        transaction {
+            val statuses = OnCallIncidents.selectAll().map { it[OnCallIncidents.status] }
+            assertEquals(2, statuses.size, statuses.toString())
+            assertEquals(1, statuses.count { it == NativeIncidentStatus.DECLINED.wire })
+            assertEquals(1, statuses.count { it == NativeIncidentStatus.TRIAGE.wire }, statuses.toString())
+        }
+        executionService.recoverDue { true }
+        transaction {
+            assertTrue(
+                OnCallIncidents.selectAll().all {
+                    it[OnCallIncidents.status] == NativeIncidentStatus.DECLINED.wire
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `recovery waits for every active episode and leaves active incidents untouched`() = runBlocking {
+        createRoute(
+            pagingTargets = 1,
+            incident = AlertRouteIncidentInput(
+                create = true,
+                mode = AlertRouteIncidentMode.ACTIVE,
+                severity = "SEV-1",
+            ),
+            recovery = AlertRouteRecoveryInput(
+                cancelEscalations = true,
+                declineUnacceptedTriage = true,
+            ),
+            pagingMode = AlertRoutePagingMode.EVERY_EPISODE,
+        )
+        val first = AlertRouteTestDatabase.seedAlertEpisode(organization.organizationId, "HOST_ALERT", "members-1")
+        val second = AlertRouteTestDatabase.seedAlertEpisode(organization.organizationId, "HOST_ALERT", "members-2")
+        executionService.execute(firingContext(first))
+        executionService.execute(firingContext(second))
+
+        executionService.execute(firingContext(first, AlertStatus.RESOLVED))
+        assertTrue(gateway.resolved.isEmpty())
+        executionService.execute(firingContext(second, AlertStatus.RESOLVED))
+
+        assertEquals(2, gateway.resolved.size)
+        transaction {
+            assertEquals(NativeIncidentStatus.ACTIVE.wire, OnCallIncidents.selectAll().single()[OnCallIncidents.status])
+        }
+    }
+
+    private fun createRoute(
+        pagingTargets: Int,
+        incident: AlertRouteIncidentInput,
+        recovery: AlertRouteRecoveryInput = AlertRouteRecoveryInput(),
+        pagingMode: AlertRoutePagingMode? = null,
+        grouping: AlertRouteGroupingInput = AlertRouteGroupingInput(
+            keys = listOf("alert.source"),
+            windowSeconds = 60,
+        ),
+    ) {
+        val targets = (1..pagingTargets).map { index ->
+            val policy = AlertRouteTestDatabase.seedEscalationPolicy(organization.organizationId, "Policy $index")
+            AlertRouteTargetInput(AlertRouteTargetKind.ESCALATION_POLICY, escalationPolicyId = policy.resourceId)
+        }
+        routeService.execute(
+            CreateAlertRouteCommand(
+                commandKey = "create-route-${Uuid.random()}",
+                actor = AlertRouteActor(organization.organizationId, organization.adminUserId, "TEST"),
+                specification = AlertRouteSpecification(
+                    key = "route-${Uuid.random()}",
+                    name = "Execution route",
+                    paging = AlertRoutePagingInput(
+                        pagingMode
+                            ?: if (targets.isEmpty()) {
+                                AlertRoutePagingMode.NONE
+                            } else {
+                                AlertRoutePagingMode.FIRST_EPISODE_PER_GROUP
+                            },
+                        targets,
+                    ),
+                    grouping = grouping,
+                    incident = incident,
+                    recovery = recovery,
+                ),
+            ),
+        )
+    }
+
+    private fun firingContext(episodeId: Uuid, status: AlertStatus = AlertStatus.FIRING): AlertFanoutContext {
+        val episode = transaction {
+            val row = AlertEpisodes.selectAll().where { AlertEpisodes.resourceId eq episodeId }.single()
+            AlertEpisodeContext(
+                id = row[AlertEpisodes.id].value,
+                resourceId = episodeId,
+                organizationId = organization.organizationId,
+                source = row[AlertEpisodes.sourceName],
+                deduplicationKey = row[AlertEpisodes.deduplicationKey],
+                title = row[AlertEpisodes.title],
+                description = row[AlertEpisodes.description],
+                priority = row[AlertEpisodes.priority],
+                episodeSeq = row[AlertEpisodes.episodeSeq],
+                episodeKey = row[AlertEpisodes.episodeKey],
+                status = row[AlertEpisodes.status],
+                openedAt = row[AlertEpisodes.openedAt],
+                lastSeenAt = row[AlertEpisodes.lastSeenAt],
+                resolvedAt = row[AlertEpisodes.resolvedAt],
+                lastNotificationAt = row[AlertEpisodes.lastNotificationAt],
+                notificationCount = row[AlertEpisodes.notificationCount],
+                suppressedAt = row[AlertEpisodes.suppressedAt],
+                suppressedByUserId = row[AlertEpisodes.suppressedByUserId],
+                suppressReason = row[AlertEpisodes.suppressReason],
+            )
+        }
+        val event = AlertLifecycleEvent(
+            title = "Checkout latency",
+            description = "Latency above threshold",
+            priority = AlertPriority.P1,
+            status = status,
+            source = AlertSource.valueOf(episode.source),
+            deduplicationKey = episode.deduplicationKey,
+            organizationId = organization.organizationId,
+            moneatUrl = "https://moneat.example/alerts/$episodeId",
+        )
+        return AlertFanoutContext(event, null, episode, deliverySilenced = false)
+    }
+
+    private class RecordingGateway : AlertRouteOnCallGateway {
+        val attempted = mutableListOf<String>()
+        val triggered = mutableListOf<String>()
+        val resolved = mutableListOf<String>()
+        var failAfterSuccesses: Int? = null
+        var returnNullAfterInsert = false
+        var cancelNext = false
+        var resolveResult = true
+        var throwResolveOnce = false
+        private var failed = false
+
+        override suspend fun trigger(request: AlertRouteEscalationRequest): String? {
+            attempted += request.deduplicationKey
+            if (cancelNext) {
+                cancelNext = false
+                throw kotlinx.coroutines.CancellationException("Simulated process interruption")
+            }
+            if (!failed && failAfterSuccesses == triggered.size) {
+                failed = true
+                error("Simulated paging failure")
+            }
+            triggered += request.deduplicationKey
+            return transaction {
+                val resourceId = Uuid.random()
+                val timestamp = kotlin.time.Clock.System.now()
+                OnCallAlerts.insert {
+                    it[OnCallAlerts.resourceId] = resourceId
+                    it[OnCallAlerts.organizationId] = request.organizationId
+                    it[OnCallAlerts.declaredIncidentId] = null
+                    it[OnCallAlerts.escalationPolicyId] = request.escalationPolicyId
+                    it[OnCallAlerts.title] = request.title
+                    it[OnCallAlerts.description] = request.description
+                    it[OnCallAlerts.priority] = request.priority
+                    it[OnCallAlerts.status] = "TRIGGERED"
+                    it[OnCallAlerts.alertSource] = request.alertSource
+                    it[OnCallAlerts.deduplicationKey] = request.deduplicationKey
+                    it[OnCallAlerts.currentStep] = 0
+                    it[OnCallAlerts.repeatIteration] = 0
+                    it[OnCallAlerts.triggeredAt] = timestamp
+                    it[OnCallAlerts.acknowledgedAt] = null
+                    it[OnCallAlerts.acknowledgedBy] = null
+                    it[OnCallAlerts.resolvedAt] = null
+                    it[OnCallAlerts.resolvedBy] = null
+                    it[OnCallAlerts.metadata] = JsonObject(emptyMap())
+                    it[OnCallAlerts.createdAt] = timestamp
+                    it[OnCallAlerts.updatedAt] = timestamp
+                }
+                resourceId.toString().takeUnless { returnNullAfterInsert }
+            }
+        }
+
+        override suspend fun resolve(organizationId: Int, alertSource: String, deduplicationKey: String): Boolean {
+            if (throwResolveOnce) {
+                throwResolveOnce = false
+                error("Simulated recovery failure")
+            }
+            resolved += deduplicationKey
+            return resolveResult
+        }
+    }
+}

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/EnterpriseAlertRouteFanoutTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/EnterpriseAlertRouteFanoutTest.kt
@@ -17,9 +17,9 @@ import kotlin.test.Test
 class EnterpriseAlertRouteFanoutTest {
     @Test
     fun `live fanout skips route evaluation when organization is not entitled`() = runBlocking {
-        val evaluationService = mockk<AlertRouteEvaluationService>()
+        val executionService = mockk<AlertRouteExecutionService>()
         val fanout = EnterpriseAlertRouteFanout(
-            evaluationService = evaluationService,
+            executionService = executionService,
             enabled = { false },
         )
 
@@ -41,6 +41,6 @@ class EnterpriseAlertRouteFanoutTest {
             ),
         )
 
-        confirmVerified(evaluationService)
+        confirmVerified(executionService)
     }
 }


### PR DESCRIPTION
## Summary
- execute the first matching enterprise alert route through the shared alert fanout seam
- persist retry-safe multi-target paging, incident creation and grouping decisions
- recover resolved groups by cancelling route escalations and declining unaccepted triage incidents

## Validation
- `./gradlew test --no-daemon`
- `./gradlew :ee:detekt :ee:compileKotlin --no-daemon`
- focused alert route execution, group, evaluation, and fanout tests
- Claude CLI review completed and supported findings applied
- `git diff --check`

Backlog: TASK-1.55


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end alert route execution for incident creation, grouping, linking, and escalation.
  * Added alert recovery with escalation cancellation and optional triage updates.
  * Added background processing for alerts eligible for recovery.
  * Added configurable initial incident status, severity, and incident type during triage.
  * Added recovery completion events and improved escalation tracking.

* **Bug Fixes**
  * Improved deduplication, retry handling, and recovery of stale paging claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->