### PR TITLE
fix: make alert route outcomes reliable

### DIFF
--- a/backend/features/org/src/main/kotlin/com/moneat/org/routes/AdminRoutes.kt
+++ b/backend/features/org/src/main/kotlin/com/moneat/org/routes/AdminRoutes.kt
@@ -22,7 +22,9 @@ import com.moneat.billing.services.BillingQuotaService
 import com.moneat.billing.services.PricingTierService
 import com.moneat.config.ClickHouseClient
 import com.moneat.config.isClickHouseError
+import com.moneat.events.models.AlertRouteActionResult
 import com.moneat.events.models.TriggerIncidentRequest
+import com.moneat.events.models.TriggerIncidentResponse
 import com.moneat.alerts.models.AlertSource
 import com.moneat.alerts.models.AlertLifecycleEvent
 import com.moneat.alerts.models.AlertPriority
@@ -411,8 +413,27 @@ fun Route.adminRoutes() {
                             metadata = mapOf("triggered_by" to JsonPrimitive(userResourceId(userId)))
                         )
 
-                    alertOrchestrator.process(event, AlertFanoutPlan.FULL)
-                    call.respond(HttpStatusCode.OK, AdminSuccessResponse(success = true))
+                    val orchestration = alertOrchestrator.process(event, AlertFanoutPlan.FULL)
+                    val routeOutcome = orchestration.outcomes.firstOrNull { it.arm.name == "ROUTE" }
+                    val route = routeOutcome?.route
+                    val incidentTriggered = route?.incident?.state?.name == "SUCCEEDED"
+                    call.respond(
+                        HttpStatusCode.OK,
+                        TriggerIncidentResponse(
+                            success = incidentTriggered,
+                            incidentTriggered = incidentTriggered,
+                            routeState = route?.state?.name ?: routeOutcome?.state?.name ?: "UNAVAILABLE",
+                            routeReason = route?.reason ?: routeOutcome?.error
+                                ?: "No Alert Route execution details were available",
+                            matchedRouteId = route?.matchedRouteId,
+                            matchedRouteRevision = route?.matchedRouteRevision,
+                            groupId = route?.groupId,
+                            incidentId = route?.incidentId,
+                            grouping = route?.grouping.toApiAction(),
+                            paging = route?.paging.toApiAction(),
+                            incident = route?.incident.toApiAction(),
+                        ),
+                    )
                 }.getOrElse { e ->
                     call.respond(
                         HttpStatusCode.InternalServerError,
@@ -1038,6 +1059,12 @@ fun Route.adminRoutes() {
         }
     }
 }
+
+private fun com.moneat.alerts.services.AlertRouteActionOutcome?.toApiAction(): AlertRouteActionResult =
+    AlertRouteActionResult(
+        state = this?.state?.name ?: "SKIPPED",
+        reason = this?.reason ?: "No action was taken",
+    )
 
 private suspend fun ApplicationCall.handleQuotaUsageRequest(
     quotaService: BillingQuotaService,

--- a/backend/features/org/src/test/kotlin/com/moneat/routes/AdminRoutesTest.kt
+++ b/backend/features/org/src/test/kotlin/com/moneat/routes/AdminRoutesTest.kt
@@ -256,6 +256,51 @@ class AdminRoutesTest {
         }
     }
 
