### PR TITLE
feat: activate incident response on lifecycle events

### DIFF
--- a/backend/src/main/resources/db/migration/V163__native_incident_response_activation.sql
+++ b/backend/src/main/resources/db/migration/V163__native_incident_response_activation.sql
@@ -1,0 +1,71 @@
+-- Durable incident-response activation policy, execution, and delivery state.
+
+CREATE TABLE native_incident_response_policies (
+    id SERIAL PRIMARY KEY,
+    resource_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    commander_policy_id INTEGER REFERENCES escalation_policies(id) ON DELETE SET NULL,
+    ownership_policy_id INTEGER REFERENCES escalation_policies(id) ON DELETE SET NULL,
+    page_ownership BOOLEAN NOT NULL DEFAULT TRUE,
+    page_test_incidents BOOLEAN NOT NULL DEFAULT FALSE,
+    page_retrospective_incidents BOOLEAN NOT NULL DEFAULT FALSE,
+    created_by INTEGER NOT NULL REFERENCES users(id),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_native_incident_response_policies_org UNIQUE (organization_id),
+    CONSTRAINT uq_native_incident_response_policies_resource UNIQUE (organization_id, resource_id)
+);
+
+CREATE TABLE native_incident_response_activations (
+    id SERIAL PRIMARY KEY,
+    resource_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    incident_id INTEGER NOT NULL REFERENCES on_call_incidents(id) ON DELETE CASCADE,
+    activation_revision INTEGER NOT NULL,
+    trigger VARCHAR(32) NOT NULL,
+    status VARCHAR(24) NOT NULL,
+    desired_count INTEGER NOT NULL DEFAULT 0,
+    attempted_count INTEGER NOT NULL DEFAULT 0,
+    acknowledged_count INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT,
+    started_at TIMESTAMP NOT NULL,
+    completed_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_native_incident_response_activation_key
+        UNIQUE (organization_id, incident_id, activation_revision, trigger),
+    CONSTRAINT uq_native_incident_response_activation_resource UNIQUE (organization_id, resource_id),
+    CONSTRAINT chk_native_incident_response_activation_counts
+        CHECK (desired_count >= 0 AND attempted_count >= 0 AND acknowledged_count >= 0)
+);
+
+CREATE INDEX idx_native_incident_response_activations_incident
+    ON native_incident_response_activations(organization_id, incident_id, created_at);
+
+CREATE TABLE native_incident_response_targets (
+    id SERIAL PRIMARY KEY,
+    resource_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    activation_id INTEGER NOT NULL REFERENCES native_incident_response_activations(id) ON DELETE CASCADE,
+    target_key VARCHAR(180) NOT NULL,
+    target_type VARCHAR(32) NOT NULL,
+    escalation_policy_id INTEGER REFERENCES escalation_policies(id) ON DELETE SET NULL,
+    user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    on_call_alert_id INTEGER REFERENCES on_call_alerts(id) ON DELETE SET NULL,
+    status VARCHAR(24) NOT NULL,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    desired_at TIMESTAMP NOT NULL,
+    attempted_at TIMESTAMP,
+    acknowledged_at TIMESTAMP,
+    failed_at TIMESTAMP,
+    last_error TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_native_incident_response_target_key
+        UNIQUE (organization_id, activation_id, target_key),
+    CONSTRAINT uq_native_incident_response_target_resource UNIQUE (organization_id, resource_id),
+    CONSTRAINT chk_native_incident_response_target_attempts CHECK (attempt_count >= 0)
+);
+
+CREATE INDEX idx_native_incident_response_targets_alert
+    ON native_incident_response_targets(organization_id, on_call_alert_id);

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/events/IncidentResponseEventConsumer.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/events/IncidentResponseEventConsumer.kt
@@ -1,0 +1,18 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.incidents.events
+
+import com.moneat.enterprise.incidents.response.IncidentResponseActivationService
+
+class IncidentResponseEventConsumer(
+    private val activationService: IncidentResponseActivationService,
+) : NativeIncidentEventConsumer {
+    override val name: String = "incident-response"
+
+    override suspend fun consume(event: NativeIncidentDomainEvent, deliveryKey: String) {
+        require(deliveryKey.isNotBlank()) { "Incident response delivery key is required" }
+        activationService.activate(event)
+    }
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/response/IncidentResponseActivationService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/response/IncidentResponseActivationService.kt
@@ -272,7 +272,7 @@ class IncidentResponseActivationService(
             }
         }
         if (updated == 0) return false
-        claimCommander(target[NativeIncidentResponseTargets.activationId], userId)
+        claimCommander(target[NativeIncidentResponseTargets.activationId], target, userId)
         addParticipant(target[NativeIncidentResponseTargets.activationId], userId)
         return true
     }
@@ -569,11 +569,16 @@ class IncidentResponseActivationService(
         }
     }
 