+    @Test
+    fun `admin incident trigger reports unavailable route without claiming an incident`() = testApplication {
+        val orchestrator = mockk<AlertLifecycleOrchestrator>()
+        val orchestration = mockk<AlertOrchestrationResult>()
+        every { orchestration.outcomes } returns listOf(
+            AlertFanoutOutcome(
+                arm = AlertFanoutArm.ROUTE,
+                state = AlertFanoutState.UNAVAILABLE,
+                error = "Alert Route execution is unavailable",
+            ),
+        )
+        coEvery { orchestrator.process(any(), any()) } returns orchestration
+        GlobalContext.get().declare(orchestrator, allowOverride = true)
+        application {
+            install(ContentNegotiation) { json() }
+            installAuth()
+            routing { adminRoutes() }
+        }
+        val userId = seedUser(isAdmin = true)
+        transaction {
+            val organizationId = Organizations.insert {
+                it[name] = "Unavailable Route Organization"
+                it[slug] = "unavailable-route-organization"
+            } get Organizations.id
+            Memberships.insert {
+                it[user_id] = userId
+                it[organization_id] = organizationId
+                it[role] = "admin"
+            }
+        }
+
+        val response = client.post("/v1/admin/incidents/trigger") {
+            header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+            contentType(ContentType.Application.Json)
+            setBody(
+                """{"source":"DASHBOARD_ALERT","severity":"P1","title":"Latency","description":"High"}""",
+            )
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().contains("\"success\":false"))
+        assertTrue(response.bodyAsText().contains("\"routeState\":\"UNAVAILABLE\""))
+        assertTrue(response.bodyAsText().contains("\"incident\":{\"state\":\"SKIPPED\""))
+    }
+
     @AfterTest
     fun teardownKoin() {
         stopTestKoin()

--- a/backend/features/org/src/test/kotlin/com/moneat/routes/AdminRoutesTest.kt
+++ b/backend/features/org/src/test/kotlin/com/moneat/routes/AdminRoutesTest.kt
@@ -20,6 +20,14 @@ import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import com.moneat.alerts.models.AlertSource
 import com.moneat.alerts.services.AlertFanoutPlan
+import com.moneat.alerts.services.AlertFanoutArm
+import com.moneat.alerts.services.AlertFanoutOutcome
+import com.moneat.alerts.services.AlertFanoutState
+import com.moneat.alerts.services.AlertOrchestrationResult
+import com.moneat.alerts.services.AlertRouteActionOutcome
+import com.moneat.alerts.services.AlertRouteActionState
+import com.moneat.alerts.services.AlertRouteExecutionOutcome
+import com.moneat.alerts.services.AlertRouteExecutionState
 import com.moneat.alerts.services.AlertLifecycleOrchestrator
 import com.moneat.org.routes.adminRoutes
 import com.moneat.shared.models.Memberships
@@ -58,6 +66,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import io.mockk.every
 
 class AdminRoutesTest {
     private val jwtSecret = "test-secret-for-admin-routes"
@@ -190,7 +199,25 @@ class AdminRoutesTest {
     @Test
     fun `admin incident trigger delegates one full lifecycle event`() = testApplication {
         val orchestrator = mockk<AlertLifecycleOrchestrator>()
-        coEvery { orchestrator.process(any(), any()) } returns mockk(relaxed = true)
+        val routeOutcome = AlertRouteExecutionOutcome(
+            state = AlertRouteExecutionState.MATCHED,
+            matchedRouteId = "route-id",
+            matchedRouteRevision = 3,
+            groupId = "group-id",
+            incidentId = "incident-id",
+            grouping = AlertRouteActionOutcome(AlertRouteActionState.SUCCEEDED, "Alert grouped"),
+            paging = AlertRouteActionOutcome(AlertRouteActionState.SUCCEEDED, "Paged one target"),
+            incident = AlertRouteActionOutcome(AlertRouteActionState.SUCCEEDED, "Incident created"),
+        )
+        val orchestration = mockk<AlertOrchestrationResult>()
+        every { orchestration.outcomes } returns listOf(
+            AlertFanoutOutcome(
+                AlertFanoutArm.ROUTE,
+                AlertFanoutState.SUCCEEDED,
+                route = routeOutcome,
+            ),
+        )
+        coEvery { orchestrator.process(any(), any()) } returns orchestration
         GlobalContext.get().declare(orchestrator, allowOverride = true)
         application {
             install(ContentNegotiation) { json() }
@@ -219,6 +246,8 @@ class AdminRoutesTest {
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().contains("\"incidentTriggered\":true"))
+        assertTrue(response.bodyAsText().contains("\"matchedRouteRevision\":3"))
         coVerify(exactly = 1) {
             orchestrator.process(
                 match { it.source == AlertSource.DASHBOARD_ALERT && it.organizationId > 0 },

--- a/backend/src/main/kotlin/com/moneat/alerts/services/AlertLifecycleOrchestrator.kt
+++ b/backend/src/main/kotlin/com/moneat/alerts/services/AlertLifecycleOrchestrator.kt
@@ -71,6 +71,7 @@ data class AlertFanoutOutcome(
     val arm: AlertFanoutArm,
     val state: AlertFanoutState,
     val error: String? = null,
+    val route: AlertRouteExecutionOutcome? = null,
 )
 
 data class AlertOrchestrationResult(
@@ -96,22 +97,41 @@ fun interface AlertRouteFanout {
     suspend fun process(context: AlertFanoutContext)
 }
 
-/** Optional enterprise route arm; core-only deployments safely retain the no-op bridge. */
-object AlertRouteFanoutRegistry {
-    @Volatile
-    private var registered: AlertRouteFanout? = null
+/** Optional details returned by an enterprise route arm after evaluating one alert. */
+data class AlertRouteExecutionOutcome(
+    val state: AlertRouteExecutionState,
+    val reason: String? = null,
+    val matchedRouteId: String? = null,
+    val matchedRouteRevision: Int? = null,
+    val groupId: String? = null,
+    val incidentId: String? = null,
+    val grouping: AlertRouteActionOutcome = AlertRouteActionOutcome(),
+    val paging: AlertRouteActionOutcome = AlertRouteActionOutcome(),
+    val incident: AlertRouteActionOutcome = AlertRouteActionOutcome(),
+)
 
-    fun register(fanout: AlertRouteFanout) {
-        registered = fanout
-    }
+enum class AlertRouteExecutionState {
+    MATCHED,
+    NO_MATCH,
+    SKIPPED,
+    FAILED,
+    UNAVAILABLE,
+}
 
-    fun unregister(fanout: AlertRouteFanout) {
-        synchronized(this) {
-            if (registered === fanout) registered = null
-        }
-    }
+data class AlertRouteActionOutcome(
+    val state: AlertRouteActionState = AlertRouteActionState.SKIPPED,
+    val reason: String? = null,
+)
 
-    fun current(): AlertRouteFanout? = registered
+enum class AlertRouteActionState {
+    SUCCEEDED,
+    SKIPPED,
+    FAILED,
+}
+
+/** Optional result channel for licensed route implementations; the legacy SAM remains source-compatible. */
+interface AlertRouteOutcomeFanout {
+    suspend fun processWithOutcome(context: AlertFanoutContext): AlertRouteExecutionOutcome
 }
 
 /** Records or resolves one episode once, then isolates every selected downstream arm. */
@@ -119,7 +139,7 @@ class AlertLifecycleOrchestrator(
     private val episodeService: AlertEpisodeService = AlertEpisodeService(),
     private val workflowFanoutProvider: () -> AlertWorkflowFanout? = ::workflowFanoutFromKoin,
     private val incidentFanoutProvider: () -> AlertIncidentFanout? = ::incidentFanoutFromKoin,
-    private val routeFanoutProvider: () -> AlertRouteFanout? = AlertRouteFanoutRegistry::current,
+    private val routeFanoutProvider: () -> AlertRouteFanout? = ::routeFanoutFromKoin,
 ) {
     suspend fun process(
         event: AlertLifecycleEvent,
@@ -182,7 +202,26 @@ class AlertLifecycleOrchestrator(
             AlertFanoutArm.ROUTE,
             AlertFanoutState.UNAVAILABLE,
         )
-        return runArm(AlertFanoutArm.ROUTE) { fanout.process(context) }
+        return suspendRunCatching {
+            (fanout as? AlertRouteOutcomeFanout)?.processWithOutcome(context)
+                ?: fanout.process(context).let { null }
+        }.fold(
+            onSuccess = { outcome ->
+                val routeOutcome = outcome ?: return@fold AlertFanoutOutcome(
+                    AlertFanoutArm.ROUTE,
+                    AlertFanoutState.SUCCEEDED,
+                )
+                AlertFanoutOutcome(
+                    AlertFanoutArm.ROUTE,
+                    routeOutcome.toFanoutState(),
+                    route = routeOutcome,
+                )
+            },
+            onFailure = { error ->
+                logger.error(error) { "Alert fan-out arm ${AlertFanoutArm.ROUTE} failed" }
+                AlertFanoutOutcome(AlertFanoutArm.ROUTE, AlertFanoutState.FAILED, error.message)
+            },
+        )
     }
 
     private suspend fun runWorkflowArm(
@@ -238,6 +277,19 @@ class AlertLifecycleOrchestrator(
 
 private fun workflowFanoutFromKoin(): AlertWorkflowFanout? =
     GlobalContext.getOrNull()?.getOrNull()
+
+private fun routeFanoutFromKoin(): AlertRouteFanout? =
+    GlobalContext.getOrNull()?.getOrNull()
+
+private fun AlertRouteExecutionOutcome.toFanoutState(): AlertFanoutState =
+    when (state) {
+        AlertRouteExecutionState.UNAVAILABLE -> AlertFanoutState.UNAVAILABLE
+        AlertRouteExecutionState.FAILED -> AlertFanoutState.FAILED
+        AlertRouteExecutionState.MATCHED,
+        AlertRouteExecutionState.NO_MATCH,
+        AlertRouteExecutionState.SKIPPED,
+        -> AlertFanoutState.SUCCEEDED
+    }
 
 private fun incidentFanoutFromKoin(): AlertIncidentFanout? =
     GlobalContext.getOrNull()?.getOrNull()

--- a/backend/src/main/kotlin/com/moneat/alerts/services/AlertLifecycleOrchestrator.kt
+++ b/backend/src/main/kotlin/com/moneat/alerts/services/AlertLifecycleOrchestrator.kt
@@ -130,7 +130,7 @@ enum class AlertRouteActionState {
 }
 
 /** Optional result channel for licensed route implementations; the legacy SAM remains source-compatible. */
-interface AlertRouteOutcomeFanout {
+fun interface AlertRouteOutcomeFanout {
     suspend fun processWithOutcome(context: AlertFanoutContext): AlertRouteExecutionOutcome
 }
 

--- a/backend/src/main/kotlin/com/moneat/events/models/ApiModels.kt
+++ b/backend/src/main/kotlin/com/moneat/events/models/ApiModels.kt
@@ -690,6 +690,27 @@ data class TriggerIncidentRequest(
 )
 
 @Serializable
+data class AlertRouteActionResult(
+    val state: String,
+    val reason: String? = null,
+)
+
+@Serializable
+data class TriggerIncidentResponse(
+    val success: Boolean,
+    val incidentTriggered: Boolean,
+    val routeState: String,
+    val routeReason: String? = null,
+    val matchedRouteId: String? = null,
+    val matchedRouteRevision: Int? = null,
+    val groupId: String? = null,
+    val incidentId: String? = null,
+    val grouping: AlertRouteActionResult,
+    val paging: AlertRouteActionResult,
+    val incident: AlertRouteActionResult,
+)
+
+@Serializable
 data class ErrorResponse(
     val error: String
 )

--- a/backend/src/test/kotlin/com/moneat/alerts/AlertLifecycleOrchestratorTest.kt
+++ b/backend/src/test/kotlin/com/moneat/alerts/AlertLifecycleOrchestratorTest.kt
@@ -214,6 +214,56 @@ class AlertLifecycleOrchestratorTest {
     }
 
     @Test
+    fun `route execution state maps to fanout state`() = runBlocking {
+        var routeState = AlertRouteExecutionState.MATCHED
+        val route = object : AlertRouteFanout, AlertRouteOutcomeFanout {
+            override suspend fun process(context: AlertFanoutContext) = Unit
+
+            override suspend fun processWithOutcome(context: AlertFanoutContext) =
+                AlertRouteExecutionOutcome(state = routeState)
+        }
+        val orchestrator = orchestrator(
+            workflow = AlertWorkflowFanout {},
+            incidents = capturingIncidentFanout(mutableListOf()),
+            route = route,
+        )
+
+        val expected = mapOf(
+            AlertRouteExecutionState.MATCHED to AlertFanoutState.SUCCEEDED,
+            AlertRouteExecutionState.NO_MATCH to AlertFanoutState.SUCCEEDED,
+            AlertRouteExecutionState.SKIPPED to AlertFanoutState.SUCCEEDED,
+            AlertRouteExecutionState.FAILED to AlertFanoutState.FAILED,
+            AlertRouteExecutionState.UNAVAILABLE to AlertFanoutState.UNAVAILABLE,
+        )
+        expected.forEach { (state, fanoutState) ->
+            routeState = state
+            val result = orchestrator.process(
+                event().copy(deduplicationKey = "route-state-${state.name}"),
+                AlertFanoutPlan(route = true, workflow = false),
+            )
+            assertEquals(fanoutState, result.outcome(AlertFanoutArm.ROUTE).state)
+        }
+    }
+
+    @Test
+    fun `route outcome failure is isolated from other arms`() = runBlocking {
+        val route = object : AlertRouteFanout, AlertRouteOutcomeFanout {
+            override suspend fun process(context: AlertFanoutContext) = Unit
+
+            override suspend fun processWithOutcome(context: AlertFanoutContext): AlertRouteExecutionOutcome =
+                error("route evaluation failed")
+        }
+        val result = orchestrator(
+            workflow = AlertWorkflowFanout {},
+            incidents = capturingIncidentFanout(mutableListOf()),
+            route = route,
+        ).process(event(), AlertFanoutPlan(route = true, workflow = false))
+
+        assertEquals(AlertFanoutState.FAILED, result.outcome(AlertFanoutArm.ROUTE).state)
+        assertEquals("route evaluation failed", result.outcome(AlertFanoutArm.ROUTE).error)
+    }
+
+    @Test
     fun `resolved lifecycle shares the closed episode with every arm`() = runBlocking {
         val captured = mutableListOf<AlertFanoutContext>()
         val orchestrator = orchestrator(
@@ -260,7 +310,6 @@ class AlertLifecycleOrchestratorTest {
             episodeService = episodeService,
             workflowFanoutProvider = { null },
             incidentFanoutProvider = { null },
-            routeFanoutProvider = { null },
         )
 
         val result = orchestrator.process(event(), AlertFanoutPlan.FULL)

--- a/backend/src/test/kotlin/com/moneat/alerts/AlertLifecycleOrchestratorTest.kt
+++ b/backend/src/test/kotlin/com/moneat/alerts/AlertLifecycleOrchestratorTest.kt
@@ -29,6 +29,11 @@ import com.moneat.alerts.services.AlertFanoutState
 import com.moneat.alerts.services.AlertIncidentFanout
 import com.moneat.alerts.services.AlertLifecycleOrchestrator
 import com.moneat.alerts.services.AlertRouteFanout
+import com.moneat.alerts.services.AlertRouteActionOutcome
+import com.moneat.alerts.services.AlertRouteActionState
+import com.moneat.alerts.services.AlertRouteExecutionOutcome
+import com.moneat.alerts.services.AlertRouteExecutionState
+import com.moneat.alerts.services.AlertRouteOutcomeFanout
 import com.moneat.alerts.services.AlertSilenceService
 import com.moneat.alerts.services.AlertWorkflowFanout
 import com.moneat.shared.models.Organizations
@@ -174,6 +179,38 @@ class AlertLifecycleOrchestratorTest {
         assertEquals(0, result.context.episode?.notificationCount)
         assertTrue(delivered.isEmpty())
         assertEquals(AlertFanoutState.SKIPPED, result.outcome(AlertFanoutArm.WORKFLOW).state)
+    }
+
+    @Test
+    fun `route action outcome is returned without executing the route twice`() = runBlocking {
+        var legacyProcessCalls = 0
+        var outcomeCalls = 0
+        val route = object : AlertRouteFanout, AlertRouteOutcomeFanout {
+            override suspend fun process(context: AlertFanoutContext) {
+                legacyProcessCalls += 1
+            }
+
+            override suspend fun processWithOutcome(context: AlertFanoutContext): AlertRouteExecutionOutcome {
+                outcomeCalls += 1
+                return AlertRouteExecutionOutcome(
+                    state = AlertRouteExecutionState.MATCHED,
+                    matchedRouteId = "route-resource",
+                    matchedRouteRevision = 3,
+                    groupId = "group-resource",
+                    grouping = AlertRouteActionOutcome(AlertRouteActionState.SUCCEEDED, "Alert grouped"),
+                )
+            }
+        }
+        val result = orchestrator(
+            workflow = AlertWorkflowFanout {},
+            incidents = capturingIncidentFanout(mutableListOf()),
+            route = route,
+        ).process(event(), AlertFanoutPlan(route = true, workflow = false))
+
+        assertEquals(0, legacyProcessCalls)
+        assertEquals(1, outcomeCalls)
+        assertEquals("route-resource", result.outcomes.single { it.arm == AlertFanoutArm.ROUTE }.route?.matchedRouteId)
+        assertEquals(AlertFanoutState.SUCCEEDED, result.outcome(AlertFanoutArm.ROUTE).state)
     }
 
     @Test

--- a/dashboard/src/components/on-call/alert-routes/AlertRouteEditorSheet.tsx
+++ b/dashboard/src/components/on-call/alert-routes/AlertRouteEditorSheet.tsx
@@ -274,6 +274,16 @@ function AlertRouteEditorForm({
           />
         </EditorSection>
 
+        {form.paging.mode !== 'NONE' && !form.incident.create && (
+          <div className="flex items-start gap-2 rounded-lg border border-warning-border bg-warning-bg p-3 text-xs text-warning-fg">
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <p>
+              This is a paging-only route. It will page the configured targets and will not create an
+              incident. Because routes use first match wins, a matching alert will not continue to a later route.
+            </p>
+          </div>
+        )}
+
         <EditorSection title="Grouping" description="How matched alerts fold together.">
           <AlertRouteGroupingSection
             grouping={form.grouping}
@@ -290,6 +300,16 @@ function AlertRouteEditorForm({
             onRecoveryChange={(recovery) => patch({recovery})}
           />
         </EditorSection>
+
+        <div className="rounded-lg border bg-muted/30 p-3 text-xs">
+          <p className="font-medium">Save summary</p>
+          <p className="mt-1 text-muted-foreground">
+            {form.enabled ? 'Enabled' : 'Disabled'} route · {form.paging.mode === 'NONE' ? 'no paging' : 'pages responders'} ·{' '}
+            {form.incident.create
+              ? `creates a ${form.incident.mode === 'ACTIVE' ? 'active' : 'triage'} incident`
+              : 'does not create incidents'}
+          </p>
+        </div>
 
         <details className="rounded-lg border">
           <summary className="cursor-pointer px-4 py-2.5 text-sm font-semibold">Preview</summary>

--- a/dashboard/src/components/on-call/alert-routes/AlertRouteEditorSheet.tsx
+++ b/dashboard/src/components/on-call/alert-routes/AlertRouteEditorSheet.tsx
@@ -16,7 +16,7 @@
 
 import {useState} from 'react'
 import {useMutation, useQueryClient} from '@tanstack/react-query'
-import {AlertTriangle, Loader2} from 'lucide-react'
+import {AlertTriangle, Loader2, WandSparkles} from 'lucide-react'
 import {api} from '@/lib/api'
 import {Button} from '@/components/ui/button'
 import {Input} from '@/components/ui/input'
@@ -37,6 +37,7 @@ import type {
 } from '@/lib/api/types'
 import {
   alertRouteToForm,
+  applyP0P2TriagePreset,
   createEmptyAlertRouteForm,
   formToRequest,
   isConflictError,
@@ -189,6 +190,7 @@ function AlertRouteEditorForm({
   }
 
   const busy = saveMutation.isPending
+  const incidentSummary = describeIncidentSummary(form)
 
   return (
     <>
@@ -259,6 +261,24 @@ function AlertRouteEditorForm({
         </section>
 
         <EditorSection title="Conditions" description="OR across groups, AND within a group.">
+          <div className="flex items-start justify-between gap-3 rounded-lg border border-info-border bg-info-bg p-3 text-xs">
+            <div>
+              <p className="font-medium text-info-fg">Need a standard high-severity path?</p>
+              <p className="mt-0.5 text-info-fg/80">
+                Opt in to page once per group and create triage incidents for P0–P2 alerts.
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-8 shrink-0"
+              onClick={() => setForm((current) => applyP0P2TriagePreset(current))}
+            >
+              <WandSparkles className="mr-1.5 h-3.5 w-3.5" />
+              Use P0–P2 preset
+            </Button>
+          </div>
           <AlertRouteConditionsSection
             groups={form.conditionGroups}
             onChange={(conditionGroups) => patch({conditionGroups})}
@@ -305,9 +325,7 @@ function AlertRouteEditorForm({
           <p className="font-medium">Save summary</p>
           <p className="mt-1 text-muted-foreground">
             {form.enabled ? 'Enabled' : 'Disabled'} route · {form.paging.mode === 'NONE' ? 'no paging' : 'pages responders'} ·{' '}
-            {form.incident.create
-              ? `creates a ${form.incident.mode === 'ACTIVE' ? 'active' : 'triage'} incident`
-              : 'does not create incidents'}
+            {incidentSummary}
           </p>
         </div>
 
@@ -383,6 +401,18 @@ function EditorSection({
       {children}
     </section>
   )
+}
+
+function describeIncidentSummary(form: AlertRouteFormState): string {
+  if (!form.incident.create) return 'does not create incidents'
+  if (form.incident.mode === 'ACTIVE') {
+    const severity = form.incident.severity ? ` at ${form.incident.severity}` : ''
+    return `creates an active incident${severity}`
+  }
+  if (form.incident.severity === 'ALERT_PRIORITY') {
+    return 'creates triage incidents with severity derived from P0–P2 priority'
+  }
+  return 'creates a triage incident'
 }
 
 interface ConflictBannerProps {

--- a/dashboard/src/components/on-call/alert-routes/AlertRouteIncidentSection.tsx
+++ b/dashboard/src/components/on-call/alert-routes/AlertRouteIncidentSection.tsx
@@ -30,7 +30,7 @@ import type {
   AlertRouteIncidentMode,
   AlertRouteRecovery,
 } from '@/lib/api/types'
-import {INCIDENT_MODE_OPTIONS, SEVERITY_OPTIONS} from './alertRouteModel'
+import {ALERT_PRIORITY_SEVERITY, INCIDENT_MODE_OPTIONS, SEVERITY_OPTIONS} from './alertRouteModel'
 import {DurationField} from './DurationField'
 
 const NONE_VALUE = '__none__'
@@ -121,14 +121,19 @@ export function AlertRouteIncidentSection({
                 <SelectContent>
                   {!activeRequiresSeverity && <SelectItem value={NONE_VALUE}>Leave unclassified</SelectItem>}
                   {SEVERITY_OPTIONS.map((option) => (
-                    <SelectItem key={option} value={option}>
-                      {option}
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
                     </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
               {activeRequiresSeverity && (
                 <p className="text-xs text-muted-foreground">Active incidents require a severity.</p>
+              )}
+              {incident.severity === ALERT_PRIORITY_SEVERITY && (
+                <p className="text-xs text-muted-foreground">
+                  P0, P1, and P2 alerts become SEV-0, SEV-1, and SEV-2 triage incidents. Other priorities stay unclassified.
+                </p>
               )}
             </div>
 

--- a/dashboard/src/components/on-call/alert-routes/__tests__/alertRouteModel.test.ts
+++ b/dashboard/src/components/on-call/alert-routes/__tests__/alertRouteModel.test.ts
@@ -18,6 +18,7 @@ import {describe, expect, it} from 'vitest'
 import type {AlertRouteEvaluation, AlertRoutePreviewResponse} from '@/lib/api/types'
 import {
   createEmptyAlertRouteForm,
+  applyP0P2TriagePreset,
   formToRequest,
   overlappingEarlierRoutes,
   validateAlertRouteForm,
@@ -66,6 +67,21 @@ describe('alert route request mapping and validation', () => {
       expect.stringMatching(/supported scoped field/i),
       expect.stringMatching(/requires a severity/i),
     ]))
+  })
+})
+
+describe('alert route presets', () => {
+  it('opts into grouped paging and priority-derived triage severity', () => {
+    const preset = applyP0P2TriagePreset(createEmptyAlertRouteForm())
+
+    expect(preset.conditionGroups[0].conditions[0]).toMatchObject({
+      field: 'priority',
+      operator: 'AT_LEAST_AS_SEVERE_AS',
+      values: ['P2'],
+    })
+    expect(preset.paging.mode).toBe('FIRST_EPISODE_PER_GROUP')
+    expect(preset.grouping.behavior).toBe('AUTOMATIC')
+    expect(preset.incident).toMatchObject({create: true, mode: 'TRIAGE', severity: 'ALERT_PRIORITY'})
   })
 })
 

--- a/dashboard/src/components/on-call/alert-routes/alertRouteModel.ts
+++ b/dashboard/src/components/on-call/alert-routes/alertRouteModel.ts
@@ -182,7 +182,15 @@ export const INCIDENT_MODE_OPTIONS: ReadonlyArray<Option<AlertRouteIncidentMode>
 ]
 
 export const PRIORITY_OPTIONS: readonly string[] = ['P0', 'P1', 'P2', 'P3', 'P4', 'P5']
-export const SEVERITY_OPTIONS: readonly string[] = ['SEV-0', 'SEV-1', 'SEV-2', 'SEV-3', 'SEV-4']
+export const ALERT_PRIORITY_SEVERITY = 'ALERT_PRIORITY'
+export const SEVERITY_OPTIONS: ReadonlyArray<Option<string>> = [
+  {value: 'SEV-0', label: 'SEV-0'},
+  {value: 'SEV-1', label: 'SEV-1'},
+  {value: 'SEV-2', label: 'SEV-2'},
+  {value: 'SEV-3', label: 'SEV-3'},
+  {value: 'SEV-4', label: 'SEV-4'},
+  {value: ALERT_PRIORITY_SEVERITY, label: 'From alert priority (P0–P2)'},
+]
 export const ALERT_STATUS_OPTIONS: readonly string[] = ['FIRING', 'RESOLVED']
 export const ALERT_SOURCE_OPTIONS: readonly string[] = [
   'HOST_ALERT',
@@ -269,6 +277,38 @@ export function createEmptyAlertRouteForm(): AlertRouteFormState {
     grouping: { behavior: 'SUGGESTED', keys: [], windowKind: 'ROLLING', windowSeconds: DEFAULT_WINDOW_SECONDS },
     incident: { create: false, mode: 'TRIAGE' },
     recovery: { cancelEscalations: false, declineUnacceptedTriage: false, graceSeconds: 0 },
+  }
+}
+
+/** Apply the opt-in route shape for paging and triaging P0–P2 alerts. */
+export function applyP0P2TriagePreset(form: AlertRouteFormState): AlertRouteFormState {
+  return {
+    ...form,
+    conditionGroups: [{
+      clientKey: createEditorKey('condition-group'),
+      conditions: [{
+        clientKey: createEditorKey('condition'),
+        field: 'priority',
+        operator: 'AT_LEAST_AS_SEVERE_AS',
+        values: ['P2'],
+      }],
+    }],
+    paging: {
+      ...form.paging,
+      mode: 'FIRST_EPISODE_PER_GROUP',
+    },
+    grouping: {
+      ...form.grouping,
+      behavior: 'AUTOMATIC',
+      windowKind: 'ROLLING',
+      windowSeconds: form.grouping.windowSeconds > 0 ? form.grouping.windowSeconds : DEFAULT_WINDOW_SECONDS,
+    },
+    incident: {
+      ...form.incident,
+      create: true,
+      mode: 'TRIAGE',
+      severity: ALERT_PRIORITY_SEVERITY,
+    },
   }
 }
 

--- a/dashboard/src/docs/pages/on-call.mdx
+++ b/dashboard/src/docs/pages/on-call.mdx
@@ -191,6 +191,7 @@ Automatic incident creation is configured separately through ordered **Alert Rou
 - An enabled route must explicitly turn on **Create an incident for matched alerts**. A route that only pages or groups alerts will not create an incident.
 - Routes are evaluated in order. A first matching page-only route prevents later routes from handling the alert, so put incident-capable routes before catch-all paging routes.
 - The route editor and test-alert result identify whether no route matched, paging occurred, grouping occurred, an incident was skipped, or a triage incident was created.
+- The administrator test-alert response is action-specific: a successful alert request does not imply an incident. Review the route state, matched route revision, group, paging result, and incident result separately.
 - Manual **Declare Incident** remains available independently of Alert Route automation.
 
 External incident-provider passthrough is a separate capability and is not affected by native incident entitlement.

--- a/dashboard/src/docs/pages/on-call.mdx
+++ b/dashboard/src/docs/pages/on-call.mdx
@@ -192,6 +192,8 @@ Automatic incident creation is configured separately through ordered **Alert Rou
 - Routes are evaluated in order. A first matching page-only route prevents later routes from handling the alert, so put incident-capable routes before catch-all paging routes.
 - The route editor and test-alert result identify whether no route matched, paging occurred, grouping occurred, an incident was skipped, or a triage incident was created.
 - The administrator test-alert response is action-specific: a successful alert request does not imply an incident. Review the route state, matched route revision, group, paging result, and incident result separately.
+- The editor includes an opt-in **P0–P2 triage preset**. It pages once per group, creates triage incidents, and derives SEV-0, SEV-1, or SEV-2 from P0, P1, or P2; fixed-severity route settings are unchanged.
+- An on-call alert detail shows the matched route revision and independent grouping, paging, and incident outcomes with the reason when an action is skipped or fails.
 - Manual **Declare Incident** remains available independently of Alert Route automation.
 
 External incident-provider passthrough is a separate capability and is not affected by native incident entitlement.

--- a/dashboard/src/lib/api/modules/__tests__/admin.test.ts
+++ b/dashboard/src/lib/api/modules/__tests__/admin.test.ts
@@ -541,12 +541,19 @@ describe('adminMethods', () => {
         http.post(`${API_BASE}/v1/admin/incidents/trigger`, async ({ request }) => {
           const body = await request.json()
           expect(body).toEqual(incident)
-          return HttpResponse.json({ success: true })
+          return HttpResponse.json({
+            success: true,
+            incidentTriggered: true,
+            routeState: 'MATCHED',
+            grouping: {state: 'SUCCEEDED', reason: 'Alert grouped'},
+            paging: {state: 'SUCCEEDED', reason: 'Paged one target'},
+            incident: {state: 'SUCCEEDED', reason: 'Incident created'},
+          })
         })
       )
 
       const result = await api.triggerIncident(incident)
-      expect(result).toEqual({ success: true })
+      expect(result).toMatchObject({success: true, incidentTriggered: true, routeState: 'MATCHED'})
     })
   })
 

--- a/dashboard/src/lib/api/modules/admin.ts
+++ b/dashboard/src/lib/api/modules/admin.ts
@@ -28,6 +28,20 @@ import type {
   BillingUsage,
 } from '../types'
 
+export type TriggerIncidentResponse = {
+  success: boolean
+  incidentTriggered: boolean
+  routeState: string
+  routeReason?: string | null
+  matchedRouteId?: string | null
+  matchedRouteRevision?: number | null
+  groupId?: string | null
+  incidentId?: string | null
+  grouping: { state: string; reason?: string | null }
+  paging: { state: string; reason?: string | null }
+  incident: { state: string; reason?: string | null }
+}
+
 export function adminMethods(core: ApiClientCore) {
   const base = core.API_BASE
 
@@ -214,7 +228,7 @@ export function adminMethods(core: ApiClientCore) {
       title: string
       description: string
     }) =>
-      core.request<{ success: boolean }>(`${base}/admin/incidents/trigger`, {
+      core.request<TriggerIncidentResponse>(`${base}/admin/incidents/trigger`, {
         method: 'POST',
         body: JSON.stringify(data),
       }),

--- a/dashboard/src/lib/api/types/on-call.ts
+++ b/dashboard/src/lib/api/types/on-call.ts
@@ -109,6 +109,21 @@ export interface EscalationPolicy {
 
 export type OnCallAlertStatus = 'TRIGGERED' | 'ACKNOWLEDGED' | 'RESOLVED'
 
+export interface AlertRouteActionSummary {
+  state: 'SUCCEEDED' | 'SKIPPED' | 'FAILED'
+  reason: string
+}
+
+export interface AlertRouteOutcomeSummary {
+  matchedRouteId: string
+  matchedRouteRevision: number
+  groupId: string
+  incidentId?: string
+  grouping: AlertRouteActionSummary
+  paging: AlertRouteActionSummary
+  incident: AlertRouteActionSummary
+}
+
 export interface OnCallAlert {
   id: string
   organizationId: string
@@ -129,6 +144,7 @@ export interface OnCallAlert {
   metadata?: Record<string, unknown>
   nextEscalationAt?: string
   viewedByCurrentUser?: boolean
+  routeOutcome?: AlertRouteOutcomeSummary
 }
 
 export interface OnCallTimelineEvent {

--- a/dashboard/src/routes/__tests__/on-call-alert-routes.test.tsx
+++ b/dashboard/src/routes/__tests__/on-call-alert-routes.test.tsx
@@ -118,6 +118,7 @@ describe('alert routes page', () => {
     expect(screen.getByText(/\(\+1 more group\)/)).toBeInTheDocument()
     expect(screen.getByText(/2 targets/)).toBeInTheDocument()
     expect(screen.getByText('Incident (active)')).toBeInTheDocument()
+    expect(screen.getByText('Active incident')).toBeInTheDocument()
     expect(screen.getByText('No conditions')).toBeInTheDocument()
 
     fireEvent.click(screen.getByLabelText('Toggle Checkout'))
@@ -150,6 +151,18 @@ describe('alert routes page', () => {
     renderPage()
     expect(await screen.findByText(/Editing routes requires an administrator/)).toBeInTheDocument()
     expect(screen.queryByText('New route')).not.toBeInTheDocument()
+  })
+
+  it('warns when enabled routes cannot create incidents', async () => {
+    api.getAlertRoutes.mockResolvedValue([
+      {
+        ...baseRoute,
+        incident: {create: false, mode: 'TRIAGE'},
+      },
+    ])
+    renderPage()
+    expect(await screen.findByText('No enabled route creates incidents')).toBeInTheDocument()
+    expect(screen.getByText('Paging only')).toBeInTheDocument()
   })
 
   it('reports stale and ordinary mutation failures', async () => {

--- a/dashboard/src/routes/__tests__/overview-alert-incident-coverage.test.tsx
+++ b/dashboard/src/routes/__tests__/overview-alert-incident-coverage.test.tsx
@@ -199,6 +199,15 @@ const alert = {
   status: 'TRIGGERED',
   alertSource: 'monitor',
   triggeredAt: '2026-06-05T12:00:00.000Z',
+  routeOutcome: {
+    matchedRouteId: resourceId(171),
+    matchedRouteRevision: 3,
+    groupId: resourceId(172),
+    incidentId: DECLARED_INCIDENT_RESOURCE_ID,
+    grouping: {state: 'SUCCEEDED', reason: 'Grouped into the active alert window'},
+    paging: {state: 'FAILED', reason: 'Paging target delivery failed'},
+    incident: {state: 'SKIPPED', reason: 'Incident already linked'},
+  },
 }
 
 const alertTimeline = [

--- a/dashboard/src/routes/admin.incidents.tsx
+++ b/dashboard/src/routes/admin.incidents.tsx
@@ -66,10 +66,13 @@ function AdminIncidentsPage() {
         description
       })
     },
-    onSuccess: () => {
+    onSuccess: (result) => {
       toast({
-        title: 'Incident Triggered',
-        description: 'The incident has been successfully triggered.',
+        title: result.incidentTriggered ? 'Incident Triggered' : 'No Incident Created',
+        description: result.incidentTriggered
+          ? result.incident?.reason || 'The alert route created or attached an incident.'
+          : result.routeReason || result.incident?.reason || 'The alert was accepted without creating an incident.',
+        variant: result.incidentTriggered ? 'default' : 'destructive',
       })
     },
     onError: (error) => {
@@ -90,14 +93,14 @@ function AdminIncidentsPage() {
     <div className="space-y-8">
       <SectionHeader
         title="Incident Management"
-        description="Manually trigger incidents to test alerting and escalation policies."
+        description="Send a test alert and review the Alert Route actions that actually occurred."
       />
 
       <Card>
         <CardHeader>
           <CardTitle>Trigger New Incident</CardTitle>
           <CardDescription>
-            Configure the parameters below to fire a test incident.
+            Configure the parameters below to evaluate a test alert. An alert is not an incident unless a matching route creates or attaches one.
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/dashboard/src/routes/on-call.alert-routes.tsx
+++ b/dashboard/src/routes/on-call.alert-routes.tsx
@@ -103,6 +103,8 @@ function AlertRoutesPage() {
   })
 
   const routes = [...(routesQuery.data ?? [])].sort((a, b) => a.position - b.position)
+  const enabledRoutes = routes.filter((route) => route.enabled)
+  const incidentCreatingRoutes = enabledRoutes.filter((route) => route.incident.create)
   const escalationPolicies = (escalationPoliciesQuery.data ?? []).map((policy) => ({
     id: policy.id,
     name: policy.name,
@@ -213,6 +215,18 @@ function AlertRoutesPage() {
       {!isAdmin && (
         <div className="rounded-lg border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
           You can review alert routes here. Editing routes requires an administrator.
+        </div>
+      )}
+
+      {!routesQuery.isLoading && routes.length > 0 && incidentCreatingRoutes.length === 0 && (
+        <div className="rounded-lg border border-warning-border bg-warning-bg px-3 py-3 text-xs text-warning-fg">
+          <p className="font-medium">No enabled route creates incidents</p>
+          <p className="mt-1">
+            Matching alerts may still be grouped or paged, but they will not open an incident.
+            {isAdmin
+              ? ' Enable incident creation on a route or create a triage route before relying on automatic incidents.'
+              : ' Ask an administrator to enable incident creation on a matching route.'}
+          </p>
         </div>
       )}
 
@@ -363,6 +377,9 @@ function AlertRouteRow({
             <Badge variant={route.enabled ? 'success' : 'neutral'} size="sm">
               {route.enabled ? 'Enabled' : 'Disabled'}
             </Badge>
+            <Badge variant="outline" size="sm">
+              {routeBehaviorLabel(route)}
+            </Badge>
           </div>
           {route.description && (
             <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">{route.description}</p>
@@ -430,4 +447,10 @@ function RouteSummary({route}: Readonly<{route: AlertRoute}>) {
       </div>
     </div>
   )
+}
+
+function routeBehaviorLabel(route: AlertRoute): string {
+  if (!route.enabled) return 'Disabled'
+  if (!route.incident.create) return route.paging.mode === 'NONE' ? 'Grouping only' : 'Paging only'
+  return route.incident.mode === 'ACTIVE' ? 'Active incident' : 'Triage incident'
 }

--- a/dashboard/src/routes/on-call.alerts.$alertId.tsx
+++ b/dashboard/src/routes/on-call.alerts.$alertId.tsx
@@ -16,7 +16,7 @@
 
 import {createFileRoute, useNavigate} from '@tanstack/react-router'
 import {useQuery, useMutation, useQueryClient} from '@tanstack/react-query'
-import {api, type OnCallTimelineEvent} from '@/lib/api'
+import {api, type AlertRouteOutcomeSummary, type OnCallTimelineEvent} from '@/lib/api'
 import {Button} from '@/components/ui/button'
 import {Badge, type BadgeProps} from '@/components/ui/badge'
 import {SectionCard} from '@/components/ui/section-card'
@@ -400,6 +400,8 @@ function AlertDetailPage() {
             </SectionCard>
           )}
 
+          {alert.routeOutcome && <AlertRouteOutcomeCard outcome={alert.routeOutcome} />}
+
           {/* Timeline */}
           <SectionCard title="Timeline" icon={Clock} iconTone="muted">
             <p className="-mt-1 mb-3 text-xs text-muted-foreground">Alert history and updates</p>
@@ -527,5 +529,36 @@ function AlertDetailPage() {
         </div>
       </div>
     </div>
+  )
+}
+
+function AlertRouteOutcomeCard({
+  outcome,
+}: Readonly<{outcome: AlertRouteOutcomeSummary}>) {
+  const action = (label: string, result: AlertRouteOutcomeSummary['grouping']) => (
+    <div className="rounded-lg border bg-muted/20 p-3">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-xs font-medium">{label}</p>
+        <Badge variant={result.state === 'SUCCEEDED' ? 'success' : result.state === 'FAILED' ? 'danger' : 'neutral'}>
+          {result.state === 'SUCCEEDED' ? 'Completed' : result.state === 'FAILED' ? 'Failed' : 'Skipped'}
+        </Badge>
+      </div>
+      <p className="mt-1 text-xs text-muted-foreground">{result.reason}</p>
+    </div>
+  )
+
+  return (
+    <SectionCard title="Alert Route outcome" icon={Zap} iconTone="accent" bodyClassName="space-y-3">
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+        <span>Route revision {outcome.matchedRouteRevision}</span>
+        <span className="font-mono">Group {outcome.groupId}</span>
+        {outcome.incidentId && <span className="font-mono">Incident {outcome.incidentId}</span>}
+      </div>
+      <div className="grid gap-2 sm:grid-cols-3">
+        {action('Grouping', outcome.grouping)}
+        {action('Paging', outcome.paging)}
+        {action('Incident', outcome.incident)}
+      </div>
+    </SectionCard>
   )
 }

--- a/dashboard/src/routes/on-call.alerts.$alertId.tsx
+++ b/dashboard/src/routes/on-call.alerts.$alertId.tsx
@@ -16,7 +16,7 @@
 
 import {createFileRoute, useNavigate} from '@tanstack/react-router'
 import {useQuery, useMutation, useQueryClient} from '@tanstack/react-query'
-import {api, type AlertRouteOutcomeSummary, type OnCallTimelineEvent} from '@/lib/api'
+import {api, type AlertRouteActionSummary, type AlertRouteOutcomeSummary, type OnCallTimelineEvent} from '@/lib/api'
 import {Button} from '@/components/ui/button'
 import {Badge, type BadgeProps} from '@/components/ui/badge'
 import {SectionCard} from '@/components/ui/section-card'
@@ -535,13 +535,21 @@ function AlertDetailPage() {
 function AlertRouteOutcomeCard({
   outcome,
 }: Readonly<{outcome: AlertRouteOutcomeSummary}>) {
+  const badgeVariant = (result: AlertRouteActionSummary): BadgeProps['variant'] => {
+    if (result.state === 'SUCCEEDED') return 'success'
+    if (result.state === 'FAILED') return 'danger'
+    return 'neutral'
+  }
+  const badgeLabel = (result: AlertRouteActionSummary): string => {
+    if (result.state === 'SUCCEEDED') return 'Completed'
+    if (result.state === 'FAILED') return 'Failed'
+    return 'Skipped'
+  }
   const action = (label: string, result: AlertRouteOutcomeSummary['grouping']) => (
     <div className="rounded-lg border bg-muted/20 p-3">
       <div className="flex items-center justify-between gap-2">
         <p className="text-xs font-medium">{label}</p>
-        <Badge variant={result.state === 'SUCCEEDED' ? 'success' : result.state === 'FAILED' ? 'danger' : 'neutral'}>
-          {result.state === 'SUCCEEDED' ? 'Completed' : result.state === 'FAILED' ? 'Failed' : 'Skipped'}
-        </Badge>
+        <Badge variant={badgeVariant(result)}>{badgeLabel(result)}</Badge>
       </div>
       <p className="mt-1 text-xs text-muted-foreground">{result.reason}</p>
     </div>

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/commands/AlertRouteCommands.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/commands/AlertRouteCommands.kt
@@ -15,6 +15,9 @@ import com.moneat.enterprise.alertroutes.models.AlertRoutePagingMode
 import com.moneat.enterprise.alertroutes.models.AlertRouteTargetKind
 import kotlin.uuid.Uuid
 
+/** Route-only sentinel resolved from the matched alert's priority at execution time. */
+const val ALERT_PRIORITY_SEVERITY = "ALERT_PRIORITY"
+
 data class AlertRouteActor(
     val organizationId: Int,
     val userId: Int,

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertGroupService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertGroupService.kt
@@ -31,6 +31,7 @@ import com.moneat.enterprise.oncall.models.OnCallAlerts
 import com.moneat.shared.models.Organizations
 import com.moneat.shared.models.EscalationPolicies
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import org.jetbrains.exposed.v1.core.Exists
 import org.jetbrains.exposed.v1.core.JoinType
@@ -202,6 +203,34 @@ class AlertGroupService(private val policy: AlertGroupPolicy = AlertGroupPolicy(
             )
             touchGroup(group, effectiveDecision, now)
             AlertGroupReader.get(context.organizationId, group[EnterpriseAlertGroups.resourceId])
+        }
+    }
+
+    internal fun recordIncidentActionOutcome(
+        organizationId: Int,
+        groupId: Uuid,
+        state: String,
+        reason: String?,
+    ) {
+        policy.requireEnabled(organizationId)
+        transaction {
+            val group = AlertGroupReader.requireGroup(organizationId, groupId, lock = true)
+            val execution = group[EnterpriseAlertGroups.incidentTemplateSnapshot]["execution"]
+                ?.let { it as? JsonObject }
+                ?.toMutableMap()
+                ?: mutableMapOf()
+            val incident = mutableMapOf<String, JsonElement>("state" to JsonPrimitive(state))
+            reason?.let { incident["reason"] = JsonPrimitive(it) }
+            execution["incident"] = JsonObject(incident)
+            val snapshot = group[EnterpriseAlertGroups.incidentTemplateSnapshot].toMutableMap()
+            snapshot["execution"] = JsonObject(execution)
+            EnterpriseAlertGroups.update({
+                (EnterpriseAlertGroups.organizationId eq organizationId) and
+                    (EnterpriseAlertGroups.resourceId eq groupId)
+            }) {
+                it[incidentTemplateSnapshot] = snapshot
+                it[updatedAt] = Clock.System.now()
+            }
         }
     }
 

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteExecutionService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteExecutionService.kt
@@ -5,7 +5,11 @@
 package com.moneat.enterprise.alertroutes.services
 
 import com.moneat.alerts.models.AlertStatus
+import com.moneat.alerts.services.AlertRouteActionOutcome
+import com.moneat.alerts.services.AlertRouteActionState
 import com.moneat.alerts.services.AlertFanoutContext
+import com.moneat.alerts.services.AlertRouteExecutionOutcome
+import com.moneat.alerts.services.AlertRouteExecutionState
 import com.moneat.enterprise.FeatureRegistry
 import com.moneat.enterprise.alertroutes.commands.AlertGroupActor
 import com.moneat.enterprise.alertroutes.commands.AttachAlertGroupIncidentCommand
@@ -60,25 +64,54 @@ class AlertRouteExecutionService(
     private val now: () -> Instant = { Clock.System.now() },
 ) {
     suspend fun execute(context: AlertFanoutContext) {
-        val episode = context.episode ?: return
+        val outcome = executeInternal(context, propagateFailures = true)
+        check(outcome.state != AlertRouteExecutionState.FAILED) { outcome.reason ?: "Alert-route execution failed" }
+    }
+
+    suspend fun executeWithOutcome(context: AlertFanoutContext): AlertRouteExecutionOutcome =
+        suspendRunCatching { executeInternal(context, propagateFailures = false) }
+            .getOrElse { error ->
+                if (error is kotlinx.coroutines.CancellationException) throw error
+                executionLogger.error(error) { "Alert-route execution failed" }
+                AlertRouteExecutionOutcome(
+                    state = AlertRouteExecutionState.FAILED,
+                    reason = error.message ?: "Alert-route execution failed",
+                )
+            }
+
+    private suspend fun executeInternal(
+        context: AlertFanoutContext,
+        propagateFailures: Boolean,
+    ): AlertRouteExecutionOutcome {
+        val episode = context.episode ?: return AlertRouteExecutionOutcome(
+                state = AlertRouteExecutionState.UNAVAILABLE,
+                reason = "Alert episode is unavailable for route evaluation",
+            )
         val episodeId = episode.resourceId
         if (context.event.status == AlertStatus.RESOLVED) {
             recover(context.event.organizationId, episodeId)
-            return
+            return AlertRouteExecutionOutcome(
+                state = AlertRouteExecutionState.SKIPPED,
+                reason = "Resolved alerts are handled by route recovery",
+            )
         }
-        executeFiring(context, episode)
+        return executeFiring(context, episode, propagateFailures)
     }
 
     private suspend fun executeFiring(
         context: AlertFanoutContext,
         episode: com.moneat.alerts.services.AlertEpisodeContext,
-    ) {
+        propagateFailures: Boolean,
+    ): AlertRouteExecutionOutcome {
         val episodeId = episode.resourceId
         val live = evaluationService.evaluateLive(
             context.event,
             com.moneat.enterprise.alertroutes.context.AlertRouteEpisodeIdentity.from(episode),
         )
-        val decision = live.result.decision ?: return
+        val decision = live.result.decision ?: return AlertRouteExecutionOutcome(
+            state = AlertRouteExecutionState.NO_MATCH,
+            reason = "No enabled alert route matched this alert",
+        )
         val candidate = if (decision.grouping.behavior in CORRELATING_GROUPING_BEHAVIORS) {
             groupService.findCandidateIncident(
                 context.event.organizationId,
@@ -90,11 +123,64 @@ class AlertRouteExecutionService(
         }
         val group = groupService.recordFiring(live.context, decision, episodeId, candidate, now())
         val incidentResult = runCatching { applyIncidentActions(context, episodeId, group) }
-        val pagingResult = suspendRunCatching {
-            if (!context.deliverySilenced) page(context, group, decision.paging.escalationPolicies.map { it.id })
+        val finalGroup = incidentResult.getOrNull() ?: group
+        val incidentOutcome = incidentResult.fold(
+            onSuccess = { updatedGroup -> incidentActionOutcome(context, group, updatedGroup) },
+            onFailure = { error ->
+                AlertRouteActionOutcome(AlertRouteActionState.FAILED, error.message ?: "Incident action failed")
+            },
+        )
+        val pagingOutcome = if (context.deliverySilenced) {
+            AlertRouteActionOutcome(AlertRouteActionState.SKIPPED, "Paging skipped because delivery is silenced")
+        } else {
+            page(context, finalGroup, decision.paging.escalationPolicies.map { it.id })
         }
-        incidentResult.exceptionOrNull()?.let { throw it }
-        pagingResult.getOrThrow()
+        if (propagateFailures) {
+            incidentResult.exceptionOrNull()?.let { throw it }
+            check(pagingOutcome.state != AlertRouteActionState.FAILED) {
+                pagingOutcome.reason ?: "Alert-route paging failed"
+            }
+        }
+        val overallState = when {
+            incidentOutcome.state == AlertRouteActionState.FAILED ||
+                pagingOutcome.state == AlertRouteActionState.FAILED -> AlertRouteExecutionState.FAILED
+            else -> AlertRouteExecutionState.MATCHED
+        }
+        return AlertRouteExecutionOutcome(
+            state = overallState,
+            reason = if (overallState == AlertRouteExecutionState.FAILED) {
+                incidentOutcome.reason ?: pagingOutcome.reason
+            } else {
+                null
+            },
+            matchedRouteId = decision.routeId.toString(),
+            matchedRouteRevision = decision.revision,
+            groupId = finalGroup.id.toString(),
+            incidentId = finalGroup.incidentId?.toString(),
+            grouping = AlertRouteActionOutcome(AlertRouteActionState.SUCCEEDED, "Alert grouped"),
+            paging = pagingOutcome,
+            incident = incidentOutcome,
+        )
+    }
+
+    private fun incidentActionOutcome(
+        context: AlertFanoutContext,
+        initialGroup: AlertGroupRecord,
+        finalGroup: AlertGroupRecord,
+    ): AlertRouteActionOutcome = when {
+        context.deliverySilenced ->
+            AlertRouteActionOutcome(
+                AlertRouteActionState.SKIPPED,
+                "Incident action skipped because delivery is silenced",
+            )
+        finalGroup.incidentId != null && initialGroup.incidentId == null ->
+            AlertRouteActionOutcome(AlertRouteActionState.SUCCEEDED, "Incident created or attached")
+        finalGroup.incidentId != null ->
+            AlertRouteActionOutcome(AlertRouteActionState.SUCCEEDED, "Alert linked to the existing incident")
+        finalGroup.candidateIncidentId != null && finalGroup.behavior != AlertRouteGroupingBehavior.AUTOMATIC ->
+            AlertRouteActionOutcome(AlertRouteActionState.SKIPPED, "Incident attachment requires automatic grouping")
+        else ->
+            AlertRouteActionOutcome(AlertRouteActionState.SKIPPED, "Incident creation is disabled for this route")
     }
 
     private fun applyIncidentActions(
@@ -162,10 +248,17 @@ class AlertRouteExecutionService(
         }
     }
 
-    private suspend fun page(context: AlertFanoutContext, group: AlertGroupRecord, policyIds: List<Int>) {
-        if (policyIds.isEmpty()) return
+    private suspend fun page(
+        context: AlertFanoutContext,
+        group: AlertGroupRecord,
+        policyIds: List<Int>,
+    ): AlertRouteActionOutcome {
+        if (policyIds.isEmpty()) {
+            return AlertRouteActionOutcome(AlertRouteActionState.SKIPPED, "No paging targets are configured")
+        }
         val episodeId = requireNotNull(context.episode).resourceId
-        val commandKey = pagingCommandKey(group, episodeId) ?: return
+        val commandKey = pagingCommandKey(group, episodeId)
+            ?: return AlertRouteActionOutcome(AlertRouteActionState.SKIPPED, "Paging is disabled for this route")
         val attemptTime = now()
         val existingByKey = groupService.escalations(context.event.organizationId, group.id)
             .associateBy(AlertGroupEscalationRecord::escalationKey)
@@ -196,7 +289,7 @@ class AlertRouteExecutionService(
                 ),
             )
         ) {
-            return
+            return AlertRouteActionOutcome(AlertRouteActionState.SKIPPED, "Paging was already claimed for this group")
         }
         var succeeded = true
         policyIds.distinct().forEach { policyId ->
@@ -254,7 +347,14 @@ class AlertRouteExecutionService(
                 succeeded,
             ),
         )
-        check(succeeded) { "One or more alert-route paging targets failed" }
+        return if (succeeded) {
+            AlertRouteActionOutcome(
+                AlertRouteActionState.SUCCEEDED,
+                "Paged ${policyIds.distinct().size} escalation target(s)",
+            )
+        } else {
+            AlertRouteActionOutcome(AlertRouteActionState.FAILED, "One or more alert-route paging targets failed")
+        }
     }
 
     private fun pagingCommandKey(group: AlertGroupRecord, episodeId: Uuid): String? =

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteExecutionService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteExecutionService.kt
@@ -5,6 +5,7 @@
 package com.moneat.enterprise.alertroutes.services
 
 import com.moneat.alerts.models.AlertStatus
+import com.moneat.alerts.models.AlertPriority
 import com.moneat.alerts.services.AlertRouteActionOutcome
 import com.moneat.alerts.services.AlertRouteActionState
 import com.moneat.alerts.services.AlertFanoutContext
@@ -12,6 +13,7 @@ import com.moneat.alerts.services.AlertRouteExecutionOutcome
 import com.moneat.alerts.services.AlertRouteExecutionState
 import com.moneat.enterprise.FeatureRegistry
 import com.moneat.enterprise.alertroutes.commands.AlertGroupActor
+import com.moneat.enterprise.alertroutes.commands.ALERT_PRIORITY_SEVERITY
 import com.moneat.enterprise.alertroutes.commands.AttachAlertGroupIncidentCommand
 import com.moneat.enterprise.alertroutes.commands.CreateAlertGroupTriageCommand
 import com.moneat.enterprise.alertroutes.models.AlertGroupEscalationState
@@ -35,6 +37,7 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -208,10 +211,11 @@ class AlertRouteExecutionService(
                         CreateAlertGroupTriageCommand(
                             commandKey = "route-create-incident:${group.id}",
                             actor = actor,
-                            groupId = group.id,
-                            expectedVersion = group.version,
-                            initialStatus = group.incidentTemplateSnapshot.incidentStatus(),
-                        ),
+                    groupId = group.id,
+                    expectedVersion = group.version,
+                    initialStatus = group.incidentTemplateSnapshot.incidentStatus(),
+                    severity = derivedIncidentSeverity(context.event.priority, group),
+                ),
                     ).group
                 else -> group
             }
@@ -231,6 +235,17 @@ class AlertRouteExecutionService(
             ).group
         }
         return group
+    }
+
+    private fun derivedIncidentSeverity(priority: AlertPriority, group: AlertGroupRecord): String? {
+        val configured = group.incidentTemplateSnapshot.text("severity") ?: return null
+        if (configured != ALERT_PRIORITY_SEVERITY) return configured
+        return when (priority) {
+            AlertPriority.P0 -> "SEV-0"
+            AlertPriority.P1 -> "SEV-1"
+            AlertPriority.P2 -> "SEV-2"
+            else -> null
+        }
     }
 
     suspend fun recoverDue(enabled: (Int) -> Boolean = FeatureRegistry::isNativeIncidentResponseEntitled) {
@@ -465,6 +480,9 @@ class AlertRouteExecutionService(
 
     private fun Map<String, kotlinx.serialization.json.JsonElement>.boolean(key: String): Boolean? =
         get(key)?.jsonPrimitive?.booleanOrNull
+
+    private fun Map<String, kotlinx.serialization.json.JsonElement>.text(key: String): String? =
+        get(key)?.jsonPrimitive?.contentOrNull
 
     private fun Map<String, kotlinx.serialization.json.JsonElement>.incidentStatus(): NativeIncidentStatus =
         when (get("mode")?.jsonPrimitive?.content) {

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteExecutionService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteExecutionService.kt
@@ -58,6 +58,12 @@ private const val ROUTE_AUTOMATION_ORIGIN = "ALERT_ROUTE"
 private const val ROUTE_EXECUTION_FAILURE_REASON = "Alert-route execution failed"
 private val executionLogger = KotlinLogging.logger {}
 
+private data class IncidentActionExecution(
+    val group: AlertGroupRecord,
+    val outcome: AlertRouteActionOutcome,
+    val error: Throwable?,
+)
+
 /** Executes the selected route without coupling it to workflow or provider delivery. */
 class AlertRouteExecutionService(
     private val evaluationService: AlertRouteEvaluationService = AlertRouteEvaluationService(),
@@ -126,21 +132,16 @@ class AlertRouteExecutionService(
             null
         }
         val group = groupService.recordFiring(live.context, decision, episodeId, candidate, now())
-        val incidentResult = runCatching { applyIncidentActions(context, episodeId, group) }
-        val finalGroup = incidentResult.getOrNull() ?: group
-        val incidentOutcome = incidentResult.fold(
-            onSuccess = { updatedGroup -> incidentActionOutcome(context, group, updatedGroup) },
-            onFailure = { error ->
-                AlertRouteActionOutcome(AlertRouteActionState.FAILED, error.message ?: "Incident action failed")
-            },
-        )
+        val incidentExecution = applyIncidentActionsWithOutcome(context, episodeId, group)
+        val finalGroup = incidentExecution.group
+        val incidentOutcome = incidentExecution.outcome
         val pagingOutcome = if (context.deliverySilenced) {
             AlertRouteActionOutcome(AlertRouteActionState.SKIPPED, "Paging skipped because delivery is silenced")
         } else {
             page(context, finalGroup, decision.paging.escalationPolicies.map { it.id })
         }
         if (propagateFailures) {
-            incidentResult.exceptionOrNull()?.let { throw it }
+            incidentExecution.error?.let { throw it }
             check(pagingOutcome.state != AlertRouteActionState.FAILED) {
                 pagingOutcome.reason ?: "Alert-route paging failed"
             }
@@ -165,6 +166,34 @@ class AlertRouteExecutionService(
             paging = pagingOutcome,
             incident = incidentOutcome,
         )
+    }
+
+    private fun applyIncidentActionsWithOutcome(
+        context: AlertFanoutContext,
+        episodeId: Uuid,
+        group: AlertGroupRecord,
+    ): IncidentActionExecution {
+        val result = runCatching { applyIncidentActions(context, episodeId, group) }
+        val error = result.exceptionOrNull()
+        error?.let {
+            groupService.recordIncidentActionOutcome(
+                organizationId = context.event.organizationId,
+                groupId = group.id,
+                state = AlertRouteActionState.FAILED.name,
+                reason = it.message ?: "Incident action failed",
+            )
+        }
+        val finalGroup = result.getOrNull() ?: group
+        val outcome = result.fold(
+            onSuccess = { updatedGroup -> incidentActionOutcome(context, group, updatedGroup) },
+            onFailure = { failure ->
+                AlertRouteActionOutcome(
+                    AlertRouteActionState.FAILED,
+                    failure.message ?: "Incident action failed",
+                )
+            },
+        )
+        return IncidentActionExecution(finalGroup, outcome, error)
     }
 
     private fun incidentActionOutcome(

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteExecutionService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteExecutionService.kt
@@ -55,6 +55,7 @@ import kotlin.uuid.Uuid
 
 private const val ROUTE_ALERT_SOURCE = "alert-route"
 private const val ROUTE_AUTOMATION_ORIGIN = "ALERT_ROUTE"
+private const val ROUTE_EXECUTION_FAILURE_REASON = "Alert-route execution failed"
 private val executionLogger = KotlinLogging.logger {}
 
 /** Executes the selected route without coupling it to workflow or provider delivery. */
@@ -68,17 +69,17 @@ class AlertRouteExecutionService(
 ) {
     suspend fun execute(context: AlertFanoutContext) {
         val outcome = executeInternal(context, propagateFailures = true)
-        check(outcome.state != AlertRouteExecutionState.FAILED) { outcome.reason ?: "Alert-route execution failed" }
+        check(outcome.state != AlertRouteExecutionState.FAILED) { outcome.reason ?: ROUTE_EXECUTION_FAILURE_REASON }
     }
 
     suspend fun executeWithOutcome(context: AlertFanoutContext): AlertRouteExecutionOutcome =
         suspendRunCatching { executeInternal(context, propagateFailures = false) }
             .getOrElse { error ->
                 if (error is kotlinx.coroutines.CancellationException) throw error
-                executionLogger.error(error) { "Alert-route execution failed" }
+                executionLogger.error(error) { ROUTE_EXECUTION_FAILURE_REASON }
                 AlertRouteExecutionOutcome(
                     state = AlertRouteExecutionState.FAILED,
-                    reason = error.message ?: "Alert-route execution failed",
+                    reason = error.message ?: ROUTE_EXECUTION_FAILURE_REASON,
                 )
             }
 

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteOutcomeReader.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteOutcomeReader.kt
@@ -1,0 +1,76 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.services
+
+import com.moneat.enterprise.alertroutes.models.AlertGroupEscalationState
+import com.moneat.enterprise.alertroutes.models.AlertRoutePagingMode
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertGroupEscalations
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertGroups
+import com.moneat.enterprise.oncall.models.AlertRouteActionSummary
+import com.moneat.enterprise.oncall.models.AlertRouteOutcomeSummary
+import com.moneat.enterprise.oncall.models.OnCallIncidents
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+
+/** Read-only route execution evidence attached to a concrete on-call alert. */
+object AlertRouteOutcomeReader {
+    fun findForOnCallAlert(organizationId: Int, onCallAlertId: Int): AlertRouteOutcomeSummary? = transaction {
+        val escalation = EnterpriseAlertGroupEscalations
+            .selectAll()
+            .where {
+                (EnterpriseAlertGroupEscalations.organizationId eq organizationId) and
+                    (EnterpriseAlertGroupEscalations.onCallAlertId eq onCallAlertId)
+            }
+            .orderBy(EnterpriseAlertGroupEscalations.updatedAt to SortOrder.DESC)
+            .firstOrNull() ?: return@transaction null
+        val group = EnterpriseAlertGroups.selectAll().where {
+            (EnterpriseAlertGroups.organizationId eq organizationId) and
+                (EnterpriseAlertGroups.id eq escalation[EnterpriseAlertGroupEscalations.groupId])
+        }.singleOrNull() ?: return@transaction null
+        val incidentId = group[EnterpriseAlertGroups.incidentId]?.let { internalId ->
+            OnCallIncidents.selectAll().where {
+                (OnCallIncidents.organizationId eq organizationId) and (OnCallIncidents.id eq internalId)
+            }.singleOrNull()?.get(OnCallIncidents.resourceId)?.toString()
+        }
+        val pagingMode = AlertRoutePagingMode.valueOf(group[EnterpriseAlertGroups.pagingMode])
+        val escalations = EnterpriseAlertGroupEscalations.selectAll().where {
+            (EnterpriseAlertGroupEscalations.organizationId eq organizationId) and
+                (EnterpriseAlertGroupEscalations.groupId eq group[EnterpriseAlertGroups.id].value)
+        }.toList()
+        val paging = when {
+            pagingMode == AlertRoutePagingMode.NONE ->
+                AlertRouteActionSummary("SKIPPED", "Paging is disabled for this route")
+            escalations.any { it[EnterpriseAlertGroupEscalations.state] == AlertGroupEscalationState.FAILED.wire } ->
+                AlertRouteActionSummary("FAILED", "One or more paging targets failed")
+            escalations.any { it[EnterpriseAlertGroupEscalations.state] == AlertGroupEscalationState.TRIGGERED.wire } ->
+                AlertRouteActionSummary("SUCCEEDED", "Paging target delivered this alert")
+            else ->
+                AlertRouteActionSummary("SKIPPED", "Paging has not been delivered for this alert")
+        }
+        val createIncident = group[EnterpriseAlertGroups.incidentTemplateSnapshot]["create"]
+            ?.jsonPrimitive?.booleanOrNull == true
+        val incident = if (incidentId != null) {
+            AlertRouteActionSummary("SUCCEEDED", "Alert linked to the incident")
+        } else if (createIncident) {
+            AlertRouteActionSummary("SKIPPED", "Incident was not created for this alert")
+        } else {
+            AlertRouteActionSummary("SKIPPED", "Incident creation is disabled for this route")
+        }
+        AlertRouteOutcomeSummary(
+            matchedRouteId = group[EnterpriseAlertGroups.routeResourceId].toString(),
+            matchedRouteRevision = group[EnterpriseAlertGroups.routeRevision],
+            groupId = group[EnterpriseAlertGroups.resourceId].toString(),
+            incidentId = incidentId,
+            grouping = AlertRouteActionSummary("SUCCEEDED", "Alert grouped by the selected route"),
+            paging = paging,
+            incident = incident,
+        )
+    }
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteOutcomeReader.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteOutcomeReader.kt
@@ -62,17 +62,14 @@ object AlertRouteOutcomeReader {
             ?.jsonObject
             ?.get("incident")
             ?.jsonObject
-        val incident = if (incidentId != null) {
-            AlertRouteActionSummary("SUCCEEDED", "Alert linked to the incident")
-        } else if (storedIncident != null) {
-            AlertRouteActionSummary(
+        val incident = when {
+            incidentId != null -> AlertRouteActionSummary("SUCCEEDED", "Alert linked to the incident")
+            storedIncident != null -> AlertRouteActionSummary(
                 state = storedIncident["state"]?.jsonPrimitive?.contentOrNull ?: "FAILED",
                 reason = storedIncident["reason"]?.jsonPrimitive?.contentOrNull ?: "Incident action failed",
             )
-        } else if (createIncident) {
-            AlertRouteActionSummary("SKIPPED", "Incident was not created for this alert")
-        } else {
-            AlertRouteActionSummary("SKIPPED", "Incident creation is disabled for this route")
+            createIncident -> AlertRouteActionSummary("SKIPPED", "Incident was not created for this alert")
+            else -> AlertRouteActionSummary("SKIPPED", "Incident creation is disabled for this route")
         }
         AlertRouteOutcomeSummary(
             matchedRouteId = group[EnterpriseAlertGroups.routeResourceId].toString(),

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteOutcomeReader.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteOutcomeReader.kt
@@ -12,6 +12,8 @@ import com.moneat.enterprise.oncall.models.AlertRouteActionSummary
 import com.moneat.enterprise.oncall.models.AlertRouteOutcomeSummary
 import com.moneat.enterprise.oncall.models.OnCallIncidents
 import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.and
@@ -56,8 +58,17 @@ object AlertRouteOutcomeReader {
         }
         val createIncident = group[EnterpriseAlertGroups.incidentTemplateSnapshot]["create"]
             ?.jsonPrimitive?.booleanOrNull == true
+        val storedIncident = group[EnterpriseAlertGroups.incidentTemplateSnapshot]["execution"]
+            ?.jsonObject
+            ?.get("incident")
+            ?.jsonObject
         val incident = if (incidentId != null) {
             AlertRouteActionSummary("SUCCEEDED", "Alert linked to the incident")
+        } else if (storedIncident != null) {
+            AlertRouteActionSummary(
+                state = storedIncident["state"]?.jsonPrimitive?.contentOrNull ?: "FAILED",
+                reason = storedIncident["reason"]?.jsonPrimitive?.contentOrNull ?: "Incident action failed",
+            )
         } else if (createIncident) {
             AlertRouteActionSummary("SKIPPED", "Incident was not created for this alert")
         } else {

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteValidator.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteValidator.kt
@@ -7,6 +7,7 @@ package com.moneat.enterprise.alertroutes.services
 import com.moneat.alerts.models.AlertPriority
 import com.moneat.alerts.models.IncidentSeverity
 import com.moneat.enterprise.alertroutes.commands.AlertRouteCommand
+import com.moneat.enterprise.alertroutes.commands.ALERT_PRIORITY_SEVERITY
 import com.moneat.enterprise.alertroutes.commands.AlertRouteConditionInput
 import com.moneat.enterprise.alertroutes.commands.AlertRouteSpecification
 import com.moneat.enterprise.alertroutes.commands.AlertRouteTargetInput
@@ -167,10 +168,14 @@ internal object AlertRouteValidator {
             "Incident type is too long"
         }
         incident.severity?.let {
-            require(IncidentSeverity.fromString(it) != null) { "Invalid incident severity: $it" }
+            require(it == ALERT_PRIORITY_SEVERITY || IncidentSeverity.fromString(it) != null) {
+                "Invalid incident severity: $it"
+            }
         }
         if (incident.create && incident.mode == AlertRouteIncidentMode.ACTIVE) {
-            require(!incident.severity.isNullOrBlank()) { "Incident creation requires a severity" }
+            require(!incident.severity.isNullOrBlank() && incident.severity != ALERT_PRIORITY_SEVERITY) {
+                "Incident creation requires a severity; active routes must use a fixed severity"
+            }
         }
         templateReferences(incident.titleTemplate, incident.summaryTemplate).forEach(::validateReference)
     }

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/EnterpriseAlertRouteFanout.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/EnterpriseAlertRouteFanout.kt
@@ -6,15 +6,27 @@ package com.moneat.enterprise.alertroutes.services
 
 import com.moneat.alerts.services.AlertFanoutContext
 import com.moneat.alerts.services.AlertRouteFanout
+import com.moneat.alerts.services.AlertRouteExecutionOutcome
+import com.moneat.alerts.services.AlertRouteExecutionState
+import com.moneat.alerts.services.AlertRouteOutcomeFanout
 import com.moneat.enterprise.FeatureRegistry
 
 /** Enterprise route-evaluation arm. Action execution is added by the downstream execution task. */
 class EnterpriseAlertRouteFanout(
     private val executionService: AlertRouteExecutionService = AlertRouteExecutionService(),
     private val enabled: (Int) -> Boolean = FeatureRegistry::isNativeIncidentResponseEntitled,
-) : AlertRouteFanout {
+) : AlertRouteFanout, AlertRouteOutcomeFanout {
     override suspend fun process(context: AlertFanoutContext) {
-        if (!enabled(context.event.organizationId)) return
-        executionService.execute(context)
+        processWithOutcome(context)
+    }
+
+    override suspend fun processWithOutcome(context: AlertFanoutContext): AlertRouteExecutionOutcome {
+        if (!enabled(context.event.organizationId)) {
+            return AlertRouteExecutionOutcome(
+                state = AlertRouteExecutionState.UNAVAILABLE,
+                reason = "Alert Route entitlement is unavailable for this organization",
+            )
+        }
+        return executionService.executeWithOutcome(context)
     }
 }

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
@@ -5,7 +5,7 @@
 package com.moneat.enterprise.oncall
 
 import com.moneat.config.RedisClient
-import com.moneat.alerts.services.AlertRouteFanoutRegistry
+import com.moneat.alerts.services.AlertRouteFanout
 import com.moneat.enterprise.EnterpriseModule
 import com.moneat.enterprise.IncidentInfo
 import com.moneat.enterprise.OnCallBridge
@@ -51,6 +51,8 @@ import io.ktor.server.routing.Route
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import mu.KotlinLogging
+import org.koin.core.module.Module
+import org.koin.dsl.module
 
 private val logger = KotlinLogging.logger {}
 
@@ -125,6 +127,13 @@ class OnCallModule :
     override val name: String = "On-Call"
     override val licenseFeature: String = "oncall"
 
+    override fun koinModules(): List<Module> =
+        listOf(
+            module {
+                single<AlertRouteFanout> { alertRouteFanout }
+            },
+        )
+
     override fun registerRoutes(route: Route) {
         route.apply {
             onCallRoutes(
@@ -150,7 +159,6 @@ class OnCallModule :
 
     override fun startBackgroundJobs(application: Application) {
         logger.info { "Starting on-call enterprise background jobs" }
-        AlertRouteFanoutRegistry.register(alertRouteFanout)
         alertRouteRecoveryWorker.start()
         escalationEngine.start()
         slackUserGroupSyncService.start()
@@ -161,7 +169,6 @@ class OnCallModule :
 
     override fun stopBackgroundJobs() {
         logger.info { "Stopping on-call enterprise background jobs" }
-        AlertRouteFanoutRegistry.unregister(alertRouteFanout)
         alertRouteRecoveryWorker.stop()
         if (escalationEngineDelegate.isInitialized()) escalationEngine.stop()
         if (slackUserGroupSyncServiceDelegate.isInitialized()) slackUserGroupSyncService.stop()

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/models/OnCallModels.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/models/OnCallModels.kt
@@ -439,7 +439,7 @@ object OnCallAlertTimeline : IntIdTable("on_call_alert_timeline") {
     val createdAt = timestamp("created_at")
 }
 
-@Serializable
+@Serializable(with = OnCallAlertSerializer::class)
 data class OnCallAlert(
     val id: String,
     @SerialName("organizationId") val organizationResourceId: String,
@@ -466,12 +466,132 @@ data class OnCallAlert(
     val viewedByCurrentUser: Boolean = false,
     val createdAt: String,
     val updatedAt: String,
+    val routeOutcome: AlertRouteOutcomeSummary? = null,
     @Transient val internalId: Int = 0,
     @Transient val organizationId: Int = 0,
     @Transient val declaredIncidentId: Int? = null,
     @Transient val escalationPolicyId: Int? = null,
     @Transient val acknowledgedBy: Int? = null,
     @Transient val resolvedBy: Int? = null,
+)
+
+@Serializable
+private data class OnCallAlertWire(
+    val id: String,
+    @SerialName("organizationId") val organizationResourceId: String,
+    @SerialName("declaredIncidentId") val declaredIncidentResourceId: String? = null,
+    @SerialName("escalationPolicyId") val escalationPolicyResourceId: String? = null,
+    val escalationPolicyName: String? = null,
+    val title: String,
+    val description: String? = null,
+    val priority: String,
+    val status: String,
+    val alertSource: String? = null,
+    val deduplicationKey: String? = null,
+    val currentStep: Int,
+    val repeatIteration: Int,
+    val triggeredAt: String,
+    val acknowledgedAt: String? = null,
+    @SerialName("acknowledgedBy") val acknowledgedByResourceId: String? = null,
+    val acknowledgedByName: String? = null,
+    val resolvedAt: String? = null,
+    @SerialName("resolvedBy") val resolvedByResourceId: String? = null,
+    val resolvedByName: String? = null,
+    val metadata: Map<String, kotlinx.serialization.json.JsonElement>? = null,
+    val nextEscalationAt: String? = null,
+    val viewedByCurrentUser: Boolean = false,
+    val createdAt: String,
+    val updatedAt: String,
+    val routeOutcome: AlertRouteOutcomeSummary? = null,
+)
+
+object OnCallAlertSerializer : KSerializer<OnCallAlert> {
+    private val delegate = OnCallAlertWire.serializer()
+
+    override val descriptor: SerialDescriptor = delegate.descriptor
+
+    override fun serialize(encoder: Encoder, value: OnCallAlert) {
+        encoder.encodeSerializableValue(
+            delegate,
+            OnCallAlertWire(
+                id = value.id,
+                organizationResourceId = value.organizationResourceId,
+                declaredIncidentResourceId = value.declaredIncidentResourceId,
+                escalationPolicyResourceId = value.escalationPolicyResourceId,
+                escalationPolicyName = value.escalationPolicyName,
+                title = value.title,
+                description = value.description,
+                priority = value.priority,
+                status = value.status,
+                alertSource = value.alertSource,
+                deduplicationKey = value.deduplicationKey,
+                currentStep = value.currentStep,
+                repeatIteration = value.repeatIteration,
+                triggeredAt = value.triggeredAt,
+                acknowledgedAt = value.acknowledgedAt,
+                acknowledgedByResourceId = value.acknowledgedByResourceId,
+                acknowledgedByName = value.acknowledgedByName,
+                resolvedAt = value.resolvedAt,
+                resolvedByResourceId = value.resolvedByResourceId,
+                resolvedByName = value.resolvedByName,
+                metadata = value.metadata,
+                nextEscalationAt = value.nextEscalationAt,
+                viewedByCurrentUser = value.viewedByCurrentUser,
+                createdAt = value.createdAt,
+                updatedAt = value.updatedAt,
+                routeOutcome = value.routeOutcome,
+            ),
+        )
+    }
+
+    override fun deserialize(decoder: Decoder): OnCallAlert {
+        val wire = decoder.decodeSerializableValue(delegate)
+        return OnCallAlert(
+            id = wire.id,
+            organizationResourceId = wire.organizationResourceId,
+            declaredIncidentResourceId = wire.declaredIncidentResourceId,
+            escalationPolicyResourceId = wire.escalationPolicyResourceId,
+            escalationPolicyName = wire.escalationPolicyName,
+            title = wire.title,
+            description = wire.description,
+            priority = wire.priority,
+            status = wire.status,
+            alertSource = wire.alertSource,
+            deduplicationKey = wire.deduplicationKey,
+            currentStep = wire.currentStep,
+            repeatIteration = wire.repeatIteration,
+            triggeredAt = wire.triggeredAt,
+            acknowledgedAt = wire.acknowledgedAt,
+            acknowledgedByResourceId = wire.acknowledgedByResourceId,
+            acknowledgedByName = wire.acknowledgedByName,
+            resolvedAt = wire.resolvedAt,
+            resolvedByResourceId = wire.resolvedByResourceId,
+            resolvedByName = wire.resolvedByName,
+            metadata = wire.metadata,
+            nextEscalationAt = wire.nextEscalationAt,
+            viewedByCurrentUser = wire.viewedByCurrentUser,
+            createdAt = wire.createdAt,
+            updatedAt = wire.updatedAt,
+            routeOutcome = wire.routeOutcome,
+        )
+    }
+}
+
+@Serializable
+data class AlertRouteActionSummary(
+    val state: String,
+    val reason: String,
+)
+
+@Serializable
+data class AlertRouteOutcomeSummary(
+    val matchedRouteId: String,
+    val matchedRouteRevision: Int,
+    val groupId: String,
+    val incidentId: String? = null,
+    val grouping: AlertRouteActionSummary,
+    val paging: AlertRouteActionSummary,
+    val incident: AlertRouteActionSummary,
 )
 
 object OnCallIncidentAlerts : Table("on_call_incident_alerts") {

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/models/OnCallModels.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/models/OnCallModels.kt
@@ -511,71 +511,72 @@ object OnCallAlertSerializer : KSerializer<OnCallAlert> {
     override val descriptor: SerialDescriptor = delegate.descriptor
 
     override fun serialize(encoder: Encoder, value: OnCallAlert) {
-        encoder.encodeSerializableValue(
-            delegate,
-            OnCallAlertWire(
-                id = value.id,
-                organizationResourceId = value.organizationResourceId,
-                declaredIncidentResourceId = value.declaredIncidentResourceId,
-                escalationPolicyResourceId = value.escalationPolicyResourceId,
-                escalationPolicyName = value.escalationPolicyName,
-                title = value.title,
-                description = value.description,
-                priority = value.priority,
-                status = value.status,
-                alertSource = value.alertSource,
-                deduplicationKey = value.deduplicationKey,
-                currentStep = value.currentStep,
-                repeatIteration = value.repeatIteration,
-                triggeredAt = value.triggeredAt,
-                acknowledgedAt = value.acknowledgedAt,
-                acknowledgedByResourceId = value.acknowledgedByResourceId,
-                acknowledgedByName = value.acknowledgedByName,
-                resolvedAt = value.resolvedAt,
-                resolvedByResourceId = value.resolvedByResourceId,
-                resolvedByName = value.resolvedByName,
-                metadata = value.metadata,
-                nextEscalationAt = value.nextEscalationAt,
-                viewedByCurrentUser = value.viewedByCurrentUser,
-                createdAt = value.createdAt,
-                updatedAt = value.updatedAt,
-                routeOutcome = value.routeOutcome,
-            ),
-        )
+        encoder.encodeSerializableValue(delegate, value.toWire())
     }
 
     override fun deserialize(decoder: Decoder): OnCallAlert {
         val wire = decoder.decodeSerializableValue(delegate)
-        return OnCallAlert(
-            id = wire.id,
-            organizationResourceId = wire.organizationResourceId,
-            declaredIncidentResourceId = wire.declaredIncidentResourceId,
-            escalationPolicyResourceId = wire.escalationPolicyResourceId,
-            escalationPolicyName = wire.escalationPolicyName,
-            title = wire.title,
-            description = wire.description,
-            priority = wire.priority,
-            status = wire.status,
-            alertSource = wire.alertSource,
-            deduplicationKey = wire.deduplicationKey,
-            currentStep = wire.currentStep,
-            repeatIteration = wire.repeatIteration,
-            triggeredAt = wire.triggeredAt,
-            acknowledgedAt = wire.acknowledgedAt,
-            acknowledgedByResourceId = wire.acknowledgedByResourceId,
-            acknowledgedByName = wire.acknowledgedByName,
-            resolvedAt = wire.resolvedAt,
-            resolvedByResourceId = wire.resolvedByResourceId,
-            resolvedByName = wire.resolvedByName,
-            metadata = wire.metadata,
-            nextEscalationAt = wire.nextEscalationAt,
-            viewedByCurrentUser = wire.viewedByCurrentUser,
-            createdAt = wire.createdAt,
-            updatedAt = wire.updatedAt,
-            routeOutcome = wire.routeOutcome,
-        )
+        return wire.toAlert()
     }
 }
+
+private fun OnCallAlert.toWire() = OnCallAlertWire(
+    id,
+    organizationResourceId,
+    declaredIncidentResourceId,
+    escalationPolicyResourceId,
+    escalationPolicyName,
+    title,
+    description,
+    priority,
+    status,
+    alertSource,
+    deduplicationKey,
+    currentStep,
+    repeatIteration,
+    triggeredAt,
+    acknowledgedAt,
+    acknowledgedByResourceId,
+    acknowledgedByName,
+    resolvedAt,
+    resolvedByResourceId,
+    resolvedByName,
+    metadata,
+    nextEscalationAt,
+    viewedByCurrentUser,
+    createdAt,
+    updatedAt,
+    routeOutcome,
+)
+
+private fun OnCallAlertWire.toAlert() = OnCallAlert(
+    id,
+    organizationResourceId,
+    declaredIncidentResourceId,
+    escalationPolicyResourceId,
+    escalationPolicyName,
+    title,
+    description,
+    priority,
+    status,
+    alertSource,
+    deduplicationKey,
+    currentStep,
+    repeatIteration,
+    triggeredAt,
+    acknowledgedAt,
+    acknowledgedByResourceId,
+    acknowledgedByName,
+    resolvedAt,
+    resolvedByResourceId,
+    resolvedByName,
+    metadata,
+    nextEscalationAt,
+    viewedByCurrentUser,
+    createdAt,
+    updatedAt,
+    routeOutcome,
+)
 
 @Serializable
 data class AlertRouteActionSummary(

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/IncidentManagementService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/IncidentManagementService.kt
@@ -4,6 +4,7 @@
 
 package com.moneat.enterprise.oncall.services
 
+import com.moneat.enterprise.alertroutes.services.AlertRouteOutcomeReader
 import com.moneat.enterprise.oncall.escalationPolicyResourceIds
 import com.moneat.enterprise.oncall.incidentResourceIds
 import com.moneat.enterprise.oncall.organizationResourceId
@@ -103,6 +104,10 @@ class OnCallAlertService(
                 viewedByCurrentUser = viewed,
                 createdAt = row[OnCallAlerts.createdAt].toString(),
                 updatedAt = row[OnCallAlerts.updatedAt].toString(),
+                routeOutcome = AlertRouteOutcomeReader.findForOnCallAlert(
+                    row[OnCallAlerts.organizationId],
+                    row[OnCallAlerts.id].value,
+                ),
                 internalId = row[OnCallAlerts.id].value,
                 organizationId = row[OnCallAlerts.organizationId],
                 declaredIncidentId = row[OnCallAlerts.declaredIncidentId],

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteCommandServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteCommandServiceTest.kt
@@ -11,6 +11,7 @@ import com.moneat.enterprise.alertroutes.commands.AlertRouteConditionGroupInput
 import com.moneat.enterprise.alertroutes.commands.AlertRouteConditionInput
 import com.moneat.enterprise.alertroutes.commands.AlertRouteGroupingInput
 import com.moneat.enterprise.alertroutes.commands.AlertRouteIncidentInput
+import com.moneat.enterprise.alertroutes.commands.ALERT_PRIORITY_SEVERITY
 import com.moneat.enterprise.alertroutes.commands.AlertRoutePagingInput
 import com.moneat.enterprise.alertroutes.commands.AlertRoutePolicy
 import com.moneat.enterprise.alertroutes.commands.AlertRouteQuotaAdmission
@@ -629,6 +630,37 @@ class AlertRouteCommandServiceTest {
             ).route!!
         assertEquals(AlertRouteIncidentMode.TRIAGE, triage.incident.mode)
         assertEquals(null, triage.incident.severity)
+
+        val priorityTriage =
+            service.execute(
+                CreateAlertRouteCommand(
+                    commandKey = "priority-triage",
+                    actor = admin(),
+                    specification = specification(key = "priority-triage", name = "Priority triage").copy(
+                        incident = AlertRouteIncidentInput(
+                            create = true,
+                            severity = ALERT_PRIORITY_SEVERITY,
+                        ),
+                    ),
+                ),
+            ).route!!
+        assertEquals(ALERT_PRIORITY_SEVERITY, priorityTriage.incident.severity)
+
+        assertFailsWith<IllegalArgumentException> {
+            service.execute(
+                CreateAlertRouteCommand(
+                    commandKey = "priority-active",
+                    actor = admin(),
+                    specification = specification(key = "priority-active", name = "Priority active").copy(
+                        incident = AlertRouteIncidentInput(
+                            create = true,
+                            mode = AlertRouteIncidentMode.ACTIVE,
+                            severity = ALERT_PRIORITY_SEVERITY,
+                        ),
+                    ),
+                ),
+            )
+        }
     }
 
     @Test

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteExecutionServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteExecutionServiceTest.kt
@@ -17,6 +17,7 @@ import com.moneat.enterprise.alertroutes.commands.AlertGroupPolicy
 import com.moneat.enterprise.alertroutes.commands.AlertRouteActor
 import com.moneat.enterprise.alertroutes.commands.AlertRouteGroupingInput
 import com.moneat.enterprise.alertroutes.commands.AlertRouteIncidentInput
+import com.moneat.enterprise.alertroutes.commands.ALERT_PRIORITY_SEVERITY
 import com.moneat.enterprise.alertroutes.commands.AlertRoutePagingInput
 import com.moneat.enterprise.alertroutes.commands.AlertRoutePolicy
 import com.moneat.enterprise.alertroutes.commands.AlertRouteRecoveryInput
@@ -120,6 +121,46 @@ class AlertRouteExecutionServiceTest {
             assertEquals(NativeIncidentStatus.ACTIVE.wire, incident[OnCallIncidents.status])
             assertEquals("Checkout latency incident", incident[OnCallIncidents.title])
         }
+    }
+
+    @Test
+    fun `priority-derived triage severity maps P0 without changing fixed severity routes`() = runBlocking {
+        createRoute(
+            pagingTargets = 0,
+            incident = AlertRouteIncidentInput(create = true, severity = ALERT_PRIORITY_SEVERITY),
+        )
+        val episodeId = AlertRouteTestDatabase.seedAlertEpisode(
+            organization.organizationId,
+            "HOST_ALERT",
+            "priority-derived",
+            priority = "P0",
+        )
+
+        executionService.execute(firingContext(episodeId))
+
+        transaction {
+            val incident = OnCallIncidents.selectAll().single()
+            assertEquals(NativeIncidentStatus.TRIAGE.wire, incident[OnCallIncidents.status])
+            assertEquals("SEV-0", incident[OnCallIncidents.severity])
+        }
+    }
+
+    @Test
+    fun `on-call alert details expose route revision and independent action outcomes`() = runBlocking {
+        createRoute(
+            pagingTargets = 1,
+            incident = AlertRouteIncidentInput(create = true),
+        )
+        val episodeId = AlertRouteTestDatabase.seedAlertEpisode(organization.organizationId, "HOST_ALERT", "detail")
+        executionService.execute(firingContext(episodeId))
+
+        val alertId = transaction { OnCallAlerts.selectAll().single()[OnCallAlerts.id].value }
+        val outcome = AlertRouteOutcomeReader.findForOnCallAlert(organization.organizationId, alertId)
+        assertNotNull(outcome)
+        assertEquals(1, outcome.matchedRouteRevision)
+        assertEquals("SUCCEEDED", outcome.grouping.state)
+        assertEquals("SUCCEEDED", outcome.paging.state)
+        assertEquals("SUCCEEDED", outcome.incident.state)
     }
 
     @Test
@@ -544,7 +585,7 @@ class AlertRouteExecutionServiceTest {
         val event = AlertLifecycleEvent(
             title = "Checkout latency",
             description = "Latency above threshold",
-            priority = AlertPriority.P1,
+            priority = AlertPriority.fromString(episode.priority) ?: AlertPriority.P1,
             status = status,
             source = AlertSource.valueOf(episode.source),
             deduplicationKey = episode.deduplicationKey,

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteExecutionServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteExecutionServiceTest.kt
@@ -164,6 +164,26 @@ class AlertRouteExecutionServiceTest {
     }
 
     @Test
+    fun `matched alert explains when incident creation is disabled`() = runBlocking {
+        createRoute(
+            pagingTargets = 1,
+            incident = AlertRouteIncidentInput(create = false),
+        )
+        val episodeId = AlertRouteTestDatabase.seedAlertEpisode(
+            organization.organizationId,
+            "HOST_ALERT",
+            "no-incident",
+        )
+        executionService.execute(firingContext(episodeId))
+
+        val alertId = transaction { OnCallAlerts.selectAll().single()[OnCallAlerts.id].value }
+        val outcome = AlertRouteOutcomeReader.findForOnCallAlert(organization.organizationId, alertId)
+        assertNotNull(outcome)
+        assertEquals("SKIPPED", outcome.incident.state)
+        assertEquals("Incident creation is disabled for this route", outcome.incident.reason)
+    }
+
+    @Test
     fun `silence retains a group without paging or automatic incident creation`() = runBlocking {
         createRoute(
             pagingTargets = 1,

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteExecutionServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteExecutionServiceTest.kt
@@ -220,6 +220,11 @@ class AlertRouteExecutionServiceTest {
         }
 
         assertEquals(1, gateway.triggered.size)
+        val alertId = transaction { OnCallAlerts.selectAll().single()[OnCallAlerts.id].value }
+        val outcome = AlertRouteOutcomeReader.findForOnCallAlert(organization.organizationId, alertId)
+        assertNotNull(outcome)
+        assertEquals("FAILED", outcome.incident.state)
+        assertNotNull(outcome.incident.reason)
     }
 
     @Test

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/OnCallModuleTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/OnCallModuleTest.kt
@@ -15,6 +15,8 @@ import io.ktor.server.auth.jwt.JWTPrincipal
 import io.ktor.server.auth.jwt.jwt
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
+import io.mockk.mockk
+import io.ktor.server.application.Application
 import org.junit.jupiter.api.Test
 import org.koin.core.KoinApplication
 import kotlin.test.assertEquals
@@ -23,7 +25,9 @@ import kotlin.test.assertNotNull
 class OnCallModuleTest {
     @Test
     fun `provides synchronous alert route fanout without starting background jobs`() {
-        val application = KoinApplication.init().apply { modules(OnCallModule().koinModules()) }
+        val module = OnCallModule()
+        val application = KoinApplication.init().apply { modules(module.koinModules()) }
+        module.startBackgroundJobs(mockk<Application>(), startSchedulers = false, startIngestionWorkers = false)
 
         assertNotNull(application.koin.get<AlertRouteFanout>())
         application.close()

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/OnCallModuleTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/OnCallModuleTest.kt
@@ -6,6 +6,7 @@ package com.moneat.enterprise.oncall
 
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
+import com.moneat.alerts.services.AlertRouteFanout
 import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.install
@@ -15,9 +16,19 @@ import io.ktor.server.auth.jwt.jwt
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
 import org.junit.jupiter.api.Test
+import org.koin.core.KoinApplication
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 class OnCallModuleTest {
+    @Test
+    fun `provides synchronous alert route fanout without starting background jobs`() {
+        val application = KoinApplication.init().apply { modules(OnCallModule().koinModules()) }
+
+        assertNotNull(application.koin.get<AlertRouteFanout>())
+        application.close()
+    }
+
     @Test
     fun `registers API routes before scheduler jobs start`() {
         val previousFrontendUrl = System.getProperty("FRONTEND_URL")


### PR DESCRIPTION
## Summary
- Make synchronous Alert Route fanout available in API processes.
- Return route, grouping, paging, and incident outcomes.
- Add the opt-in P0-P2 triage preset and outcome guidance.

## Tests
- Focused backend and dashboard tests
- Detekt, lint, typecheck


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed results for administrator-triggered test incidents, including route matching, grouping, paging, and incident creation status.
  * Added route outcome details to alert pages, including matched route, group, incident, and action statuses.
  * Added a P0–P2 triage preset with priority-derived severity.
  * Added standard severity options and guidance for priority-derived triage severity.
  * Added route behavior badges, save summaries, and warnings for paging-only configurations.
  * Added reporting for unavailable, skipped, unmatched, and failed route outcomes.

* **Documentation**
  * Documented test alerts, P0–P2 triage behavior, and route outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->