-    private fun claimCommander(activationId: Int, userId: Int) = transaction {
-        val target = NativeIncidentResponseTargets.selectAll().where {
+    private fun claimCommander(
+        activationId: Int,
+        acknowledgedTarget: org.jetbrains.exposed.v1.core.ResultRow,
+        userId: Int,
+    ) = transaction {
+        val commanderTarget = NativeIncidentResponseTargets.selectAll().where {
             (NativeIncidentResponseTargets.activationId eq activationId) and
+                (NativeIncidentResponseTargets.targetType eq TARGET_COMMANDER) and
                 NativeIncidentResponseTargets.onCallAlertId.isNotNull()
-        }.singleOrNull() ?: return@transaction
+        }.singleOrNull() ?: acknowledgedTarget
         val activation = NativeIncidentResponseActivations.selectAll().where {
             NativeIncidentResponseActivations.id eq activationId
         }.single()
@@ -608,7 +613,7 @@ class IncidentResponseActivationService(
             }
         }
         NativeIncidentResponseTargets.update({
-            NativeIncidentResponseTargets.id eq target[NativeIncidentResponseTargets.id].value
+            NativeIncidentResponseTargets.id eq commanderTarget[NativeIncidentResponseTargets.id].value
         }) {
             it[NativeIncidentResponseTargets.userId] = userId
             it[updatedAt] = now()

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/response/IncidentResponseActivationService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/response/IncidentResponseActivationService.kt
@@ -40,6 +40,7 @@ import kotlin.time.Instant
 private const val INCIDENT_COMMANDER_ROLE_KEY = "incident-commander"
 private const val TARGET_COMMANDER = "COMMANDER"
 private const val TARGET_OWNERSHIP = "OWNERSHIP"
+private const val INCIDENT_ACTIVATION_NOT_FOUND = "Incident response activation not found"
 
 data class IncidentResponsePageRequest(
     val organizationId: Int,
@@ -226,9 +227,9 @@ class IncidentResponseActivationService(
                     (NativeIncidentResponseActivations.resourceId eq resourceId)
             }.singleOrNull()?.also {
                 if (incidentId != null && it[NativeIncidentResponseActivations.incidentId] != incidentId) {
-                    throw NoSuchElementException("Incident response activation not found")
+                    throw NoSuchElementException(INCIDENT_ACTIVATION_NOT_FOUND)
                 }
-            } ?: throw NoSuchElementException("Incident response activation not found")
+            } ?: throw NoSuchElementException(INCIDENT_ACTIVATION_NOT_FOUND)
             NativeIncidentResponseTargets.update({
                 (NativeIncidentResponseTargets.organizationId eq organizationId) and
                     (NativeIncidentResponseTargets.activationId eq
@@ -284,7 +285,7 @@ class IncidentResponseActivationService(
             val activation = NativeIncidentResponseActivations.selectAll().where {
                 (NativeIncidentResponseActivations.organizationId eq organizationId) and
                     (NativeIncidentResponseActivations.resourceId eq resourceId)
-            }.singleOrNull() ?: throw NoSuchElementException("Incident response activation not found")
+            }.singleOrNull() ?: throw NoSuchElementException(INCIDENT_ACTIVATION_NOT_FOUND)
             activationResponse(activation)
         }
 

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/response/IncidentResponseActivationService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/response/IncidentResponseActivationService.kt
@@ -1,0 +1,712 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.incidents.response
+
+import com.moneat.enterprise.incidents.events.NativeIncidentDomainEvent
+import com.moneat.enterprise.incidents.models.IncidentParticipationType
+import com.moneat.enterprise.incidents.models.NativeIncidentMode
+import com.moneat.enterprise.incidents.models.NativeIncidentParticipants
+import com.moneat.enterprise.incidents.models.NativeIncidentRoleAssignments
+import com.moneat.enterprise.incidents.models.NativeIncidentRoleDefinitions
+import com.moneat.enterprise.incidents.models.NativeIncidentStatus
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertGroupEscalations
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertGroups
+import com.moneat.enterprise.oncall.models.OnCallAlerts
+import com.moneat.enterprise.oncall.models.OnCallIncidentAlerts
+import com.moneat.enterprise.oncall.models.OnCallIncidents
+import com.moneat.shared.models.Memberships
+import com.moneat.shared.services.toUuidOrNull
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.core.isNotNull
+import org.jetbrains.exposed.v1.core.isNull
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
+import org.jetbrains.exposed.v1.jdbc.insertIgnore
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+private const val INCIDENT_COMMANDER_ROLE_KEY = "incident-commander"
+private const val TARGET_COMMANDER = "COMMANDER"
+private const val TARGET_OWNERSHIP = "OWNERSHIP"
+
+data class IncidentResponsePageRequest(
+    val organizationId: Int,
+    val escalationPolicyId: Int,
+    val title: String,
+    val severity: String,
+    val deduplicationKey: String,
+    val metadata: Map<String, JsonElement>,
+)
+
+private data class IncidentResponseActivationPlan(
+    val status: IncidentResponseActivationStatus,
+    val error: String?,
+)
+
+fun interface IncidentResponsePager {
+    fun page(request: IncidentResponsePageRequest): Int?
+}
+
+@Serializable
+data class IncidentResponsePolicyResponse(
+    val id: String?,
+    val commanderPolicyId: String? = null,
+    val ownershipPolicyId: String? = null,
+    val pageOwnership: Boolean = true,
+    val pageTestIncidents: Boolean = false,
+    val pageRetrospectiveIncidents: Boolean = false,
+)
+
+data class IncidentResponsePolicyInput(
+    val commanderPolicyResourceId: String?,
+    val ownershipPolicyResourceId: String?,
+    val pageOwnership: Boolean,
+    val pageTestIncidents: Boolean,
+    val pageRetrospectiveIncidents: Boolean,
+)
+
+@Serializable
+data class IncidentResponseTargetResponse(
+    val id: String,
+    val targetKey: String,
+    val targetType: String,
+    val status: String,
+    val attemptCount: Int,
+    val onCallAlertId: String? = null,
+    val error: String? = null,
+)
+
+@Serializable
+data class IncidentResponseActivationResponse(
+    val id: String,
+    val revision: Int,
+    val trigger: String,
+    val status: String,
+    val desiredCount: Int,
+    val attemptedCount: Int,
+    val acknowledgedCount: Int,
+    val lastError: String? = null,
+    val targets: List<IncidentResponseTargetResponse>,
+)
+
+class IncidentResponsePolicyService {
+    fun get(organizationId: Int): IncidentResponsePolicyResponse = transaction {
+        NativeIncidentResponsePolicies
+            .selectAll()
+            .where { NativeIncidentResponsePolicies.organizationId eq organizationId }
+            .singleOrNull()
+            ?.let(::toResponse)
+            ?: IncidentResponsePolicyResponse(id = null)
+    }
+
+    fun update(
+        organizationId: Int,
+        actorUserId: Int,
+        input: IncidentResponsePolicyInput,
+    ): IncidentResponsePolicyResponse = transaction {
+        requireMember(organizationId, actorUserId)
+        val commanderPolicyId = resolvePolicy(organizationId, input.commanderPolicyResourceId)
+        val ownershipPolicyId = resolvePolicy(organizationId, input.ownershipPolicyResourceId)
+        val now = Clock.System.now()
+        val current = NativeIncidentResponsePolicies.selectAll()
+            .where { NativeIncidentResponsePolicies.organizationId eq organizationId }
+            .singleOrNull()
+        if (current == null) {
+            NativeIncidentResponsePolicies.insert {
+                it[resourceId] = kotlin.uuid.Uuid.random()
+                it[NativeIncidentResponsePolicies.organizationId] = organizationId
+                it[NativeIncidentResponsePolicies.commanderPolicyId] = commanderPolicyId
+                it[NativeIncidentResponsePolicies.ownershipPolicyId] = ownershipPolicyId
+                it[pageOwnership] = input.pageOwnership
+                it[pageTestIncidents] = input.pageTestIncidents
+                it[pageRetrospectiveIncidents] = input.pageRetrospectiveIncidents
+                it[createdBy] = actorUserId
+                it[createdAt] = now
+                it[updatedAt] = now
+            }
+        } else {
+            NativeIncidentResponsePolicies.update({ NativeIncidentResponsePolicies.organizationId eq organizationId }) {
+                it[NativeIncidentResponsePolicies.commanderPolicyId] = commanderPolicyId
+                it[NativeIncidentResponsePolicies.ownershipPolicyId] = ownershipPolicyId
+                it[pageOwnership] = input.pageOwnership
+                it[pageTestIncidents] = input.pageTestIncidents
+                it[pageRetrospectiveIncidents] = input.pageRetrospectiveIncidents
+                it[updatedAt] = now
+            }
+        }
+        get(organizationId)
+    }
+
+    fun resolvePolicyId(organizationId: Int, resourceId: String?): Int? =
+        resolvePolicy(organizationId, resourceId)
+
+    private fun resolvePolicy(organizationId: Int, resourceId: String?): Int? {
+        val uuid = resourceId?.trim()?.takeIf(String::isNotEmpty)?.toUuidOrNull() ?: return null
+        return com.moneat.shared.models.EscalationPolicies
+            .selectAll()
+            .where {
+                (com.moneat.shared.models.EscalationPolicies.organizationId eq organizationId) and
+                    (com.moneat.shared.models.EscalationPolicies.resourceId eq uuid)
+            }
+            .singleOrNull()
+            ?.get(com.moneat.shared.models.EscalationPolicies.id)
+            ?.value
+            ?: throw IllegalArgumentException("Escalation policy not found")
+    }
+
+    private fun requireMember(organizationId: Int, userId: Int) {
+        require(
+            Memberships.selectAll().where {
+                (Memberships.organization_id eq organizationId) and (Memberships.user_id eq userId)
+            }.limit(1).any(),
+        ) { "Actor is not a member of the incident organization" }
+    }
+
+    private fun toResponse(row: org.jetbrains.exposed.v1.core.ResultRow): IncidentResponsePolicyResponse =
+        IncidentResponsePolicyResponse(
+            id = row[NativeIncidentResponsePolicies.resourceId].toString(),
+            commanderPolicyId = row[NativeIncidentResponsePolicies.commanderPolicyId]?.let { policyResourceId(it) },
+            ownershipPolicyId = row[NativeIncidentResponsePolicies.ownershipPolicyId]?.let { policyResourceId(it) },
+            pageOwnership = row[NativeIncidentResponsePolicies.pageOwnership],
+            pageTestIncidents = row[NativeIncidentResponsePolicies.pageTestIncidents],
+            pageRetrospectiveIncidents = row[NativeIncidentResponsePolicies.pageRetrospectiveIncidents],
+        )
+
+    private fun policyResourceId(policyId: Int): String =
+        com.moneat.shared.models.EscalationPolicies.selectAll()
+            .where { com.moneat.shared.models.EscalationPolicies.id eq policyId }
+            .single()[com.moneat.shared.models.EscalationPolicies.resourceId]
+            .toString()
+}
+
+class IncidentResponseActivationService(
+    private val policyService: IncidentResponsePolicyService = IncidentResponsePolicyService(),
+    private val pager: IncidentResponsePager = IncidentResponsePager { null },
+    private val now: () -> Instant = { Clock.System.now() },
+) {
+    fun policy(organizationId: Int): IncidentResponsePolicyResponse = policyService.get(organizationId)
+
+    fun updatePolicy(
+        organizationId: Int,
+        actorUserId: Int,
+        input: IncidentResponsePolicyInput,
+    ): IncidentResponsePolicyResponse = policyService.update(organizationId, actorUserId, input)
+
+    fun activate(event: NativeIncidentDomainEvent) {
+        if (event.eventType == "INCIDENT_DECLARE" && event.status() != NativeIncidentStatus.ACTIVE.wire) return
+        if (event.eventType != "INCIDENT_DECLARE" && event.eventType != "INCIDENT_ACCEPT") return
+        val activationId = ensureActivation(event)
+        dispatch(activationId)
+    }
+
+    fun retry(
+        organizationId: Int,
+        activationResourceId: String,
+        actorUserId: Int,
+        incidentId: Int? = null,
+    ): IncidentResponseActivationResponse =
+        transaction {
+            requireMember(organizationId, actorUserId)
+            val resourceId = activationResourceId.toUuidOrNull()
+                ?: throw IllegalArgumentException("Invalid activation ID")
+            val activation = NativeIncidentResponseActivations.selectAll().where {
+                (NativeIncidentResponseActivations.organizationId eq organizationId) and
+                    (NativeIncidentResponseActivations.resourceId eq resourceId)
+            }.singleOrNull()?.also {
+                if (incidentId != null && it[NativeIncidentResponseActivations.incidentId] != incidentId) {
+                    throw NoSuchElementException("Incident response activation not found")
+                }
+            } ?: throw NoSuchElementException("Incident response activation not found")
+            NativeIncidentResponseTargets.update({
+                (NativeIncidentResponseTargets.organizationId eq organizationId) and
+                    (NativeIncidentResponseTargets.activationId eq
+                        activation[NativeIncidentResponseActivations.id].value) and
+                    (NativeIncidentResponseTargets.status inList listOf(
+                        IncidentResponseTargetStatus.FAILED.wire,
+                        IncidentResponseTargetStatus.RETRYING.wire,
+                    ))
+            }) {
+                it[status] = IncidentResponseTargetStatus.RETRYING.wire
+                it[lastError] = null
+                it[updatedAt] = now()
+            }
+            NativeIncidentResponseActivations.update({
+                NativeIncidentResponseActivations.id eq activation[NativeIncidentResponseActivations.id].value
+            }) {
+                it[status] = IncidentResponseActivationStatus.ACTIVE.wire
+                it[lastError] = null
+                it[updatedAt] = now()
+            }
+            activation[NativeIncidentResponseActivations.id].value
+        }.also(::dispatch).let { activationResponse(organizationId, activationResourceId) }
+
+    fun markAcknowledged(alertId: Int, userId: Int): Boolean {
+        val target = transaction {
+            NativeIncidentResponseTargets.selectAll().where {
+                (NativeIncidentResponseTargets.onCallAlertId eq alertId) and
+                    (NativeIncidentResponseTargets.status inList listOf(
+                        IncidentResponseTargetStatus.ATTEMPTED.wire,
+                        IncidentResponseTargetStatus.RETRYING.wire,
+                    ))
+            }.singleOrNull()
+        } ?: return false
+        val updated = transaction {
+            NativeIncidentResponseTargets.update({
+                NativeIncidentResponseTargets.id eq target[NativeIncidentResponseTargets.id].value
+            }) {
+                it[status] = IncidentResponseTargetStatus.ACKNOWLEDGED.wire
+                it[acknowledgedAt] = now()
+                it[updatedAt] = now()
+            }
+        }
+        if (updated == 0) return false
+        claimCommander(target[NativeIncidentResponseTargets.activationId], userId)
+        addParticipant(target[NativeIncidentResponseTargets.activationId], userId)
+        return true
+    }
+
+    fun activationResponse(organizationId: Int, activationResourceId: String): IncidentResponseActivationResponse =
+        transaction {
+            val resourceId = activationResourceId.toUuidOrNull()
+                ?: throw IllegalArgumentException("Invalid activation ID")
+            val activation = NativeIncidentResponseActivations.selectAll().where {
+                (NativeIncidentResponseActivations.organizationId eq organizationId) and
+                    (NativeIncidentResponseActivations.resourceId eq resourceId)
+            }.singleOrNull() ?: throw NoSuchElementException("Incident response activation not found")
+            activationResponse(activation)
+        }
+
+    fun incidentResponse(organizationId: Int, incidentResourceId: String): List<IncidentResponseActivationResponse> =
+        transaction {
+            val incidentUuid = incidentResourceId.toUuidOrNull()
+                ?: throw IllegalArgumentException("Invalid incident ID")
+            val incidentId = OnCallIncidents.selectAll().where {
+                (OnCallIncidents.organizationId eq organizationId) and (OnCallIncidents.resourceId eq incidentUuid)
+            }.singleOrNull()?.get(OnCallIncidents.id)?.value
+                ?: throw NoSuchElementException("Incident not found")
+            NativeIncidentResponseActivations.selectAll().where {
+                (NativeIncidentResponseActivations.organizationId eq organizationId) and
+                    (NativeIncidentResponseActivations.incidentId eq incidentId)
+            }.orderBy(NativeIncidentResponseActivations.createdAt).map(::activationResponse)
+        }
+
+    fun incidentResponseById(organizationId: Int, incidentId: Int): List<IncidentResponseActivationResponse> =
+        transaction {
+            val incident = OnCallIncidents.selectAll().where {
+                (OnCallIncidents.organizationId eq organizationId) and (OnCallIncidents.id eq incidentId)
+            }.singleOrNull() ?: throw NoSuchElementException("Incident not found")
+            NativeIncidentResponseActivations.selectAll().where {
+                (NativeIncidentResponseActivations.organizationId eq organizationId) and
+                (NativeIncidentResponseActivations.incidentId eq incident[OnCallIncidents.id].value)
+            }.orderBy(NativeIncidentResponseActivations.createdAt).map(::activationResponse)
+        }
+
+    private fun ensureActivation(event: NativeIncidentDomainEvent): Int = transaction {
+        val existing = NativeIncidentResponseActivations.selectAll().where {
+            (NativeIncidentResponseActivations.organizationId eq event.organizationId) and
+                (NativeIncidentResponseActivations.incidentId eq event.incidentId) and
+                (NativeIncidentResponseActivations.activationRevision eq event.aggregateVersion) and
+                (NativeIncidentResponseActivations.trigger eq event.eventType)
+        }.singleOrNull()
+        if (existing != null) return@transaction existing[NativeIncidentResponseActivations.id].value
+
+        val incident = OnCallIncidents.selectAll().where { OnCallIncidents.id eq event.incidentId }.single()
+        val config = policyService.get(event.organizationId)
+        val status = NativeIncidentStatus.fromWire(incident[OnCallIncidents.status])
+        val mode = NativeIncidentMode.entries.firstOrNull { it.wire == incident[OnCallIncidents.mode] }
+        val plan = activationPlan(status, mode, config)
+        val activationId = createActivation(event, plan)
+        if (plan.status == IncidentResponseActivationStatus.PENDING) {
+            prepareTargets(event, config, activationId)
+        }
+        activationId
+    }
+
+    private fun activationPlan(
+        status: NativeIncidentStatus?,
+        mode: NativeIncidentMode?,
+        config: IncidentResponsePolicyResponse,
+    ): IncidentResponseActivationPlan {
+        val pagingDisabled = when (mode) {
+            NativeIncidentMode.TEST -> !config.pageTestIncidents
+            NativeIncidentMode.RETROSPECTIVE -> !config.pageRetrospectiveIncidents
+            else -> false
+        }
+        return when {
+            status != NativeIncidentStatus.ACTIVE ->
+                IncidentResponseActivationPlan(IncidentResponseActivationStatus.SKIPPED, "Incident is not active")
+            pagingDisabled -> IncidentResponseActivationPlan(
+                IncidentResponseActivationStatus.SKIPPED,
+                "Paging is disabled for ${mode?.wire?.lowercase()} incidents",
+            )
+            else -> IncidentResponseActivationPlan(IncidentResponseActivationStatus.PENDING, null)
+        }
+    }
+
+    private fun createActivation(
+        event: NativeIncidentDomainEvent,
+        plan: IncidentResponseActivationPlan,
+    ): Int = NativeIncidentResponseActivations.insertAndGetId {
+        it[resourceId] = kotlin.uuid.Uuid.random()
+        it[organizationId] = event.organizationId
+        it[incidentId] = event.incidentId
+        it[activationRevision] = event.aggregateVersion
+        it[trigger] = event.eventType
+        it[NativeIncidentResponseActivations.status] = plan.status.wire
+        it[desiredCount] = 0
+        it[attemptedCount] = 0
+        it[acknowledgedCount] = 0
+        it[lastError] = plan.error
+        it[startedAt] = now()
+        it[completedAt] = now().takeIf { plan.status != IncidentResponseActivationStatus.PENDING }
+        it[createdAt] = now()
+        it[updatedAt] = now()
+    }.value
+
+    private fun prepareTargets(
+        event: NativeIncidentDomainEvent,
+        config: IncidentResponsePolicyResponse,
+        activationId: Int,
+    ) {
+        val commanderPolicyId = policyService.resolvePolicyId(event.organizationId, config.commanderPolicyId)
+        val ownershipPolicyId = policyService.resolvePolicyId(event.organizationId, config.ownershipPolicyId)
+        val policies: List<Pair<String, Int>> = listOfNotNull(
+            commanderPolicyId?.let { policyId -> TARGET_COMMANDER to policyId },
+            ownershipPolicyId
+                ?.takeIf { config.pageOwnership }
+                ?.let { policyId -> TARGET_OWNERSHIP to policyId },
+        ).distinctBy { it.second }
+        val routePolicies = routePagedPolicies(event.organizationId, event.incidentId)
+        policies.forEach { (type, policyId) ->
+            val skipped = policyId in routePolicies
+            NativeIncidentResponseTargets.insert {
+                it[resourceId] = kotlin.uuid.Uuid.random()
+                it[organizationId] = event.organizationId
+                it[NativeIncidentResponseTargets.activationId] = activationId
+                it[NativeIncidentResponseTargets.targetKey] = "$type:$policyId"
+                it[NativeIncidentResponseTargets.targetType] = type
+                it[NativeIncidentResponseTargets.escalationPolicyId] = policyId
+                it[NativeIncidentResponseTargets.userId] = null
+                it[NativeIncidentResponseTargets.onCallAlertId] = null
+                it[NativeIncidentResponseTargets.status] = targetStatus(skipped)
+                it[NativeIncidentResponseTargets.attemptCount] = 0
+                it[NativeIncidentResponseTargets.desiredAt] = now()
+                it[NativeIncidentResponseTargets.attemptedAt] = null
+                it[NativeIncidentResponseTargets.acknowledgedAt] = null
+                it[NativeIncidentResponseTargets.failedAt] = null
+                it[NativeIncidentResponseTargets.lastError] = "Already paged by Alert Route".takeIf { skipped }
+                it[NativeIncidentResponseTargets.createdAt] = now()
+                it[NativeIncidentResponseTargets.updatedAt] = now()
+            }
+        }
+        NativeIncidentResponseActivations.update({ NativeIncidentResponseActivations.id eq activationId }) {
+            it[desiredCount] = NativeIncidentResponseTargets.selectAll().where {
+                NativeIncidentResponseTargets.activationId eq activationId
+            }.count().toInt()
+            it[NativeIncidentResponseActivations.status] = if (policies.isEmpty()) {
+                IncidentResponseActivationStatus.FAILED.wire
+            } else {
+                IncidentResponseActivationStatus.PENDING.wire
+            }
+            it[lastError] = "No incident response policy is configured".takeIf { policies.isEmpty() }
+            it[updatedAt] = now()
+        }
+    }
+
+    private fun targetStatus(skipped: Boolean): String = if (skipped) {
+        IncidentResponseTargetStatus.SKIPPED.wire
+    } else {
+        IncidentResponseTargetStatus.DESIRED.wire
+    }
+
+    private fun dispatch(activationId: Int) {
+        val activation = transaction {
+            NativeIncidentResponseActivations.selectAll().where {
+                NativeIncidentResponseActivations.id eq activationId
+            }.single()
+        }
+        if (activation[NativeIncidentResponseActivations.status] != IncidentResponseActivationStatus.PENDING.wire &&
+            activation[NativeIncidentResponseActivations.status] != IncidentResponseActivationStatus.ACTIVE.wire
+        ) {
+            return
+        }
+        val incident = transaction {
+            OnCallIncidents.selectAll().where {
+                OnCallIncidents.id eq activation[NativeIncidentResponseActivations.incidentId]
+            }.single()
+        }
+        val pending = transaction {
+            NativeIncidentResponseTargets.selectAll().where {
+                (NativeIncidentResponseTargets.activationId eq activationId) and
+                    (NativeIncidentResponseTargets.status inList listOf(
+                        IncidentResponseTargetStatus.DESIRED.wire,
+                        IncidentResponseTargetStatus.RETRYING.wire,
+                    ))
+            }.toList()
+        }
+        pending.forEach { target ->
+            val claimed = transaction {
+                NativeIncidentResponseTargets.update({
+                    (NativeIncidentResponseTargets.id eq target[NativeIncidentResponseTargets.id].value) and
+                        (NativeIncidentResponseTargets.status inList listOf(
+                            IncidentResponseTargetStatus.DESIRED.wire,
+                            IncidentResponseTargetStatus.RETRYING.wire,
+                        ))
+                }) {
+                    it[status] = IncidentResponseTargetStatus.ATTEMPTED.wire
+                    it[attemptCount] = target[NativeIncidentResponseTargets.attemptCount] + 1
+                    it[attemptedAt] = now()
+                    it[updatedAt] = now()
+                }
+            }
+            if (claimed == 0) return@forEach
+            try {
+                val alertId = pager.page(
+                    IncidentResponsePageRequest(
+                        organizationId = activation[NativeIncidentResponseActivations.organizationId],
+                        escalationPolicyId = target[NativeIncidentResponseTargets.escalationPolicyId]
+                            ?: error("Response target has no escalation policy"),
+                        title = incident[OnCallIncidents.title],
+                        severity = incident[OnCallIncidents.severity] ?: "SEV-1",
+                        deduplicationKey =
+                            "incident:${activation[NativeIncidentResponseActivations.resourceId]}:" +
+                                target[NativeIncidentResponseTargets.targetKey],
+                        metadata = mapOf(
+                            "incidentId" to JsonPrimitive(incident[OnCallIncidents.resourceId].toString()),
+                        ),
+                    ),
+                )
+                if (alertId == null) error("Paging provider did not return an alert")
+                linkAlert(activation, target, alertId)
+            } catch (error: Exception) {
+                transaction {
+                    NativeIncidentResponseTargets.update({
+                        NativeIncidentResponseTargets.id eq target[NativeIncidentResponseTargets.id].value
+                    }) {
+                        it[status] = IncidentResponseTargetStatus.FAILED.wire
+                        it[failedAt] = now()
+                        it[lastError] = error.message ?: "Paging failed"
+                        it[updatedAt] = now()
+                    }
+                }
+            }
+        }
+        finalize(activationId)
+    }
+
+    private fun linkAlert(
+        activation: org.jetbrains.exposed.v1.core.ResultRow,
+        target: org.jetbrains.exposed.v1.core.ResultRow,
+        alertId: Int,
+    ) = transaction {
+        OnCallAlerts.update({ OnCallAlerts.id eq alertId }) {
+            it[declaredIncidentId] = activation[NativeIncidentResponseActivations.incidentId]
+            it[updatedAt] = now()
+        }
+        OnCallIncidentAlerts.insertIgnore {
+            it[incidentId] = activation[NativeIncidentResponseActivations.incidentId]
+            it[OnCallIncidentAlerts.alertId] = alertId
+        }
+        NativeIncidentResponseTargets.update({
+            NativeIncidentResponseTargets.id eq target[NativeIncidentResponseTargets.id].value
+        }) {
+            it[onCallAlertId] = alertId
+            it[status] = IncidentResponseTargetStatus.ATTEMPTED.wire
+            it[updatedAt] = now()
+        }
+    }
+
+    private fun finalize(activationId: Int) = transaction {
+        val targets = NativeIncidentResponseTargets.selectAll().where {
+            NativeIncidentResponseTargets.activationId eq activationId
+        }.toList()
+        val failed = targets.any {
+            it[NativeIncidentResponseTargets.status] == IncidentResponseTargetStatus.FAILED.wire
+        }
+        val pending = targets.any {
+            it[NativeIncidentResponseTargets.status] in listOf(
+                IncidentResponseTargetStatus.DESIRED.wire,
+                IncidentResponseTargetStatus.RETRYING.wire,
+            )
+        }
+        val skipped = targets.isNotEmpty() && targets.all {
+            it[NativeIncidentResponseTargets.status] == IncidentResponseTargetStatus.SKIPPED.wire
+        }
+        val active = when {
+            failed -> IncidentResponseActivationStatus.FAILED
+            pending -> IncidentResponseActivationStatus.ACTIVE
+            skipped -> IncidentResponseActivationStatus.SKIPPED
+            else -> IncidentResponseActivationStatus.COMPLETED
+        }
+        NativeIncidentResponseActivations.update({ NativeIncidentResponseActivations.id eq activationId }) {
+            it[status] = active.wire
+            it[attemptedCount] = targets.count { row ->
+                row[NativeIncidentResponseTargets.status] in listOf(
+                    IncidentResponseTargetStatus.ATTEMPTED.wire,
+                    IncidentResponseTargetStatus.ACKNOWLEDGED.wire,
+                )
+            }
+            it[acknowledgedCount] = targets.count { row ->
+                row[NativeIncidentResponseTargets.status] == IncidentResponseTargetStatus.ACKNOWLEDGED.wire
+            }
+            it[lastError] = targets.firstOrNull { row ->
+                row[NativeIncidentResponseTargets.status] == IncidentResponseTargetStatus.FAILED.wire
+            }?.get(NativeIncidentResponseTargets.lastError)
+            it[completedAt] = now().takeIf { active != IncidentResponseActivationStatus.ACTIVE }
+            it[updatedAt] = now()
+        }
+    }
+
+    private fun claimCommander(activationId: Int, userId: Int) = transaction {
+        val target = NativeIncidentResponseTargets.selectAll().where {
+            (NativeIncidentResponseTargets.activationId eq activationId) and
+                NativeIncidentResponseTargets.onCallAlertId.isNotNull()
+        }.singleOrNull() ?: return@transaction
+        val activation = NativeIncidentResponseActivations.selectAll().where {
+            NativeIncidentResponseActivations.id eq activationId
+        }.single()
+        OnCallIncidents.selectAll().where {
+            OnCallIncidents.id eq activation[NativeIncidentResponseActivations.incidentId]
+        }
+            .forUpdate()
+            .single()
+        val role = NativeIncidentRoleDefinitions.selectAll().where {
+            (NativeIncidentRoleDefinitions.organizationId eq
+                activation[NativeIncidentResponseActivations.organizationId]) and
+                (NativeIncidentRoleDefinitions.stableKey eq INCIDENT_COMMANDER_ROLE_KEY) and
+                (NativeIncidentRoleDefinitions.isCurrent eq true)
+        }.singleOrNull() ?: return@transaction
+        val existing = NativeIncidentRoleAssignments.selectAll().where {
+            (NativeIncidentRoleAssignments.incidentId eq activation[NativeIncidentResponseActivations.incidentId]) and
+                (NativeIncidentRoleAssignments.roleDefinitionId eq role[NativeIncidentRoleDefinitions.id].value) and
+                NativeIncidentRoleAssignments.endedAt.isNull()
+        }.singleOrNull()
+        if (existing == null) {
+            NativeIncidentRoleAssignments.insertIgnore {
+                it[resourceId] = kotlin.uuid.Uuid.random()
+                it[organizationId] = activation[NativeIncidentResponseActivations.organizationId]
+                it[incidentId] = activation[NativeIncidentResponseActivations.incidentId]
+                it[roleDefinitionId] = role[NativeIncidentRoleDefinitions.id].value
+                it[assigneeUserId] = userId
+                it[assignedBy] = userId
+                it[assignedAt] = now()
+                it[endedBy] = null
+                it[endedAt] = null
+                it[endReason] = null
+            }
+        }
+        NativeIncidentResponseTargets.update({
+            NativeIncidentResponseTargets.id eq target[NativeIncidentResponseTargets.id].value
+        }) {
+            it[NativeIncidentResponseTargets.userId] = userId
+            it[updatedAt] = now()
+        }
+    }
+
+    private fun addParticipant(activationId: Int, userId: Int) = transaction {
+        val activation = NativeIncidentResponseActivations.selectAll().where {
+            NativeIncidentResponseActivations.id eq activationId
+        }.single()
+        val organizationId = activation[NativeIncidentResponseActivations.organizationId]
+        val incidentId = activation[NativeIncidentResponseActivations.incidentId]
+        val member = Memberships.selectAll().where {
+            (Memberships.organization_id eq organizationId) and (Memberships.user_id eq userId)
+        }.limit(1).any()
+        if (!member) return@transaction
+        val existing = NativeIncidentParticipants.selectAll().where {
+            (NativeIncidentParticipants.organizationId eq organizationId) and
+                (NativeIncidentParticipants.incidentId eq incidentId) and
+                (NativeIncidentParticipants.userId eq userId) and
+                NativeIncidentParticipants.leftAt.isNull()
+        }.singleOrNull()
+        if (existing == null) {
+            NativeIncidentParticipants.insertIgnore {
+                it[resourceId] = kotlin.uuid.Uuid.random()
+                it[NativeIncidentParticipants.organizationId] = organizationId
+                it[NativeIncidentParticipants.incidentId] = incidentId
+                it[NativeIncidentParticipants.userId] = userId
+                it[participationType] = IncidentParticipationType.PARTICIPANT.wire
+                it[joinedBy] = userId
+                it[joinedAt] = now()
+                it[leftBy] = null
+                it[leftAt] = null
+            }
+        }
+    }
+
+    private fun routePagedPolicies(organizationId: Int, incidentId: Int): Set<Int> = transaction {
+        val direct = OnCallIncidentAlerts
+            .innerJoin(OnCallAlerts)
+            .selectAll()
+            .where {
+                (OnCallIncidentAlerts.incidentId eq incidentId) and
+                    (OnCallAlerts.organizationId eq organizationId) and
+                    (OnCallAlerts.alertSource eq "alert-route")
+            }
+            .mapNotNull { it[OnCallAlerts.escalationPolicyId] }
+        val groups = EnterpriseAlertGroupEscalations
+            .innerJoin(EnterpriseAlertGroups)
+            .selectAll()
+            .where {
+                (EnterpriseAlertGroupEscalations.organizationId eq organizationId) and
+                    (EnterpriseAlertGroups.organizationId eq organizationId) and
+                    (EnterpriseAlertGroups.incidentId eq incidentId)
+            }
+            .map { it[EnterpriseAlertGroupEscalations.escalationPolicyId] }
+        (direct + groups).toSet()
+    }
+
+    private fun activationResponse(row: org.jetbrains.exposed.v1.core.ResultRow): IncidentResponseActivationResponse {
+        val targets = transaction {
+            NativeIncidentResponseTargets.selectAll().where {
+                NativeIncidentResponseTargets.activationId eq row[NativeIncidentResponseActivations.id].value
+            }.orderBy(NativeIncidentResponseTargets.targetKey).map {
+                IncidentResponseTargetResponse(
+                    id = it[NativeIncidentResponseTargets.resourceId].toString(),
+                    targetKey = it[NativeIncidentResponseTargets.targetKey],
+                    targetType = it[NativeIncidentResponseTargets.targetType],
+                    status = it[NativeIncidentResponseTargets.status],
+                    attemptCount = it[NativeIncidentResponseTargets.attemptCount],
+                    onCallAlertId = it[NativeIncidentResponseTargets.onCallAlertId]?.let { id ->
+                        OnCallAlerts.selectAll().where { OnCallAlerts.id eq id }.single()[OnCallAlerts.resourceId]
+                            .toString()
+                    },
+                    error = it[NativeIncidentResponseTargets.lastError],
+                )
+            }
+        }
+        return IncidentResponseActivationResponse(
+            id = row[NativeIncidentResponseActivations.resourceId].toString(),
+            revision = row[NativeIncidentResponseActivations.activationRevision],
+            trigger = row[NativeIncidentResponseActivations.trigger],
+            status = row[NativeIncidentResponseActivations.status],
+            desiredCount = row[NativeIncidentResponseActivations.desiredCount],
+            attemptedCount = row[NativeIncidentResponseActivations.attemptedCount],
+            acknowledgedCount = row[NativeIncidentResponseActivations.acknowledgedCount],
+            lastError = row[NativeIncidentResponseActivations.lastError],
+            targets = targets,
+        )
+    }
+
+    private fun requireMember(organizationId: Int, userId: Int) {
+        require(
+            Memberships.selectAll().where {
+                (Memberships.organization_id eq organizationId) and (Memberships.user_id eq userId)
+            }.limit(1).any(),
+        ) { "Actor is not a member of the incident organization" }
+    }
+
+    private fun NativeIncidentDomainEvent.status(): String? = payload["status"]?.jsonPrimitive?.contentOrNull
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/response/IncidentResponseModels.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/response/IncidentResponseModels.kt
@@ -1,0 +1,100 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.incidents.response
+
+import com.moneat.enterprise.oncall.models.OnCallAlerts
+import com.moneat.enterprise.oncall.models.OnCallIncidents
+import com.moneat.shared.models.EscalationPolicies
+import com.moneat.shared.models.Organizations
+import com.moneat.shared.models.Users
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
+import org.jetbrains.exposed.v1.datetime.timestamp
+import kotlin.uuid.Uuid
+
+enum class IncidentResponseActivationStatus(val wire: String) {
+    PENDING("PENDING"),
+    ACTIVE("ACTIVE"),
+    COMPLETED("COMPLETED"),
+    FAILED("FAILED"),
+    SKIPPED("SKIPPED"),
+}
+
+enum class IncidentResponseTargetStatus(val wire: String) {
+    DESIRED("DESIRED"),
+    ATTEMPTED("ATTEMPTED"),
+    ACKNOWLEDGED("ACKNOWLEDGED"),
+    FAILED("FAILED"),
+    RETRYING("RETRYING"),
+    SKIPPED("SKIPPED"),
+}
+
+object NativeIncidentResponsePolicies : IntIdTable("native_incident_response_policies") {
+    val resourceId = uuid("resource_id").clientDefault { Uuid.random() }
+    val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
+    val commanderPolicyId = integer("commander_policy_id").references(EscalationPolicies.id).nullable()
+    val ownershipPolicyId = integer("ownership_policy_id").references(EscalationPolicies.id).nullable()
+    val pageOwnership = bool("page_ownership").default(true)
+    val pageTestIncidents = bool("page_test_incidents").default(false)
+    val pageRetrospectiveIncidents = bool("page_retrospective_incidents").default(false)
+    val createdBy = integer("created_by").references(Users.id)
+    val createdAt = timestamp("created_at")
+    val updatedAt = timestamp("updated_at")
+
+    init {
+        uniqueIndex(organizationId)
+        uniqueIndex(organizationId, resourceId)
+    }
+}
+
+object NativeIncidentResponseActivations : IntIdTable("native_incident_response_activations") {
+    val resourceId = uuid("resource_id").clientDefault { Uuid.random() }
+    val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
+    val incidentId = integer("incident_id").references(OnCallIncidents.id, onDelete = ReferenceOption.CASCADE)
+    val activationRevision = integer("activation_revision")
+    val trigger = varchar("trigger", 32)
+    val status = varchar("status", 24)
+    val desiredCount = integer("desired_count").default(0)
+    val attemptedCount = integer("attempted_count").default(0)
+    val acknowledgedCount = integer("acknowledged_count").default(0)
+    val lastError = text("last_error").nullable()
+    val startedAt = timestamp("started_at")
+    val completedAt = timestamp("completed_at").nullable()
+    val createdAt = timestamp("created_at")
+    val updatedAt = timestamp("updated_at")
+
+    init {
+        uniqueIndex(organizationId, incidentId, activationRevision, trigger)
+        uniqueIndex(organizationId, resourceId)
+        index(false, organizationId, incidentId, createdAt)
+    }
+}
+
+object NativeIncidentResponseTargets : IntIdTable("native_incident_response_targets") {
+    val resourceId = uuid("resource_id").clientDefault { Uuid.random() }
+    val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
+    val activationId = integer("activation_id")
+        .references(NativeIncidentResponseActivations.id, onDelete = ReferenceOption.CASCADE)
+    val targetKey = varchar("target_key", 180)
+    val targetType = varchar("target_type", 32)
+    val escalationPolicyId = integer("escalation_policy_id").references(EscalationPolicies.id).nullable()
+    val userId = integer("user_id").references(Users.id).nullable()
+    val onCallAlertId = integer("on_call_alert_id").references(OnCallAlerts.id).nullable()
+    val status = varchar("status", 24)
+    val attemptCount = integer("attempt_count").default(0)
+    val desiredAt = timestamp("desired_at")
+    val attemptedAt = timestamp("attempted_at").nullable()
+    val acknowledgedAt = timestamp("acknowledged_at").nullable()
+    val failedAt = timestamp("failed_at").nullable()
+    val lastError = text("last_error").nullable()
+    val createdAt = timestamp("created_at")
+    val updatedAt = timestamp("updated_at")
+
+    init {
+        uniqueIndex(organizationId, activationId, targetKey)
+        uniqueIndex(organizationId, resourceId)
+        index(false, organizationId, onCallAlertId)
+    }
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
@@ -21,7 +21,12 @@ import com.moneat.enterprise.incidents.commands.DeclareIncidentCommand
 import com.moneat.enterprise.incidents.commands.IncidentCommandActor
 import com.moneat.enterprise.incidents.events.IncidentOutboxService
 import com.moneat.enterprise.incidents.events.IncidentOutboxWorker
+import com.moneat.enterprise.incidents.events.IncidentResponseEventConsumer
 import com.moneat.enterprise.incidents.events.WorkflowIncidentEventConsumer
+import com.moneat.enterprise.incidents.response.IncidentResponseActivationService
+import com.moneat.enterprise.incidents.response.IncidentResponsePager
+import com.moneat.enterprise.incidents.response.IncidentResponsePageRequest
+import com.moneat.enterprise.incidents.response.IncidentResponsePolicyService
 import com.moneat.enterprise.oncall.routes.deviceRoutes
 import com.moneat.enterprise.oncall.routes.escalationRoutes
 import com.moneat.enterprise.oncall.routes.incidentRoutes
@@ -84,7 +89,30 @@ class OnCallModule :
             )
         }
     private val escalationEngine by escalationEngineDelegate
-    private val onCallAlertService by lazy { OnCallAlertService(escalationEngine = escalationEngine) }
+    private val incidentResponsePolicyService = IncidentResponsePolicyService()
+    private val incidentResponseActivationService by lazy {
+        IncidentResponseActivationService(
+            policyService = incidentResponsePolicyService,
+            pager = IncidentResponsePager { request: IncidentResponsePageRequest ->
+                escalationEngine.triggerEscalation(
+                    organizationId = request.organizationId,
+                    escalationPolicyId = request.escalationPolicyId,
+                    title = request.title,
+                    description = "Incident response activation",
+                    priority = request.severity,
+                    alertSource = "incident-response",
+                    deduplicationKey = request.deduplicationKey,
+                    metadata = request.metadata,
+                )?.internalId
+            },
+        )
+    }
+    private val onCallAlertService by lazy {
+        OnCallAlertService(
+            escalationEngine = escalationEngine,
+            responseActivationService = incidentResponseActivationService,
+        )
+    }
     private val slackUserGroupSyncServiceDelegate =
         lazy {
             SlackUserGroupSyncService(
@@ -115,7 +143,10 @@ class OnCallModule :
         lazy {
             IncidentOutboxWorker(
                 IncidentOutboxService(
-                    consumers = listOf(WorkflowIncidentEventConsumer()),
+                    consumers = listOf(
+                        WorkflowIncidentEventConsumer(),
+                        IncidentResponseEventConsumer(incidentResponseActivationService),
+                    ),
                 ),
             )
         }
@@ -143,7 +174,10 @@ class OnCallModule :
             escalationRoutes()
             priorityRoutes()
             deviceRoutes()
-            incidentRoutes({ onCallAlertService })
+            incidentRoutes(
+                alertServiceProvider = { onCallAlertService },
+                incidentResponseActivationService = incidentResponseActivationService,
+            )
             alertRouteRoutes()
             alertGroupRoutes()
             twilioWebhookRoutes()

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutes.kt
@@ -27,6 +27,8 @@ import com.moneat.enterprise.incidents.commands.LinkIncidentSourceCommand
 import com.moneat.enterprise.incidents.commands.UnlinkIncidentSourceCommand
 import com.moneat.enterprise.incidents.config.IncidentConfigurationService
 import com.moneat.enterprise.incidents.responders.IncidentResponderService
+import com.moneat.enterprise.incidents.response.IncidentResponseActivationService
+import com.moneat.enterprise.incidents.response.IncidentResponsePolicyInput
 import com.moneat.enterprise.incidents.timeline.IncidentTimelineService
 import com.moneat.enterprise.incidents.models.IncidentFormStage
 import com.moneat.enterprise.incidents.models.IncidentParticipationType
@@ -206,12 +208,22 @@ data class MergeIncidentRequest(
     val expectedVersion: Int? = null,
 )
 
+@Serializable
+data class IncidentResponsePolicyRequest(
+    val commanderPolicyId: String? = null,
+    val ownershipPolicyId: String? = null,
+    val pageOwnership: Boolean = true,
+    val pageTestIncidents: Boolean = false,
+    val pageRetrospectiveIncidents: Boolean = false,
+)
+
 private data class IncidentRouteServices(
     val alertServiceProvider: () -> OnCallAlertService,
     val incidentService: OnCallIncidentService,
     val configurationService: IncidentConfigurationService,
     val responderService: IncidentResponderService,
     val timelineService: IncidentTimelineService,
+    val responseService: IncidentResponseActivationService?,
 )
 
 fun Route.incidentRoutes(
@@ -222,6 +234,7 @@ fun Route.incidentRoutes(
     },
     entitlementStatusProvider: (Int) -> NativeIncidentEntitlementStatus =
         FeatureRegistry::nativeIncidentEntitlementStatus,
+    incidentResponseActivationService: IncidentResponseActivationService? = null,
 ) {
     val services =
         IncidentRouteServices(
@@ -230,8 +243,10 @@ fun Route.incidentRoutes(
             configurationService = IncidentConfigurationService(),
             responderService = IncidentResponderService(),
             timelineService = IncidentTimelineService(),
+            responseService = incidentResponseActivationService,
         )
     registerIncidentCapabilitiesRoute(entitlementStatusProvider)
+    incidentResponseActivationService?.let { registerIncidentResponseRoutes(it) }
     registerAlertRoutes(services.alertServiceProvider, services.incidentService, incidentEntitlement)
     registerDeclaredIncidentRoutes(services, incidentEntitlement)
     registerIncidentConfigurationRoutes(
@@ -311,9 +326,57 @@ private fun Route.registerDeclaredIncidentRoutes(
             registerAddAlertToIncidentRoute(services.alertServiceProvider, services.incidentService)
             registerIncidentSourceRoutes(services.incidentService)
             registerIncidentResponderRoutes(services.incidentService, services.responderService)
+            services.responseService?.let { registerIncidentResponseIncidentRoutes(it) }
             registerIncidentTimelineRoutes(services.timelineService)
             registerAddIncidentNoteRoute(services.incidentService)
         }
+    }
+}
+
+private fun Route.registerIncidentResponseRoutes(
+    responseService: IncidentResponseActivationService,
+) {
+    route("/v1/on-call/incident-response/settings") {
+        authenticate(JWT_AUTH_PROVIDER) {
+            get {
+                val context = call.requireUserContext() ?: return@get
+                call.respond(responseService.policy(context.organizationId))
+            }
+            post {
+                val context = call.requireIncidentAdminContext() ?: return@post
+                val request = call.receive<IncidentResponsePolicyRequest>()
+                call.respond(
+                    responseService.updatePolicy(
+                        context.organizationId,
+                        context.userId,
+                        IncidentResponsePolicyInput(
+                            commanderPolicyResourceId = request.commanderPolicyId,
+                            ownershipPolicyResourceId = request.ownershipPolicyId,
+                            pageOwnership = request.pageOwnership,
+                            pageTestIncidents = request.pageTestIncidents,
+                            pageRetrospectiveIncidents = request.pageRetrospectiveIncidents,
+                        ),
+                    ),
+                )
+            }
+        }
+    }
+}
+
+private fun Route.registerIncidentResponseIncidentRoutes(
+    responseService: IncidentResponseActivationService,
+) {
+    get("/{id}/response") {
+        val context = call.requireUserContext() ?: return@get
+        val incidentId = call.requireIncidentId(context.organizationId) ?: return@get
+        call.respond(responseService.incidentResponseById(context.organizationId, incidentId))
+    }
+    post("/{id}/response/{activationId}/retry") {
+        val context = call.requireUserContext() ?: return@post
+        val incidentId = call.requireIncidentId(context.organizationId) ?: return@post
+        val activationId = call.parameters["activationId"] ?: return@post
+        val response = responseService.retry(context.organizationId, activationId, context.userId, incidentId)
+        call.respond(response)
     }
 }
 

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/IncidentManagementService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/IncidentManagementService.kt
@@ -11,6 +11,7 @@ import com.moneat.enterprise.oncall.organizationResourceId
 import com.moneat.enterprise.oncall.requireValue
 import com.moneat.enterprise.oncall.userResourceIds
 import com.moneat.enterprise.oncall.userResourceIdOrNull
+import com.moneat.enterprise.incidents.response.IncidentResponseActivationService
 import com.moneat.enterprise.oncall.models.OnCallAlert
 import com.moneat.enterprise.oncall.models.OnCallAlertTimeline
 import com.moneat.enterprise.oncall.models.OnCallAlerts
@@ -33,6 +34,7 @@ import kotlin.time.Clock
 
 class OnCallAlertService(
     private val escalationEngine: EscalationEngine,
+    private val responseActivationService: IncidentResponseActivationService? = null,
 ) {
     private data class AlertResponseResourceIds(
         val organizationResourceId: String,
@@ -239,7 +241,11 @@ class OnCallAlertService(
     fun acknowledge(
         alertId: Int,
         userId: Int,
-    ): Boolean = escalationEngine.acknowledgeAlert(alertId, userId)
+    ): Boolean {
+        val acknowledged = escalationEngine.acknowledgeAlert(alertId, userId)
+        if (acknowledged) responseActivationService?.markAcknowledged(alertId, userId)
+        return acknowledged
+    }
 
     fun resolve(
         alertId: Int,

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/AlertRouteTestDatabase.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/AlertRouteTestDatabase.kt
@@ -26,6 +26,9 @@ import com.moneat.enterprise.incidents.models.NativeIncidentForms
 import com.moneat.enterprise.incidents.models.NativeIncidentFormSubmissions
 import com.moneat.enterprise.incidents.models.NativeIncidentOutboxDeliveries
 import com.moneat.enterprise.incidents.models.NativeIncidentOutboxEvents
+import com.moneat.enterprise.incidents.response.NativeIncidentResponseActivations
+import com.moneat.enterprise.incidents.response.NativeIncidentResponsePolicies
+import com.moneat.enterprise.incidents.response.NativeIncidentResponseTargets
 import com.moneat.enterprise.incidents.models.NativeIncidentSourceLinks
 import com.moneat.enterprise.incidents.models.NativeIncidentTimelineRevisions
 import com.moneat.enterprise.incidents.models.NativeIncidentTypes
@@ -100,6 +103,9 @@ object AlertRouteTestDatabase {
             NativeIncidentCommands,
             NativeIncidentOutboxEvents,
             NativeIncidentOutboxDeliveries,
+            NativeIncidentResponsePolicies,
+            NativeIncidentResponseActivations,
+            NativeIncidentResponseTargets,
             IncidentProviderConfigs,
             IncidentRoutingRules,
             IncidentEventLog,

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/IncidentTestDatabase.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/IncidentTestDatabase.kt
@@ -5,6 +5,18 @@
 package com.moneat.enterprise.incidents
 
 import com.moneat.alerts.models.AlertEpisodes
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertGroupCommands
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertGroupDecisions
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertGroupEscalations
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertGroupMembers
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertGroups
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRouteActions
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRouteCommands
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRouteConditionGroups
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRouteConditions
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRouteRevisions
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRouteTargets
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRoutes
 import com.moneat.enterprise.incidents.models.NativeIncidentAlertEpisodeLinks
 import com.moneat.enterprise.incidents.models.NativeIncidentCommands
 import com.moneat.enterprise.incidents.models.NativeIncidentCustomFieldOptions
@@ -15,6 +27,9 @@ import com.moneat.enterprise.incidents.models.NativeIncidentFormSubmissions
 import com.moneat.enterprise.incidents.models.NativeIncidentHandovers
 import com.moneat.enterprise.incidents.models.NativeIncidentOutboxDeliveries
 import com.moneat.enterprise.incidents.models.NativeIncidentOutboxEvents
+import com.moneat.enterprise.incidents.response.NativeIncidentResponseActivations
+import com.moneat.enterprise.incidents.response.NativeIncidentResponsePolicies
+import com.moneat.enterprise.incidents.response.NativeIncidentResponseTargets
 import com.moneat.enterprise.incidents.models.NativeIncidentParticipants
 import com.moneat.enterprise.incidents.models.NativeIncidentRoleAssignments
 import com.moneat.enterprise.incidents.models.NativeIncidentRoleDefinitions
@@ -28,7 +43,10 @@ import com.moneat.enterprise.oncall.models.OnCallIncidents
 import com.moneat.enterprise.sso.support.EnterpriseTestDatabaseHelper
 import com.moneat.shared.models.EscalationPolicies
 import com.moneat.shared.models.Memberships
+import com.moneat.shared.models.OnCallSchedules
+import com.moneat.shared.models.OrganizationTeams
 import com.moneat.shared.models.Organizations
+import com.moneat.monitor.repositories.ResourceOwnership
 import com.moneat.shared.models.Users
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
@@ -51,7 +69,10 @@ object IncidentTestDatabase {
             Users,
             Organizations,
             Memberships,
+            OnCallSchedules,
             EscalationPolicies,
+            OrganizationTeams,
+            ResourceOwnership,
             AlertEpisodes,
             NativeIncidentTypes,
             NativeIncidentCustomFields,
@@ -73,6 +94,21 @@ object IncidentTestDatabase {
             NativeIncidentCommands,
             NativeIncidentOutboxEvents,
             NativeIncidentOutboxDeliveries,
+            NativeIncidentResponsePolicies,
+            NativeIncidentResponseActivations,
+            NativeIncidentResponseTargets,
+            EnterpriseAlertRoutes,
+            EnterpriseAlertRouteConditionGroups,
+            EnterpriseAlertRouteConditions,
+            EnterpriseAlertRouteActions,
+            EnterpriseAlertRouteTargets,
+            EnterpriseAlertRouteRevisions,
+            EnterpriseAlertRouteCommands,
+            EnterpriseAlertGroups,
+            EnterpriseAlertGroupMembers,
+            EnterpriseAlertGroupDecisions,
+            EnterpriseAlertGroupEscalations,
+            EnterpriseAlertGroupCommands,
         )
     }
 

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/response/IncidentResponseActivationServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/response/IncidentResponseActivationServiceTest.kt
@@ -1,0 +1,293 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.incidents.response
+
+import com.moneat.enterprise.incidents.IncidentTestDatabase
+import com.moneat.enterprise.incidents.events.NativeIncidentDomainEvent
+import com.moneat.enterprise.incidents.models.IncidentParticipationType
+import com.moneat.enterprise.incidents.models.NativeIncidentParticipants
+import com.moneat.enterprise.incidents.models.NativeIncidentRoleDefinitions
+import com.moneat.enterprise.incidents.models.NativeIncidentStatus
+import com.moneat.enterprise.oncall.models.OnCallAlerts
+import com.moneat.enterprise.oncall.models.OnCallIncidents
+import com.moneat.shared.models.EscalationPolicies
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.uuid.Uuid
+
+class IncidentResponseActivationServiceTest {
+    private lateinit var member: com.moneat.enterprise.incidents.SeededMember
+    private lateinit var incident: SeededIncident
+    private lateinit var policy: SeededPolicy
+
+    @BeforeTest
+    fun setUp() {
+        IncidentTestDatabase.reset()
+        member = IncidentTestDatabase.seedMember()
+        policy = seedPolicy()
+        incident = seedIncident(NativeIncidentStatus.ACTIVE.wire)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        IncidentTestDatabase.clearReference()
+    }
+
+    @Test
+    fun `active declaration pages once and replay is idempotent`() {
+        val pagedAlerts = mutableListOf<Int>()
+        val alertId = seedAlert()
+        val service = IncidentResponseActivationService(
+            pager = IncidentResponsePager { _ ->
+                pagedAlerts += alertId
+                alertId
+            },
+        )
+        service.updatePolicy(
+            member.organizationId,
+            member.userId,
+            IncidentResponsePolicyInput(
+                commanderPolicyResourceId = policy.resourceId.toString(),
+                ownershipPolicyResourceId = null,
+                pageOwnership = false,
+                pageTestIncidents = false,
+                pageRetrospectiveIncidents = false,
+            ),
+        )
+
+        val event = event("INCIDENT_DECLARE", NativeIncidentStatus.ACTIVE.wire)
+        service.activate(event)
+        service.activate(event)
+
+        val response = service.incidentResponse(member.organizationId, incident.resourceId.toString()).single()
+        assertEquals(IncidentResponseActivationStatus.COMPLETED.wire, response.status)
+        assertEquals(1, response.desiredCount)
+        assertEquals(1, response.attemptedCount)
+        assertEquals(1, pagedAlerts.size)
+        assertEquals(
+            1,
+            transaction {
+                OnCallAlerts.selectAll().where { OnCallAlerts.declaredIncidentId eq incident.id }.count()
+            },
+        )
+    }
+
+    @Test
+    fun `triage declaration waits for acceptance before paging`() {
+        val triageIncident = seedIncident(NativeIncidentStatus.TRIAGE.wire)
+        val service = IncidentResponseActivationService()
+        service.updatePolicy(
+            member.organizationId,
+            member.userId,
+            IncidentResponsePolicyInput(policy.resourceId.toString(), null, false, false, false),
+        )
+
+        service.activate(event("INCIDENT_DECLARE", NativeIncidentStatus.TRIAGE.wire, triageIncident))
+        assertEquals(0, service.incidentResponse(member.organizationId, triageIncident.resourceId.toString()).size)
+
+        transaction {
+            OnCallIncidents.update({ OnCallIncidents.id eq triageIncident.id }) {
+                it[OnCallIncidents.status] = NativeIncidentStatus.ACTIVE.wire
+                it[OnCallIncidents.severity] = "SEV-2"
+                it[OnCallIncidents.acceptedAt] = Clock.System.now()
+            }
+        }
+        service.activate(event("INCIDENT_ACCEPT", NativeIncidentStatus.ACTIVE.wire, triageIncident))
+
+        val response = service.incidentResponse(member.organizationId, triageIncident.resourceId.toString()).single()
+        assertEquals("INCIDENT_ACCEPT", response.trigger)
+    }
+
+    @Test
+    fun `missing page result is durable and retry can recover`() {
+        var shouldPage = false
+        val service = IncidentResponseActivationService(
+            pager = IncidentResponsePager { if (shouldPage) seedAlert() else null },
+        )
+        service.updatePolicy(
+            member.organizationId,
+            member.userId,
+            IncidentResponsePolicyInput(policy.resourceId.toString(), null, false, false, false),
+        )
+
+        service.activate(event("INCIDENT_DECLARE", NativeIncidentStatus.ACTIVE.wire))
+        val failed = service.incidentResponse(member.organizationId, incident.resourceId.toString()).single()
+        assertEquals(IncidentResponseActivationStatus.FAILED.wire, failed.status)
+        assertEquals(IncidentResponseTargetStatus.FAILED.wire, failed.targets.single().status)
+        assertNotNull(failed.lastError)
+
+        shouldPage = true
+        service.retry(member.organizationId, failed.id, member.userId)
+        val recovered = service.incidentResponse(member.organizationId, incident.resourceId.toString()).single()
+        assertEquals(IncidentResponseActivationStatus.COMPLETED.wire, recovered.status)
+        assertEquals(2, recovered.targets.single().attemptCount)
+    }
+
+    @Test
+    fun `acknowledgement claims commander and adds participant`() {
+        val alertId = seedAlert()
+        seedCommanderRole()
+        val service = IncidentResponseActivationService(
+            pager = IncidentResponsePager { alertId },
+        )
+        service.updatePolicy(
+            member.organizationId,
+            member.userId,
+            IncidentResponsePolicyInput(policy.resourceId.toString(), null, false, false, false),
+        )
+        service.activate(event("INCIDENT_DECLARE", NativeIncidentStatus.ACTIVE.wire))
+
+        assertTrue(service.markAcknowledged(alertId, member.userId))
+        assertTrue(service.markAcknowledged(alertId, member.userId).not())
+        assertEquals(
+            1,
+            transaction {
+                NativeIncidentParticipants.selectAll().where {
+                    (NativeIncidentParticipants.incidentId eq incident.id) and
+                        (NativeIncidentParticipants.userId eq member.userId) and
+                        (NativeIncidentParticipants.participationType eq IncidentParticipationType.PARTICIPANT.wire)
+                }.count()
+            },
+        )
+        val activation = service.incidentResponse(member.organizationId, incident.resourceId.toString()).single()
+        assertEquals(IncidentResponseTargetStatus.ACKNOWLEDGED.wire, activation.targets.single().status)
+    }
+
+    @Test
+    fun `retry rejects an activation from another incident`() {
+        val service = IncidentResponseActivationService()
+        service.updatePolicy(
+            member.organizationId,
+            member.userId,
+            IncidentResponsePolicyInput(policy.resourceId.toString(), null, false, false, false),
+        )
+        service.activate(event("INCIDENT_DECLARE", NativeIncidentStatus.ACTIVE.wire))
+        val response = service.incidentResponse(member.organizationId, incident.resourceId.toString()).single()
+        val other = seedIncident(NativeIncidentStatus.ACTIVE.wire)
+
+        assertFailsWith<NoSuchElementException> {
+            service.retry(member.organizationId, response.id, member.userId, other.id)
+        }
+    }
+
+    private fun seedPolicy(): SeededPolicy = transaction {
+        val resourceId = Uuid.random()
+        val id = EscalationPolicies.insertAndGetId {
+            it[EscalationPolicies.resourceId] = resourceId
+            it[organizationId] = member.organizationId
+            it[name] = "Incident Commander"
+            it[repeatCount] = 1
+            it[createdAt] = Clock.System.now()
+            it[updatedAt] = Clock.System.now()
+        }.value
+        SeededPolicy(id, resourceId)
+    }
+
+    private fun seedIncident(status: String): SeededIncident = transaction {
+        val resourceId = Uuid.random()
+        val now = Clock.System.now()
+        val id = OnCallIncidents.insertAndGetId {
+            it[OnCallIncidents.resourceId] = resourceId
+            it[organizationId] = member.organizationId
+            it[title] = "Checkout unavailable"
+            it[description] = null
+            it[severity] = if (status == NativeIncidentStatus.ACTIVE.wire) "SEV-2" else null
+            it[OnCallIncidents.status] = status
+            it[mode] = "LIVE"
+            it[visibility] = "ORGANIZATION"
+            it[declarationSnapshot] = emptyMap<String, JsonElement>()
+            it[version] = 1
+            it[declaredBy] = member.userId
+            it[declaredAt] = now
+            it[acceptedAt] = now.takeIf { status == NativeIncidentStatus.ACTIVE.wire }
+            it[createdAt] = now
+            it[updatedAt] = now
+        }.value
+        SeededIncident(id, resourceId)
+    }
+
+    private fun seedAlert(): Int = transaction {
+        val now = Clock.System.now()
+        OnCallAlerts.insertAndGetId {
+            it[resourceId] = Uuid.random()
+            it[organizationId] = member.organizationId
+            it[escalationPolicyId] = policy.id
+            it[title] = "Incident response page"
+            it[description] = null
+            it[priority] = "P1"
+            it[status] = "TRIGGERED"
+            it[alertSource] = "incident-response"
+            it[deduplicationKey] = null
+            it[currentStep] = 0
+            it[repeatIteration] = 0
+            it[triggeredAt] = now
+            it[acknowledgedAt] = null
+            it[acknowledgedBy] = null
+            it[resolvedAt] = null
+            it[resolvedBy] = null
+            it[metadata] = emptyMap()
+            it[createdAt] = now
+            it[updatedAt] = now
+        }.value
+    }
+
+    private fun seedCommanderRole() = transaction {
+        NativeIncidentRoleDefinitions.insert {
+            it[resourceId] = Uuid.random()
+            it[organizationId] = member.organizationId
+            it[stableKey] = "incident-commander"
+            it[version] = 1
+            it[isCurrent] = true
+            it[name] = "Incident Commander"
+            it[description] = null
+            it[responsibilities] = "Coordinate the response"
+            it[privateInstructions] = null
+            it[isRequired] = true
+            it[isDefault] = true
+            it[createdBy] = member.userId
+            it[createdAt] = Clock.System.now()
+            it[supersededAt] = null
+        }
+    }
+
+    private fun event(
+        eventType: String,
+        status: String,
+        sourceIncident: SeededIncident = incident,
+    ) = NativeIncidentDomainEvent(
+        id = 1,
+        resourceId = Uuid.random().toString(),
+        organizationId = member.organizationId,
+        incidentId = sourceIncident.id,
+        eventType = eventType,
+        aggregateVersion = 1,
+        idempotencyKey = "incident-event-$eventType-${sourceIncident.id}",
+        payload = mapOf(
+            "title" to JsonPrimitive("Checkout unavailable"),
+            "status" to JsonPrimitive(status),
+            "severity" to JsonPrimitive("SEV-2"),
+        ),
+        createdAt = Clock.System.now().toString(),
+    )
+}
+
+private data class SeededIncident(val id: Int, val resourceId: Uuid)
+
+private data class SeededPolicy(val id: Int, val resourceId: Uuid)


### PR DESCRIPTION
Add durable incident-response activation for direct declarations and accepted triage incidents. Persist target delivery and retry state, assign commander and participants on acknowledgement, and suppress duplicate route paging with organization-scoped response APIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable incident-response policies for ownership and escalation paging.
  - Automatically activates response workflows for eligible incidents with deduplicated targets and status tracking.
  - Added incident-response lookup, retry, acknowledgment, and commander participation support.
  - Added administrative controls for managing policies and retrying failed activations.
  - Integrated paging with on-call escalation and incident acknowledgment workflows.

- **Bug Fixes**
  - Prevented duplicate activations and invalid cross-incident retries.
  - Preserved paging failures for later retry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->