### PR TITLE
feat: add layered on-call schedule resolution

### DIFF
--- a/backend/src/main/kotlin/com/moneat/shared/models/OnCallSharedModels.kt
+++ b/backend/src/main/kotlin/com/moneat/shared/models/OnCallSharedModels.kt
@@ -114,6 +114,30 @@ object OnCallParticipants : IntIdTable("on_call_participants") {
     val createdAt = timestamp("created_at")
 }
 
+object OnCallScheduleLayers : IntIdTable("on_call_schedule_layers") {
+    val resourceId = uuid("resource_id").clientDefault { Uuid.random() }
+    val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
+    val scheduleId = integer("schedule_id").references(OnCallSchedules.id, onDelete = ReferenceOption.CASCADE)
+    val layerOrder = integer("layer_order")
+    val name = varchar("name", 255)
+    val rotationType = varchar("rotation_type", 20)
+    val handoffTime = time("handoff_time")
+    val timezone = varchar("timezone", 100)
+    val enabled = bool("enabled").default(true)
+    val explicitGap = bool("explicit_gap").default(false)
+    val createdAt = timestamp("created_at")
+    val updatedAt = timestamp("updated_at")
+}
+
+object OnCallScheduleLayerParticipants : IntIdTable("on_call_schedule_layer_participants") {
+    val resourceId = uuid("resource_id").clientDefault { Uuid.random() }
+    val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
+    val layerId = integer("layer_id").references(OnCallScheduleLayers.id, onDelete = ReferenceOption.CASCADE)
+    val userId = integer("user_id").references(Users.id, onDelete = ReferenceOption.CASCADE)
+    val position = integer("position")
+    val createdAt = timestamp("created_at")
+}
+
 object OnCallIncidents : IntIdTable("on_call_incidents") {
     val resourceId = uuid("resource_id").clientDefault { Uuid.random() }
     val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)

--- a/backend/src/main/resources/db/migration/V164__add_layered_on_call_schedules.sql
+++ b/backend/src/main/resources/db/migration/V164__add_layered_on_call_schedules.sql
@@ -1,0 +1,40 @@
+-- Versioned layered schedules preserve the existing single-rotation schedule contract.
+
+CREATE TABLE on_call_schedule_layers (
+    id SERIAL PRIMARY KEY,
+    resource_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    schedule_id INTEGER NOT NULL REFERENCES on_call_schedules(id) ON DELETE CASCADE,
+    layer_order INTEGER NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    rotation_type VARCHAR(20) NOT NULL,
+    handoff_time TIME NOT NULL,
+    timezone VARCHAR(100) NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    explicit_gap BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_on_call_schedule_layers_resource UNIQUE (organization_id, resource_id),
+    CONSTRAINT uq_on_call_schedule_layers_order UNIQUE (schedule_id, layer_order),
+    CONSTRAINT chk_on_call_schedule_layers_order CHECK (layer_order >= 0)
+);
+
+CREATE INDEX idx_on_call_schedule_layers_schedule
+    ON on_call_schedule_layers(organization_id, schedule_id, layer_order);
+
+CREATE TABLE on_call_schedule_layer_participants (
+    id SERIAL PRIMARY KEY,
+    resource_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    layer_id INTEGER NOT NULL REFERENCES on_call_schedule_layers(id) ON DELETE CASCADE,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    position INTEGER NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_on_call_schedule_layer_participant_resource UNIQUE (organization_id, resource_id),
+    CONSTRAINT uq_on_call_schedule_layer_participant_position UNIQUE (layer_id, position),
+    CONSTRAINT uq_on_call_schedule_layer_participant_user UNIQUE (layer_id, user_id),
+    CONSTRAINT chk_on_call_schedule_layer_participant_position CHECK (position >= 0)
+);
+
+CREATE INDEX idx_on_call_schedule_layer_participants_layer
+    ON on_call_schedule_layer_participants(organization_id, layer_id, position);

--- a/dashboard/src/lib/api/modules/on-call.ts
+++ b/dashboard/src/lib/api/modules/on-call.ts
@@ -20,6 +20,8 @@ import type {
   Priority,
   BusinessHours,
   OnCallSchedule,
+  OnCallScheduleLayer,
+  OnCallResponderResolution,
   OnCallOverride,
   EscalationPolicy,
   OnCallAlert,
@@ -32,6 +34,8 @@ import type {
   CreateOnCallScheduleRequest,
   UpdateOnCallScheduleRequest,
   CreateOverrideRequest,
+  CreateScheduleLayerRequest,
+  UpdateScheduleLayerRequest,
   CreateEscalationPolicyRequest,
   UpdateEscalationPolicyRequest,
   UpdatePrioritiesRequest,
@@ -169,6 +173,47 @@ export function onCallMethods(core: ApiClientCore) {
     getCurrentOnCall: (scheduleId: string) =>
       core.request<{ userId: string; userName: string }>(
         `${base}/on-call/schedules/${encodeURIComponent(scheduleId)}/current`
+      ),
+
+    getOnCallResponders: (scheduleId: string, all = true) =>
+      core.request<OnCallResponderResolution[]>(
+        `${base}/on-call/schedules/${encodeURIComponent(scheduleId)}/responders?all=${String(all)}`
+      ),
+
+    getScheduleLayers: (scheduleId: string) =>
+      core.request<OnCallScheduleLayer[]>(
+        `${base}/on-call/schedules/${encodeURIComponent(scheduleId)}/layers`
+      ),
+
+    createScheduleLayer: (
+      scheduleId: string,
+      request: CreateScheduleLayerRequest
+    ) =>
+      core.request<OnCallScheduleLayer>(
+        `${base}/on-call/schedules/${encodeURIComponent(scheduleId)}/layers`,
+        {
+          method: 'POST',
+          body: JSON.stringify(request),
+        }
+      ),
+
+    updateScheduleLayer: (
+      scheduleId: string,
+      layerId: string,
+      request: UpdateScheduleLayerRequest
+    ) =>
+      core.request<OnCallScheduleLayer>(
+        `${base}/on-call/schedules/${encodeURIComponent(scheduleId)}/layers/${encodeURIComponent(layerId)}`,
+        {
+          method: 'PUT',
+          body: JSON.stringify(request),
+        }
+      ),
+
+    deleteScheduleLayer: (scheduleId: string, layerId: string) =>
+      core.request<void>(
+        `${base}/on-call/schedules/${encodeURIComponent(scheduleId)}/layers/${encodeURIComponent(layerId)}`,
+        {method: 'DELETE'}
       ),
 
     createOverride: (

--- a/dashboard/src/lib/api/types/on-call.ts
+++ b/dashboard/src/lib/api/types/on-call.ts
@@ -52,6 +52,7 @@ export interface OnCallSchedule {
   updatedAt: string
   participants: OnCallParticipant[]
   overrides: OnCallOverride[]
+  layers?: OnCallScheduleLayer[]
   currentOnCall?: {
     userId: string
     userName: string
@@ -76,6 +77,31 @@ export interface OnCallOverride {
   startAt: string
   endAt: string
   createdBy: string
+}
+
+export interface OnCallScheduleLayer {
+  id: string
+  scheduleId: string
+  name: string
+  layerOrder: number
+  rotationType: OnCallRotationType
+  handoffTime: string
+  timezone: string
+  enabled: boolean
+  explicitGap: boolean
+  participants: OnCallParticipant[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface OnCallResponderResolution {
+  userId: string
+  userName: string
+  userEmail: string
+  scheduleId: string
+  layerId?: string
+  source: 'OVERRIDE' | 'LAYER' | 'ROTATION'
+  activeUntil?: string
 }
 
 export interface EscalationTarget {
@@ -248,6 +274,28 @@ export interface CreateOverrideRequest {
   userId: string
   startAt: string
   endAt: string
+}
+
+export interface CreateScheduleLayerRequest {
+  name: string
+  layerOrder: number
+  rotationType: OnCallRotationType
+  handoffTime: string
+  timezone: string
+  enabled?: boolean
+  explicitGap?: boolean
+  participants?: { userId: string; position: number }[]
+}
+
+export interface UpdateScheduleLayerRequest {
+  name?: string
+  layerOrder?: number
+  rotationType?: OnCallRotationType
+  handoffTime?: string
+  timezone?: string
+  enabled?: boolean
+  explicitGap?: boolean
+  participants?: { userId: string; position: number }[]
 }
 
 export interface CreateEscalationPolicyRequest {

--- a/dashboard/src/lib/api/types/on-call.ts
+++ b/dashboard/src/lib/api/types/on-call.ts
@@ -63,10 +63,11 @@ export interface OnCallSchedule {
 
 export interface OnCallParticipant {
   id: string
-  scheduleId: string
   userId: string
   userName: string
+  userEmail: string
   position: number
+  scheduleId?: string
 }
 
 export interface OnCallOverride {

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
@@ -240,8 +240,7 @@ class OnCallModule :
         organizationId: Int,
         scheduleId: Int,
     ): OnCallUserInfo? {
-        val schedule = onCallScheduleService.getSchedule(scheduleId) ?: return null
-        if (schedule.organizationId != organizationId) return null
+        if (!onCallScheduleService.isScheduleInOrganization(scheduleId, organizationId)) return null
         val participant = onCallScheduleService.getCurrentOnCall(scheduleId) ?: return null
         return OnCallUserInfo(userId = participant.userResourceId, userName = participant.userName)
     }

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/models/OnCallModels.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/models/OnCallModels.kt
@@ -237,6 +237,37 @@ object OnCallScheduleUsergroups : IntIdTable("on_call_schedule_usergroups") {
 }
 
 @Serializable
+data class OnCallScheduleLayer(
+    val id: String,
+    @SerialName("scheduleId") val scheduleResourceId: String,
+    val name: String,
+    val layerOrder: Int,
+    val rotationType: String,
+    @Serializable(with = LocalTimeSerializer::class)
+    val handoffTime: LocalTime,
+    val timezone: String,
+    val enabled: Boolean,
+    val explicitGap: Boolean,
+    val participants: List<OnCallParticipant>,
+    val createdAt: String,
+    val updatedAt: String,
+    @Transient val internalId: Int = 0,
+    @Transient val scheduleId: Int = 0,
+)
+
+@Serializable
+data class OnCallResponderResolution(
+    val userId: String,
+    val userName: String,
+    val userEmail: String,
+    @SerialName("scheduleId") val scheduleResourceId: String,
+    val layerId: String? = null,
+    val source: String,
+    val activeUntil: String? = null,
+    @Transient val internalUserId: Int = 0,
+)
+
+@Serializable
 data class OnCallParticipant(
     val id: String,
     @SerialName("userId") val userResourceId: String,
@@ -274,6 +305,7 @@ data class OnCallSchedule(
     val timezone: String,
     val participants: List<OnCallParticipant>,
     val overrides: List<OnCallOverride>,
+    val layers: List<OnCallScheduleLayer> = emptyList(),
     val currentOnCall: OnCallParticipant? = null,
     val slackUsergroupId: String? = null,
     val slackUsergroupHandle: String? = null,

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/models/OnCallModels.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/models/OnCallModels.kt
@@ -308,8 +308,6 @@ data class OnCallSchedule(
     val slackUsergroupHandle: String? = null,
     val createdAt: String,
     val updatedAt: String,
-    @Transient val internalId: Int = 0,
-    @Transient val organizationId: Int = 0,
 )
 
 // ===== On-Call Incidents (User Declared) =====

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/models/OnCallModels.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/models/OnCallModels.kt
@@ -251,8 +251,6 @@ data class OnCallScheduleLayer(
     val participants: List<OnCallParticipant>,
     val createdAt: String,
     val updatedAt: String,
-    @Transient val internalId: Int = 0,
-    @Transient val scheduleId: Int = 0,
 )
 
 @Serializable
@@ -264,7 +262,6 @@ data class OnCallResponderResolution(
     val layerId: String? = null,
     val source: String,
     val activeUntil: String? = null,
-    @Transient val internalUserId: Int = 0,
 )
 
 @Serializable

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/OnCallRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/OnCallRoutes.kt
@@ -9,9 +9,12 @@ import com.moneat.enterprise.oncall.overrideResourceId
 import com.moneat.enterprise.oncall.models.OnCallOverrides
 import com.moneat.enterprise.oncall.models.OnCallScheduleUsergroups
 import com.moneat.enterprise.oncall.services.OnCallScheduleService
+import com.moneat.enterprise.oncall.services.ScheduleLayerDefinition
+import com.moneat.enterprise.oncall.services.ScheduleLayerUpdate
 import com.moneat.shared.models.Memberships
 import com.moneat.shared.models.OnCallSchedules
 import com.moneat.shared.models.OnCallParticipants
+import com.moneat.shared.models.OnCallScheduleLayers
 import com.moneat.shared.models.Users
 import com.moneat.shared.services.toUuidOrNull
 import com.moneat.utils.ErrorResponse
@@ -38,6 +41,7 @@ import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.greater
 import org.jetbrains.exposed.v1.core.less
+import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
@@ -111,6 +115,30 @@ data class CreateOverrideRequest(
     val endAt: String, // ISO 8601 timestamp
 )
 
+@Serializable
+data class CreateScheduleLayerRequest(
+    val name: String,
+    val layerOrder: Int,
+    val rotationType: String,
+    val handoffTime: String,
+    val timezone: String,
+    val enabled: Boolean = true,
+    val explicitGap: Boolean = false,
+    val participants: List<ScheduleParticipant> = emptyList(),
+)
+
+@Serializable
+data class UpdateScheduleLayerRequest(
+    val name: String? = null,
+    val layerOrder: Int? = null,
+    val rotationType: String? = null,
+    val handoffTime: String? = null,
+    val timezone: String? = null,
+    val enabled: Boolean? = null,
+    val explicitGap: Boolean? = null,
+    val participants: List<ScheduleParticipant>? = null,
+)
+
 private data class TimelineParticipant(
     val userId: Int,
     val userResourceId: String,
@@ -144,6 +172,47 @@ fun Route.onCallRoutes(
 
                 val schedules = scheduleService.listSchedules(organizationId)
                 call.respond(schedules)
+            }
+
+            get("/responders") {
+                val principal = call.principal<JWTPrincipal>()
+                val organizationId = principal?.currentOrgIdOrNull()
+                if (organizationId == null) {
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    return@get
+                }
+                val rawScheduleIds =
+                    call.request.queryParameters.getAll("scheduleId")
+                        .orEmpty()
+                        .flatMap { it.split(',') }
+                        .map(String::trim)
+                        .filter(String::isNotEmpty)
+                if (rawScheduleIds.isEmpty()) {
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse("At least one scheduleId is required"))
+                    return@get
+                }
+                val scheduleResourceIds = rawScheduleIds.mapNotNull { it.toUuidOrNull() }
+                if (scheduleResourceIds.size != rawScheduleIds.size) {
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid schedule ID"))
+                    return@get
+                }
+                val scheduleIds =
+                    transaction {
+                        OnCallSchedules
+                            .selectAll()
+                            .where {
+                                (OnCallSchedules.organizationId eq organizationId) and
+                                    (OnCallSchedules.resourceId inList scheduleResourceIds)
+                            }
+                            .map { it[OnCallSchedules.id].value }
+                    }
+                val all = call.request.queryParameters["all"]?.toBooleanStrictOrNull() ?: true
+                val responders = scheduleService.resolveCurrentResponders(organizationId, scheduleIds, all = all)
+                if (responders.isEmpty()) {
+                    call.respond(HttpStatusCode.NotFound, ErrorResponse("No on-call responders found"))
+                } else {
+                    call.respond(responders)
+                }
             }
 
             post {
@@ -303,6 +372,141 @@ fun Route.onCallRoutes(
                     call.respond(currentOnCall)
                 } else {
                     call.respond(HttpStatusCode.NotFound, ErrorResponse("No on-call user found"))
+                }
+            }
+
+            get("/{id}/responders") {
+                val principal = call.principal<JWTPrincipal>()
+                val organizationId = principal?.currentOrgIdOrNull()
+                val scheduleId = call.resolveScheduleId(organizationId)
+
+                if (organizationId == null) {
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    return@get
+                }
+                if (scheduleId == null) return@get
+                if (!scheduleService.isScheduleInOrganization(scheduleId, organizationId)) {
+                    call.respond(HttpStatusCode.NotFound, ErrorResponse(SCHEDULE_NOT_FOUND_MESSAGE))
+                    return@get
+                }
+
+                val all = call.request.queryParameters["all"]?.toBooleanStrictOrNull() ?: true
+                val responders = scheduleService.resolveCurrentResponders(
+                    organizationId = organizationId,
+                    scheduleIds = listOf(scheduleId),
+                    all = all,
+                )
+                if (responders.isEmpty()) {
+                    call.respond(HttpStatusCode.NotFound, ErrorResponse("No on-call responders found"))
+                } else {
+                    call.respond(responders)
+                }
+            }
+
+            get("/{id}/layers") {
+                val principal = call.principal<JWTPrincipal>()
+                val organizationId = principal?.currentOrgIdOrNull()
+                val scheduleId = call.resolveScheduleId(organizationId)
+                if (organizationId == null) {
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    return@get
+                }
+                if (scheduleId == null) return@get
+                call.respond(scheduleService.listLayers(organizationId, scheduleId))
+            }
+
+            post("/{id}/layers") {
+                val principal = call.principal<JWTPrincipal>()
+                val organizationId = principal?.currentOrgIdOrNull()
+                val scheduleId = call.resolveScheduleId(organizationId)
+                if (organizationId == null) {
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    return@post
+                }
+                if (scheduleId == null) return@post
+                val request = call.receive<CreateScheduleLayerRequest>()
+                try {
+                    val layer =
+                        scheduleService.createLayer(
+                            organizationId = organizationId,
+                            scheduleId = scheduleId,
+                            definition =
+                                ScheduleLayerDefinition(
+                                    name = request.name,
+                                    layerOrder = request.layerOrder,
+                                    rotationType = request.rotationType,
+                                    handoffTime = LocalTime.parse(request.handoffTime),
+                                    timezone = request.timezone,
+                                    enabled = request.enabled,
+                                    explicitGap = request.explicitGap,
+                                    participantIds =
+                                        request.participants
+                                            .sortedBy { it.position }
+                                            .map { resolveOnCallUserId(organizationId, it.userId) },
+                                ),
+                        )
+                    call.respond(HttpStatusCode.Created, layer)
+                } catch (e: Exception) {
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(e.message))
+                }
+            }
+
+            put("/{id}/layers/{layerId}") {
+                val principal = call.principal<JWTPrincipal>()
+                val organizationId = principal?.currentOrgIdOrNull()
+                val scheduleId = call.resolveScheduleId(organizationId)
+                val layerId = call.resolveLayerId(organizationId, scheduleId)
+                if (organizationId == null) {
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    return@put
+                }
+                if (scheduleId == null || layerId == null) return@put
+                val request = call.receive<UpdateScheduleLayerRequest>()
+                try {
+                    val layer =
+                        scheduleService.updateLayer(
+                            organizationId = organizationId,
+                            scheduleId = scheduleId,
+                            layerId = layerId,
+                            update =
+                                ScheduleLayerUpdate(
+                                    name = request.name,
+                                    layerOrder = request.layerOrder,
+                                    rotationType = request.rotationType,
+                                    handoffTime = request.handoffTime?.let(LocalTime::parse),
+                                    timezone = request.timezone,
+                                    enabled = request.enabled,
+                                    explicitGap = request.explicitGap,
+                                    participantIds =
+                                        request.participants
+                                            ?.sortedBy { it.position }
+                                            ?.map { resolveOnCallUserId(organizationId, it.userId) },
+                                ),
+                        )
+                    if (layer == null) {
+                        call.respond(HttpStatusCode.NotFound, ErrorResponse("Layer not found"))
+                    } else {
+                        call.respond(layer)
+                    }
+                } catch (e: Exception) {
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(e.message))
+                }
+            }
+
+            delete("/{id}/layers/{layerId}") {
+                val principal = call.principal<JWTPrincipal>()
+                val organizationId = principal?.currentOrgIdOrNull()
+                val scheduleId = call.resolveScheduleId(organizationId)
+                val layerId = call.resolveLayerId(organizationId, scheduleId)
+                if (organizationId == null) {
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    return@delete
+                }
+                if (scheduleId == null || layerId == null) return@delete
+                if (scheduleService.deleteLayer(organizationId, scheduleId, layerId)) {
+                    call.respond(HttpStatusCode.NoContent)
+                } else {
+                    call.respond(HttpStatusCode.NotFound, ErrorResponse("Layer not found"))
                 }
             }
 
@@ -736,6 +940,35 @@ private suspend fun io.ktor.server.application.ApplicationCall.resolveScheduleId
         respond(HttpStatusCode.NotFound, ErrorResponse(SCHEDULE_NOT_FOUND_MESSAGE))
     }
     return scheduleId
+}
+
+private suspend fun io.ktor.server.application.ApplicationCall.resolveLayerId(
+    organizationId: Int?,
+    scheduleId: Int?,
+): Int? {
+    if (organizationId == null || scheduleId == null) return null
+    val resourceId = parameters["layerId"]?.toUuidOrNull()
+    if (resourceId == null) {
+        respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid layer ID"))
+        return null
+    }
+    val layerId =
+        transaction {
+            OnCallScheduleLayers
+                .selectAll()
+                .where {
+                    (OnCallScheduleLayers.organizationId eq organizationId) and
+                        (OnCallScheduleLayers.scheduleId eq scheduleId) and
+                        (OnCallScheduleLayers.resourceId eq resourceId)
+                }
+                .firstOrNull()
+                ?.get(OnCallScheduleLayers.id)
+                ?.value
+        }
+    if (layerId == null) {
+        respond(HttpStatusCode.NotFound, ErrorResponse("Layer not found"))
+    }
+    return layerId
 }
 
 private suspend fun io.ktor.server.application.ApplicationCall.resolveOverrideId(organizationId: Int?): Int? {

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/OnCallRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/OnCallRoutes.kt
@@ -57,8 +57,10 @@ import kotlin.time.Instant
 import kotlin.uuid.Uuid
 
 private const val WEEKLY_ROTATION_DAYS = 7L
+private const val INVALID_TOKEN_MESSAGE = "Invalid token"
 private const val SCHEDULE_NOT_FOUND_MESSAGE = "Schedule not found"
 private const val OVERRIDE_NOT_FOUND_MESSAGE = "Override not found"
+private const val LAYER_NOT_FOUND_MESSAGE = "Layer not found"
 
 @Serializable
 data class ScheduleTimelineEntry(
@@ -166,7 +168,7 @@ fun Route.onCallRoutes(
                 val organizationId = principal?.currentOrgIdOrNull()
 
                 if (organizationId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
                     return@get
                 }
 
@@ -178,7 +180,7 @@ fun Route.onCallRoutes(
                 val principal = call.principal<JWTPrincipal>()
                 val organizationId = principal?.currentOrgIdOrNull()
                 if (organizationId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
                     return@get
                 }
                 val rawScheduleIds =
@@ -220,7 +222,7 @@ fun Route.onCallRoutes(
                 val organizationId = principal?.currentOrgIdOrNull()
 
                 if (organizationId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
                     return@post
                 }
 
@@ -253,7 +255,7 @@ fun Route.onCallRoutes(
                 val scheduleId = call.resolveScheduleId(organizationId)
 
                 if (organizationId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
                     return@get
                 }
 
@@ -280,7 +282,7 @@ fun Route.onCallRoutes(
                 val scheduleId = call.resolveScheduleId(organizationId)
 
                 if (organizationId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
                     return@put
                 }
 
@@ -327,7 +329,7 @@ fun Route.onCallRoutes(
                 val scheduleId = call.resolveScheduleId(organizationId)
 
                 if (organizationId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
                     return@delete
                 }
 
@@ -354,7 +356,7 @@ fun Route.onCallRoutes(
                 val scheduleId = call.resolveScheduleId(organizationId)
 
                 if (organizationId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
                     return@get
                 }
 
@@ -381,7 +383,7 @@ fun Route.onCallRoutes(
                 val scheduleId = call.resolveScheduleId(organizationId)
 
                 if (organizationId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
                     return@get
                 }
                 if (scheduleId == null) return@get
@@ -408,7 +410,7 @@ fun Route.onCallRoutes(
                 val organizationId = principal?.currentOrgIdOrNull()
                 val scheduleId = call.resolveScheduleId(organizationId)
                 if (organizationId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
                     return@get
                 }
                 if (scheduleId == null) return@get
@@ -420,7 +422,7 @@ fun Route.onCallRoutes(
                 val organizationId = principal?.currentOrgIdOrNull()
                 val scheduleId = call.resolveScheduleId(organizationId)
                 if (organizationId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
                     return@post
                 }
                 if (scheduleId == null) return@post
@@ -457,7 +459,7 @@ fun Route.onCallRoutes(
                 val scheduleId = call.resolveScheduleId(organizationId)
                 val layerId = call.resolveLayerId(organizationId, scheduleId)
                 if (organizationId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
                     return@put
                 }
                 if (scheduleId == null || layerId == null) return@put
@@ -484,7 +486,7 @@ fun Route.onCallRoutes(
                                 ),
                         )
                     if (layer == null) {
-                        call.respond(HttpStatusCode.NotFound, ErrorResponse("Layer not found"))
+                        call.respond(HttpStatusCode.NotFound, ErrorResponse(LAYER_NOT_FOUND_MESSAGE))
                     } else {
                         call.respond(layer)
                     }
@@ -499,14 +501,14 @@ fun Route.onCallRoutes(
                 val scheduleId = call.resolveScheduleId(organizationId)
                 val layerId = call.resolveLayerId(organizationId, scheduleId)
                 if (organizationId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
                     return@delete
                 }
                 if (scheduleId == null || layerId == null) return@delete
                 if (scheduleService.deleteLayer(organizationId, scheduleId, layerId)) {
                     call.respond(HttpStatusCode.NoContent)
                 } else {
-                    call.respond(HttpStatusCode.NotFound, ErrorResponse("Layer not found"))
+                    call.respond(HttpStatusCode.NotFound, ErrorResponse(LAYER_NOT_FOUND_MESSAGE))
                 }
             }
 
@@ -518,7 +520,7 @@ fun Route.onCallRoutes(
                 val endParam = call.request.queryParameters["end"]
 
                 if (organizationId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
                     return@get
                 }
                 if (scheduleId == null) {
@@ -557,7 +559,7 @@ fun Route.onCallRoutes(
                 val scheduleId = call.resolveScheduleId(organizationId)
 
                 if (organizationId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
                     return@post
                 }
 
@@ -566,7 +568,7 @@ fun Route.onCallRoutes(
                 }
 
                 if (userId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
                     return@post
                 }
 
@@ -618,7 +620,7 @@ fun Route.onCallRoutes(
                 val overrideId = call.resolveOverrideId(organizationId)
 
                 if (organizationId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
                     return@delete
                 }
 
@@ -651,7 +653,7 @@ fun Route.onCallRoutes(
                 val scheduleId = call.resolveScheduleId(organizationId)
 
                 if (organizationId == null || userId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
                     return@put
                 }
 
@@ -717,7 +719,7 @@ fun Route.onCallRoutes(
                 val scheduleId = call.resolveScheduleId(organizationId)
 
                 if (organizationId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
                     return@delete
                 }
 
@@ -966,7 +968,7 @@ private suspend fun io.ktor.server.application.ApplicationCall.resolveLayerId(
                 ?.value
         }
     if (layerId == null) {
-        respond(HttpStatusCode.NotFound, ErrorResponse("Layer not found"))
+        respond(HttpStatusCode.NotFound, ErrorResponse(LAYER_NOT_FOUND_MESSAGE))
     }
     return layerId
 }

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/OnCallScheduleService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/OnCallScheduleService.kt
@@ -283,7 +283,7 @@ class OnCallScheduleService {
                             (OnCallSchedules.organizationId eq organizationId)
                     }
                     .singleOrNull() ?: return@transaction null
-            val layer =
+            if (
                 OnCallScheduleLayers
                     .selectAll()
                     .where {
@@ -291,7 +291,10 @@ class OnCallScheduleService {
                             (OnCallScheduleLayers.scheduleId eq scheduleId) and
                             (OnCallScheduleLayers.organizationId eq organizationId)
                     }
-                    .singleOrNull() ?: return@transaction null
+                    .singleOrNull() == null
+            ) {
+                return@transaction null
+            }
             if (update.layerOrder != null) require(update.layerOrder >= 0) { "Layer order must be non-negative" }
             update.timezone?.let { ZoneId.of(it) }
             val now = Clock.System.now()

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/OnCallScheduleService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/OnCallScheduleService.kt
@@ -205,8 +205,6 @@ class OnCallScheduleService {
             slackUsergroupHandle = usergroupMapping?.get(OnCallScheduleUsergroups.slackUsergroupHandle),
             createdAt = scheduleRow[OnCallSchedules.createdAt].toString(),
             updatedAt = scheduleRow[OnCallSchedules.updatedAt].toString(),
-            internalId = scheduleRow[OnCallSchedules.id].value,
-            organizationId = scheduleRow[OnCallSchedules.organizationId],
         )
     }
 
@@ -304,7 +302,7 @@ class OnCallScheduleService {
                             (OnCallSchedules.organizationId eq organizationId)
                     }
                     .singleOrNull() ?: return@transaction null
-            if (
+            val existingLayerId =
                 OnCallScheduleLayers
                     .selectAll()
                     .where {
@@ -312,8 +310,9 @@ class OnCallScheduleService {
                             (OnCallScheduleLayers.scheduleId eq scheduleId) and
                             (OnCallScheduleLayers.organizationId eq organizationId)
                     }
-                    .singleOrNull() == null
-            ) {
+                    .singleOrNull()
+                    ?.get(OnCallScheduleLayers.id)
+            if (existingLayerId == null) {
                 return@transaction null
             }
             if (update.layerOrder != null) require(update.layerOrder >= 0) { "Layer order must be non-negative" }

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/OnCallScheduleService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/OnCallScheduleService.kt
@@ -99,10 +99,27 @@ class OnCallScheduleService {
 
             if (scheduleIds.isEmpty()) return@transaction 0
 
-            OnCallParticipants
-                .selectAll()
-                .where { OnCallParticipants.scheduleId inList scheduleIds }
-                .map { it[OnCallParticipants.userId] }
+            val participantUserIds =
+                OnCallParticipants
+                    .selectAll()
+                    .where { OnCallParticipants.scheduleId inList scheduleIds }
+                    .map { it[OnCallParticipants.userId] }
+            val layerIds =
+                OnCallScheduleLayers
+                    .selectAll()
+                    .where { OnCallScheduleLayers.scheduleId inList scheduleIds }
+                    .map { it[OnCallScheduleLayers.id].value }
+            val layerUserIds =
+                if (layerIds.isEmpty()) {
+                    emptyList()
+                } else {
+                    OnCallScheduleLayerParticipants
+                        .selectAll()
+                        .where { OnCallScheduleLayerParticipants.layerId inList layerIds }
+                        .map { it[OnCallScheduleLayerParticipants.userId] }
+                }
+
+            (participantUserIds + layerUserIds)
                 .distinct()
                 .count()
         }
@@ -265,6 +282,7 @@ class OnCallScheduleService {
                     .singleOrNull() ?: throw IllegalArgumentException("Schedule not found")
             ZoneId.of(definition.timezone)
             require(definition.layerOrder >= 0) { "Layer order must be non-negative" }
+            checkSeatLimit(organizationId, definition.participantIds)
             val now = Clock.System.now()
             val layerId =
                 OnCallScheduleLayers
@@ -329,6 +347,11 @@ class OnCallScheduleService {
                 it[OnCallScheduleLayers.updatedAt] = now
             }
             if (update.participantIds != null) {
+                checkSeatLimit(
+                    organizationId = organizationId,
+                    newParticipantUserIds = update.participantIds,
+                    layerIdToExclude = layerId,
+                )
                 OnCallScheduleLayerParticipants.deleteWhere {
                     OnCallScheduleLayerParticipants.layerId eq layerId
                 }
@@ -831,6 +854,7 @@ class OnCallScheduleService {
         organizationId: Int,
         newParticipantUserIds: List<Int>,
         scheduleIdToExclude: Int? = null,
+        layerIdToExclude: Int? = null,
     ) {
         val sub =
             Subscriptions
@@ -850,7 +874,7 @@ class OnCallScheduleService {
                 .map { it[OnCallSchedules.id].value }
                 .filter { it != scheduleIdToExclude }
 
-        val existingUsers =
+        val existingScheduleUsers =
             if (scheduleIds.isEmpty()) {
                 emptySet()
             } else {
@@ -861,7 +885,28 @@ class OnCallScheduleService {
                     .toSet()
             }
 
-        val allUsers = existingUsers + newParticipantUserIds
+        val layerIds =
+            if (scheduleIds.isEmpty()) {
+                emptyList()
+            } else {
+                OnCallScheduleLayers
+                    .selectAll()
+                    .where { OnCallScheduleLayers.scheduleId inList scheduleIds }
+                    .map { it[OnCallScheduleLayers.id].value }
+                    .filter { it != layerIdToExclude }
+            }
+        val existingLayerUsers =
+            if (layerIds.isEmpty()) {
+                emptySet()
+            } else {
+                OnCallScheduleLayerParticipants
+                    .selectAll()
+                    .where { OnCallScheduleLayerParticipants.layerId inList layerIds }
+                    .map { it[OnCallScheduleLayerParticipants.userId] }
+                    .toSet()
+            }
+
+        val allUsers = existingScheduleUsers + existingLayerUsers + newParticipantUserIds
         val neededSeats = allUsers.size
 
         if (neededSeats > seatsPurchased) {

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/OnCallScheduleService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/OnCallScheduleService.kt
@@ -68,6 +68,26 @@ data class ScheduleLayerUpdate(
     val participantIds: List<Int>? = null,
 )
 
+private data class ScheduleLayerRecord(
+    val model: OnCallScheduleLayer,
+    val internalId: Int,
+)
+
+internal data class ResolvedResponder(
+    val model: OnCallResponderResolution,
+    val internalUserId: Int,
+) {
+    fun asParticipant(): OnCallParticipant =
+        OnCallParticipant(
+            id = model.userId,
+            userResourceId = model.userId,
+            userName = model.userName,
+            userEmail = model.userEmail,
+            position = -1,
+            userId = internalUserId,
+        )
+}
+
 class OnCallScheduleService {
     fun getOnCallUsedSeats(organizationId: Int): Int =
         transaction {
@@ -161,7 +181,7 @@ class OnCallScheduleService {
                 schedule = scheduleRow,
                 at = Clock.System.now(),
             ).firstOrNull()?.asParticipant()
-        val layers = layersForSchedule(scheduleId, scheduleResourceId)
+        val layers = layersForSchedule(scheduleId, scheduleResourceId).map { it.model }
 
         // Fetch Slack usergroup mapping if it exists
         val usergroupMapping =
@@ -228,7 +248,7 @@ class OnCallScheduleService {
                             (OnCallSchedules.organizationId eq organizationId)
                     }
                     .singleOrNull() ?: return@transaction emptyList()
-            layersForSchedule(scheduleId, schedule[OnCallSchedules.resourceId].toString())
+            layersForSchedule(scheduleId, schedule[OnCallSchedules.resourceId].toString()).map { it.model }
         }
 
     fun createLayer(
@@ -266,6 +286,7 @@ class OnCallScheduleService {
             insertLayerParticipants(layerId, organizationId, definition.participantIds, now)
             layersForSchedule(scheduleId, schedule[OnCallSchedules.resourceId].toString())
                 .single { it.internalId == layerId }
+                .model
         }
 
     fun updateLayer(
@@ -316,6 +337,7 @@ class OnCallScheduleService {
             }
             layersForSchedule(scheduleId, schedule[OnCallSchedules.resourceId].toString())
                 .single { it.internalId == layerId }
+                .model
         }
 
     fun deleteLayer(
@@ -351,7 +373,7 @@ class OnCallScheduleService {
     private fun layersForSchedule(
         scheduleId: Int,
         scheduleResourceId: String,
-    ): List<OnCallScheduleLayer> =
+    ): List<ScheduleLayerRecord> =
         OnCallScheduleLayers
             .selectAll()
             .where { OnCallScheduleLayers.scheduleId eq scheduleId }
@@ -374,21 +396,23 @@ class OnCallScheduleService {
                                 userId = row[OnCallScheduleLayerParticipants.userId],
                             )
                         }
-                OnCallScheduleLayer(
-                    id = layer[OnCallScheduleLayers.resourceId].toString(),
-                    scheduleResourceId = scheduleResourceId,
-                    name = layer[OnCallScheduleLayers.name],
-                    layerOrder = layer[OnCallScheduleLayers.layerOrder],
-                    rotationType = layer[OnCallScheduleLayers.rotationType],
-                    handoffTime = layer[OnCallScheduleLayers.handoffTime],
-                    timezone = layer[OnCallScheduleLayers.timezone],
-                    enabled = layer[OnCallScheduleLayers.enabled],
-                    explicitGap = layer[OnCallScheduleLayers.explicitGap],
-                    participants = participants,
-                    createdAt = layer[OnCallScheduleLayers.createdAt].toString(),
-                    updatedAt = layer[OnCallScheduleLayers.updatedAt].toString(),
+                ScheduleLayerRecord(
+                    model =
+                        OnCallScheduleLayer(
+                            id = layer[OnCallScheduleLayers.resourceId].toString(),
+                            scheduleResourceId = scheduleResourceId,
+                            name = layer[OnCallScheduleLayers.name],
+                            layerOrder = layer[OnCallScheduleLayers.layerOrder],
+                            rotationType = layer[OnCallScheduleLayers.rotationType],
+                            handoffTime = layer[OnCallScheduleLayers.handoffTime],
+                            timezone = layer[OnCallScheduleLayers.timezone],
+                            enabled = layer[OnCallScheduleLayers.enabled],
+                            explicitGap = layer[OnCallScheduleLayers.explicitGap],
+                            participants = participants,
+                            createdAt = layer[OnCallScheduleLayers.createdAt].toString(),
+                            updatedAt = layer[OnCallScheduleLayers.updatedAt].toString(),
+                        ),
                     internalId = layer[OnCallScheduleLayers.id].value,
-                    scheduleId = layer[OnCallScheduleLayers.scheduleId],
                 )
             }
 
@@ -397,7 +421,15 @@ class OnCallScheduleService {
         scheduleIds: Collection<Int>,
         at: Instant = Clock.System.now(),
         all: Boolean = true,
-    ): List<OnCallResponderResolution> = transaction {
+    ): List<OnCallResponderResolution> =
+        resolveCurrentResponderRecords(organizationId, scheduleIds, at, all).map { it.model }
+
+    internal fun resolveCurrentResponderRecords(
+        organizationId: Int,
+        scheduleIds: Collection<Int>,
+        at: Instant = Clock.System.now(),
+        all: Boolean = true,
+    ): List<ResolvedResponder> = transaction {
         if (scheduleIds.isEmpty()) return@transaction emptyList()
         val schedules =
             OnCallSchedules
@@ -408,7 +440,7 @@ class OnCallScheduleService {
                 }
                 .orderBy(OnCallSchedules.id to SortOrder.ASC)
                 .toList()
-        val resolved = linkedMapOf<Int, OnCallResponderResolution>()
+        val resolved = linkedMapOf<Int, ResolvedResponder>()
         schedules.forEach { schedule ->
             resolveScheduleResponders(organizationId, schedule, at).forEach { response ->
                 resolved.putIfAbsent(response.internalUserId, response)
@@ -422,7 +454,7 @@ class OnCallScheduleService {
         organizationId: Int,
         schedule: ResultRow,
         at: Instant,
-    ): List<OnCallResponderResolution> {
+    ): List<ResolvedResponder> {
         val scheduleId = schedule[OnCallSchedules.id].value
         val scheduleResourceId = schedule[OnCallSchedules.resourceId].toString()
         val override =
@@ -439,13 +471,16 @@ class OnCallScheduleService {
                 .singleOrNull()
         if (override != null) {
             return listOf(
-                OnCallResponderResolution(
-                    userId = override[Users.resource_id].toString(),
-                    userName = override[Users.name] ?: override[Users.email],
-                    userEmail = override[Users.email],
-                    scheduleResourceId = scheduleResourceId,
-                    source = "OVERRIDE",
-                    activeUntil = override[OnCallOverrides.endAt].toString(),
+                ResolvedResponder(
+                    model =
+                        OnCallResponderResolution(
+                            userId = override[Users.resource_id].toString(),
+                            userName = override[Users.name] ?: override[Users.email],
+                            userEmail = override[Users.email],
+                            scheduleResourceId = scheduleResourceId,
+                            source = "OVERRIDE",
+                            activeUntil = override[OnCallOverrides.endAt].toString(),
+                        ),
                     internalUserId = override[OnCallOverrides.userId],
                 ),
             )
@@ -469,12 +504,15 @@ class OnCallScheduleService {
 
         return computeOnCallAt(scheduleId, at)?.let { participant ->
             listOf(
-                OnCallResponderResolution(
-                    userId = participant.userResourceId,
-                    userName = participant.userName,
-                    userEmail = participant.userEmail,
-                    scheduleResourceId = scheduleResourceId,
-                    source = "ROTATION",
+                ResolvedResponder(
+                    model =
+                        OnCallResponderResolution(
+                            userId = participant.userResourceId,
+                            userName = participant.userName,
+                            userEmail = participant.userEmail,
+                            scheduleResourceId = scheduleResourceId,
+                            source = "ROTATION",
+                        ),
                     internalUserId = participant.userId,
                 ),
             )
@@ -485,7 +523,7 @@ class OnCallScheduleService {
         layer: ResultRow,
         scheduleResourceId: String,
         at: Instant,
-    ): List<OnCallResponderResolution> {
+    ): List<ResolvedResponder> {
         val participants =
             OnCallScheduleLayerParticipants
                 .innerJoin(Users)
@@ -506,27 +544,20 @@ class OnCallScheduleService {
             ) ?: return emptyList()
         val participant = participants.getOrNull(index) ?: return emptyList()
         return listOf(
-            OnCallResponderResolution(
-                userId = participant[Users.resource_id].toString(),
-                userName = participant[Users.name] ?: participant[Users.email],
-                userEmail = participant[Users.email],
-                scheduleResourceId = scheduleResourceId,
-                layerId = layer[OnCallScheduleLayers.resourceId].toString(),
-                source = "LAYER",
+            ResolvedResponder(
+                model =
+                    OnCallResponderResolution(
+                        userId = participant[Users.resource_id].toString(),
+                        userName = participant[Users.name] ?: participant[Users.email],
+                        userEmail = participant[Users.email],
+                        scheduleResourceId = scheduleResourceId,
+                        layerId = layer[OnCallScheduleLayers.resourceId].toString(),
+                        source = "LAYER",
+                    ),
                 internalUserId = participant[OnCallScheduleLayerParticipants.userId],
             ),
         )
     }
-
-    private fun OnCallResponderResolution.asParticipant(): OnCallParticipant =
-        OnCallParticipant(
-            id = userId,
-            userResourceId = userId,
-            userName = userName,
-            userEmail = userEmail,
-            position = -1,
-            userId = internalUserId,
-        )
 
     // Extracted so both getCurrentOnCall and getOnCallAt share logic within an open transaction
     private fun computeOnCallAt(scheduleId: Int, now: Instant): OnCallParticipant? {

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/OnCallScheduleService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/OnCallScheduleService.kt
@@ -14,9 +14,13 @@ import com.moneat.enterprise.oncall.models.OnCallOverride
 import com.moneat.enterprise.oncall.models.OnCallOverrides
 import com.moneat.enterprise.oncall.models.OnCallParticipant
 import com.moneat.enterprise.oncall.models.OnCallSchedule
+import com.moneat.enterprise.oncall.models.OnCallScheduleLayer
 import com.moneat.enterprise.oncall.models.OnCallScheduleUsergroups
+import com.moneat.enterprise.oncall.models.OnCallResponderResolution
 import com.moneat.shared.models.OnCallParticipants
 import com.moneat.shared.models.OnCallSchedules
+import com.moneat.shared.models.OnCallScheduleLayers
+import com.moneat.shared.models.OnCallScheduleLayerParticipants
 import com.moneat.shared.models.Subscriptions
 import com.moneat.shared.models.Users
 import org.jetbrains.exposed.v1.core.JoinType
@@ -41,6 +45,28 @@ import kotlin.time.Clock
 import kotlin.time.Instant
 
 private const val WEEKLY_ROTATION_DAYS = 7
+
+data class ScheduleLayerDefinition(
+    val name: String,
+    val layerOrder: Int,
+    val rotationType: String,
+    val handoffTime: LocalTime,
+    val timezone: String,
+    val enabled: Boolean,
+    val explicitGap: Boolean,
+    val participantIds: List<Int>,
+)
+
+data class ScheduleLayerUpdate(
+    val name: String? = null,
+    val layerOrder: Int? = null,
+    val rotationType: String? = null,
+    val handoffTime: LocalTime? = null,
+    val timezone: String? = null,
+    val enabled: Boolean? = null,
+    val explicitGap: Boolean? = null,
+    val participantIds: List<Int>? = null,
+)
 
 class OnCallScheduleService {
     fun getOnCallUsedSeats(organizationId: Int): Int =
@@ -129,7 +155,13 @@ class OnCallScheduleService {
                     )
                 }
 
-        val currentOnCall = computeOnCallAt(scheduleId, Clock.System.now())
+        val currentOnCall =
+            resolveScheduleResponders(
+                organizationId = scheduleRow[OnCallSchedules.organizationId],
+                schedule = scheduleRow,
+                at = Clock.System.now(),
+            ).firstOrNull()?.asParticipant()
+        val layers = layersForSchedule(scheduleId, scheduleResourceId)
 
         // Fetch Slack usergroup mapping if it exists
         val usergroupMapping =
@@ -147,6 +179,7 @@ class OnCallScheduleService {
             timezone = scheduleRow[OnCallSchedules.timezone],
             participants = participantResponses,
             overrides = overrides,
+            layers = layers,
             currentOnCall = currentOnCall,
             slackUsergroupId = usergroupMapping?.get(OnCallScheduleUsergroups.slackUsergroupId),
             slackUsergroupHandle = usergroupMapping?.get(OnCallScheduleUsergroups.slackUsergroupHandle),
@@ -157,13 +190,340 @@ class OnCallScheduleService {
         )
     }
 
-    fun getOnCallAt(scheduleId: Int, at: Instant): OnCallParticipant? = transaction { computeOnCallAt(scheduleId, at) }
+    fun getOnCallAt(scheduleId: Int, at: Instant): OnCallParticipant? =
+        transaction {
+            val schedule =
+                OnCallSchedules
+                    .selectAll()
+                    .where { OnCallSchedules.id eq scheduleId }
+                    .singleOrNull() ?: return@transaction null
+            resolveScheduleResponders(schedule[OnCallSchedules.organizationId], schedule, at)
+                .firstOrNull()
+                ?.asParticipant()
+        }
 
     fun getCurrentOnCall(scheduleId: Int): OnCallParticipant? =
         transaction {
             val now = Clock.System.now()
-            computeOnCallAt(scheduleId, now)
+            val schedule =
+                OnCallSchedules
+                    .selectAll()
+                    .where { OnCallSchedules.id eq scheduleId }
+                    .singleOrNull() ?: return@transaction null
+            resolveScheduleResponders(schedule[OnCallSchedules.organizationId], schedule, now)
+                .firstOrNull()
+                ?.asParticipant()
         }
+
+    fun listLayers(
+        organizationId: Int,
+        scheduleId: Int,
+    ): List<OnCallScheduleLayer> =
+        transaction {
+            val schedule =
+                OnCallSchedules
+                    .selectAll()
+                    .where {
+                        (OnCallSchedules.id eq scheduleId) and
+                            (OnCallSchedules.organizationId eq organizationId)
+                    }
+                    .singleOrNull() ?: return@transaction emptyList()
+            layersForSchedule(scheduleId, schedule[OnCallSchedules.resourceId].toString())
+        }
+
+    fun createLayer(
+        organizationId: Int,
+        scheduleId: Int,
+        definition: ScheduleLayerDefinition,
+    ): OnCallScheduleLayer =
+        transaction {
+            val schedule =
+                OnCallSchedules
+                    .selectAll()
+                    .where {
+                        (OnCallSchedules.id eq scheduleId) and
+                            (OnCallSchedules.organizationId eq organizationId)
+                    }
+                    .singleOrNull() ?: throw IllegalArgumentException("Schedule not found")
+            ZoneId.of(definition.timezone)
+            require(definition.layerOrder >= 0) { "Layer order must be non-negative" }
+            val now = Clock.System.now()
+            val layerId =
+                OnCallScheduleLayers
+                    .insertAndGetId {
+                        it[OnCallScheduleLayers.organizationId] = organizationId
+                        it[OnCallScheduleLayers.scheduleId] = scheduleId
+                        it[OnCallScheduleLayers.name] = definition.name
+                        it[OnCallScheduleLayers.layerOrder] = definition.layerOrder
+                        it[OnCallScheduleLayers.rotationType] = definition.rotationType
+                        it[OnCallScheduleLayers.handoffTime] = definition.handoffTime
+                        it[OnCallScheduleLayers.timezone] = definition.timezone
+                        it[OnCallScheduleLayers.enabled] = definition.enabled
+                        it[OnCallScheduleLayers.explicitGap] = definition.explicitGap
+                        it[OnCallScheduleLayers.createdAt] = now
+                        it[OnCallScheduleLayers.updatedAt] = now
+                    }.value
+            insertLayerParticipants(layerId, organizationId, definition.participantIds, now)
+            layersForSchedule(scheduleId, schedule[OnCallSchedules.resourceId].toString())
+                .single { it.internalId == layerId }
+        }
+
+    fun updateLayer(
+        organizationId: Int,
+        scheduleId: Int,
+        layerId: Int,
+        update: ScheduleLayerUpdate,
+    ): OnCallScheduleLayer? =
+        transaction {
+            val schedule =
+                OnCallSchedules
+                    .selectAll()
+                    .where {
+                        (OnCallSchedules.id eq scheduleId) and
+                            (OnCallSchedules.organizationId eq organizationId)
+                    }
+                    .singleOrNull() ?: return@transaction null
+            val layer =
+                OnCallScheduleLayers
+                    .selectAll()
+                    .where {
+                        (OnCallScheduleLayers.id eq layerId) and
+                            (OnCallScheduleLayers.scheduleId eq scheduleId) and
+                            (OnCallScheduleLayers.organizationId eq organizationId)
+                    }
+                    .singleOrNull() ?: return@transaction null
+            if (update.layerOrder != null) require(update.layerOrder >= 0) { "Layer order must be non-negative" }
+            update.timezone?.let { ZoneId.of(it) }
+            val now = Clock.System.now()
+            OnCallScheduleLayers.update({ OnCallScheduleLayers.id eq layerId }) {
+                update.name?.let { value -> it[OnCallScheduleLayers.name] = value }
+                update.layerOrder?.let { value -> it[OnCallScheduleLayers.layerOrder] = value }
+                update.rotationType?.let { value -> it[OnCallScheduleLayers.rotationType] = value }
+                update.handoffTime?.let { value -> it[OnCallScheduleLayers.handoffTime] = value }
+                update.timezone?.let { value -> it[OnCallScheduleLayers.timezone] = value }
+                update.enabled?.let { value -> it[OnCallScheduleLayers.enabled] = value }
+                update.explicitGap?.let { value -> it[OnCallScheduleLayers.explicitGap] = value }
+                it[OnCallScheduleLayers.updatedAt] = now
+            }
+            if (update.participantIds != null) {
+                OnCallScheduleLayerParticipants.deleteWhere {
+                    OnCallScheduleLayerParticipants.layerId eq layerId
+                }
+                insertLayerParticipants(layerId, organizationId, update.participantIds, now)
+            }
+            layersForSchedule(scheduleId, schedule[OnCallSchedules.resourceId].toString())
+                .single { it.internalId == layerId }
+        }
+
+    fun deleteLayer(
+        organizationId: Int,
+        scheduleId: Int,
+        layerId: Int,
+    ): Boolean =
+        transaction {
+            OnCallScheduleLayers.deleteWhere {
+                (OnCallScheduleLayers.id eq layerId) and
+                    (OnCallScheduleLayers.scheduleId eq scheduleId) and
+                    (OnCallScheduleLayers.organizationId eq organizationId)
+            } > 0
+        }
+
+    private fun insertLayerParticipants(
+        layerId: Int,
+        organizationId: Int,
+        participantIds: List<Int>,
+        now: Instant,
+    ) {
+        participantIds.forEachIndexed { index, userId ->
+            OnCallScheduleLayerParticipants.insert {
+                it[OnCallScheduleLayerParticipants.organizationId] = organizationId
+                it[OnCallScheduleLayerParticipants.layerId] = layerId
+                it[OnCallScheduleLayerParticipants.userId] = userId
+                it[OnCallScheduleLayerParticipants.position] = index
+                it[OnCallScheduleLayerParticipants.createdAt] = now
+            }
+        }
+    }
+
+    private fun layersForSchedule(
+        scheduleId: Int,
+        scheduleResourceId: String,
+    ): List<OnCallScheduleLayer> =
+        OnCallScheduleLayers
+            .selectAll()
+            .where { OnCallScheduleLayers.scheduleId eq scheduleId }
+            .orderBy(OnCallScheduleLayers.layerOrder to SortOrder.ASC)
+            .map { layer ->
+                val participants =
+                    OnCallScheduleLayerParticipants
+                        .innerJoin(Users)
+                        .selectAll()
+                        .where { OnCallScheduleLayerParticipants.layerId eq layer[OnCallScheduleLayers.id].value }
+                        .orderBy(OnCallScheduleLayerParticipants.position to SortOrder.ASC)
+                        .map { row ->
+                            OnCallParticipant(
+                                id = row[OnCallScheduleLayerParticipants.resourceId].toString(),
+                                userResourceId = row[Users.resource_id].toString(),
+                                userName = row[Users.name] ?: row[Users.email],
+                                userEmail = row[Users.email],
+                                position = row[OnCallScheduleLayerParticipants.position],
+                                internalId = row[OnCallScheduleLayerParticipants.id].value,
+                                userId = row[OnCallScheduleLayerParticipants.userId],
+                            )
+                        }
+                OnCallScheduleLayer(
+                    id = layer[OnCallScheduleLayers.resourceId].toString(),
+                    scheduleResourceId = scheduleResourceId,
+                    name = layer[OnCallScheduleLayers.name],
+                    layerOrder = layer[OnCallScheduleLayers.layerOrder],
+                    rotationType = layer[OnCallScheduleLayers.rotationType],
+                    handoffTime = layer[OnCallScheduleLayers.handoffTime],
+                    timezone = layer[OnCallScheduleLayers.timezone],
+                    enabled = layer[OnCallScheduleLayers.enabled],
+                    explicitGap = layer[OnCallScheduleLayers.explicitGap],
+                    participants = participants,
+                    createdAt = layer[OnCallScheduleLayers.createdAt].toString(),
+                    updatedAt = layer[OnCallScheduleLayers.updatedAt].toString(),
+                    internalId = layer[OnCallScheduleLayers.id].value,
+                    scheduleId = layer[OnCallScheduleLayers.scheduleId],
+                )
+            }
+
+    fun resolveCurrentResponders(
+        organizationId: Int,
+        scheduleIds: Collection<Int>,
+        at: Instant = Clock.System.now(),
+        all: Boolean = true,
+    ): List<OnCallResponderResolution> = transaction {
+        if (scheduleIds.isEmpty()) return@transaction emptyList()
+        val schedules =
+            OnCallSchedules
+                .selectAll()
+                .where {
+                    (OnCallSchedules.organizationId eq organizationId) and
+                        (OnCallSchedules.id inList scheduleIds.distinct())
+                }
+                .orderBy(OnCallSchedules.id to SortOrder.ASC)
+                .toList()
+        val resolved = linkedMapOf<Int, OnCallResponderResolution>()
+        schedules.forEach { schedule ->
+            resolveScheduleResponders(organizationId, schedule, at).forEach { response ->
+                resolved.putIfAbsent(response.internalUserId, response)
+            }
+            if (!all && resolved.isNotEmpty()) return@transaction resolved.values.take(1)
+        }
+        resolved.values.toList()
+    }
+
+    private fun resolveScheduleResponders(
+        organizationId: Int,
+        schedule: ResultRow,
+        at: Instant,
+    ): List<OnCallResponderResolution> {
+        val scheduleId = schedule[OnCallSchedules.id].value
+        val scheduleResourceId = schedule[OnCallSchedules.resourceId].toString()
+        val override =
+            OnCallOverrides
+                .join(Users, JoinType.INNER, onColumn = OnCallOverrides.userId, otherColumn = Users.id)
+                .selectAll()
+                .where {
+                    (OnCallOverrides.scheduleId eq scheduleId) and
+                        (OnCallOverrides.startAt lessEq at) and
+                        (OnCallOverrides.endAt greater at)
+                }
+                .orderBy(OnCallOverrides.startAt to SortOrder.DESC)
+                .limit(1)
+                .singleOrNull()
+        if (override != null) {
+            return listOf(
+                OnCallResponderResolution(
+                    userId = override[Users.resource_id].toString(),
+                    userName = override[Users.name] ?: override[Users.email],
+                    userEmail = override[Users.email],
+                    scheduleResourceId = scheduleResourceId,
+                    source = "OVERRIDE",
+                    activeUntil = override[OnCallOverrides.endAt].toString(),
+                    internalUserId = override[OnCallOverrides.userId],
+                ),
+            )
+        }
+
+        val layers =
+            OnCallScheduleLayers
+                .selectAll()
+                .where {
+                    (OnCallScheduleLayers.organizationId eq organizationId) and
+                        (OnCallScheduleLayers.scheduleId eq scheduleId) and
+                        (OnCallScheduleLayers.enabled eq true)
+                }
+                .orderBy(OnCallScheduleLayers.layerOrder to SortOrder.ASC)
+                .toList()
+        if (layers.isNotEmpty()) {
+            return layers.flatMap { layer ->
+                resolveLayerParticipant(layer, scheduleResourceId, at)
+            }
+        }
+
+        return computeOnCallAt(scheduleId, at)?.let { participant ->
+            listOf(
+                OnCallResponderResolution(
+                    userId = participant.userResourceId,
+                    userName = participant.userName,
+                    userEmail = participant.userEmail,
+                    scheduleResourceId = scheduleResourceId,
+                    source = "ROTATION",
+                    internalUserId = participant.userId,
+                ),
+            )
+        } ?: emptyList()
+    }
+
+    private fun resolveLayerParticipant(
+        layer: ResultRow,
+        scheduleResourceId: String,
+        at: Instant,
+    ): List<OnCallResponderResolution> {
+        val participants =
+            OnCallScheduleLayerParticipants
+                .innerJoin(Users)
+                .selectAll()
+                .where { OnCallScheduleLayerParticipants.layerId eq layer[OnCallScheduleLayers.id].value }
+                .orderBy(OnCallScheduleLayerParticipants.position to SortOrder.ASC)
+                .toList()
+        val index =
+            ScheduleRotationResolver.participantIndex(
+                RotationDefinition(
+                    rotationType = layer[OnCallScheduleLayers.rotationType],
+                    handoffTime = layer[OnCallScheduleLayers.handoffTime],
+                    timezone = layer[OnCallScheduleLayers.timezone],
+                    explicitGap = layer[OnCallScheduleLayers.explicitGap],
+                ),
+                participants.size,
+                at,
+            ) ?: return emptyList()
+        val participant = participants.getOrNull(index) ?: return emptyList()
+        return listOf(
+            OnCallResponderResolution(
+                userId = participant[Users.resource_id].toString(),
+                userName = participant[Users.name] ?: participant[Users.email],
+                userEmail = participant[Users.email],
+                scheduleResourceId = scheduleResourceId,
+                layerId = layer[OnCallScheduleLayers.resourceId].toString(),
+                source = "LAYER",
+                internalUserId = participant[OnCallScheduleLayerParticipants.userId],
+            ),
+        )
+    }
+
+    private fun OnCallResponderResolution.asParticipant(): OnCallParticipant =
+        OnCallParticipant(
+            id = userId,
+            userResourceId = userId,
+            userName = userName,
+            userEmail = userEmail,
+            position = -1,
+            userId = internalUserId,
+        )
 
     // Extracted so both getCurrentOnCall and getOnCallAt share logic within an open transaction
     private fun computeOnCallAt(scheduleId: Int, now: Instant): OnCallParticipant? {

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/ScheduleRotationResolver.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/ScheduleRotationResolver.kt
@@ -1,0 +1,41 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.oncall.services
+
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+import kotlin.time.Instant
+
+internal data class RotationDefinition(
+    val rotationType: String,
+    val handoffTime: LocalTime,
+    val timezone: String,
+    val explicitGap: Boolean = false,
+)
+
+internal object ScheduleRotationResolver {
+    private const val WEEKLY_ROTATION_DAYS = 7L
+
+    fun participantIndex(definition: RotationDefinition, participantCount: Int, at: Instant): Int? {
+        if (definition.explicitGap || participantCount == 0) return null
+        val rotationDays = when (definition.rotationType) {
+            "DAILY" -> 1L
+            "WEEKLY", "CUSTOM" -> WEEKLY_ROTATION_DAYS
+            else -> WEEKLY_ROTATION_DAYS
+        }
+        val zone = runCatching { ZoneId.of(definition.timezone) }.getOrNull() ?: return null
+        val zonedAt = java.time.Instant.ofEpochMilli(at.toEpochMilliseconds()).atZone(zone)
+        val rotationDate = if (zonedAt.toLocalTime().isBefore(definition.handoffTime)) {
+            zonedAt.toLocalDate().minusDays(1)
+        } else {
+            zonedAt.toLocalDate()
+        }
+        val daysSinceEpoch = ChronoUnit.DAYS.between(LocalDate.EPOCH, rotationDate)
+        val cycle = Math.floorDiv(daysSinceEpoch, rotationDays)
+        return Math.floorMod(cycle, participantCount.toLong()).toInt()
+    }
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/SlackUserGroupSyncService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/SlackUserGroupSyncService.kt
@@ -30,7 +30,7 @@ private const val ONE_HOUR_SECONDS = 3600L
 /**
  * Background service that syncs on-call schedules to Slack user groups.
  * Runs every 60 seconds and updates Slack user groups to contain:
- * - The current on-call user (if they have a Slack mapping)
+ * - Every current responder (if they have a Slack mapping)
  * - The Moneat bot user
  *
  * Uses Redis caching to avoid redundant API calls when membership hasn't changed.
@@ -122,24 +122,29 @@ class SlackUserGroupSyncService(
         schedule: ScheduleUsergroupMapping,
         slackConfig: SlackConfig,
     ) {
-        // Get current on-call user
-        val currentOnCall = onCallScheduleService.getCurrentOnCall(schedule.scheduleId)
+        val responders =
+            onCallScheduleService.resolveCurrentResponders(
+                organizationId = schedule.organizationId,
+                scheduleIds = listOf(schedule.scheduleId),
+                all = true,
+            )
 
-        // Resolve on-call user's Slack ID (if mapped)
-        val onCallSlackId = currentOnCall?.let { getSlackUserId(it.userId) }
-
-        // Build target member list: bot + on-call user (if mapped)
+        // Build target member list: bot + every current responder (if mapped)
         val targetMembers =
             buildList {
                 add(slackConfig.botUserId)
-                if (onCallSlackId != null) {
-                    add(onCallSlackId)
-                } else if (currentOnCall != null) {
-                    logger.warn(
-                        "On-call user ${currentOnCall.userId} (${currentOnCall.userName}) has no Slack " +
-                            "mapping for schedule ${schedule.scheduleName}",
-                    )
-                } else {
+                responders.forEach { responder ->
+                    val slackId = getSlackUserId(responder.internalUserId)
+                    if (slackId != null) {
+                        add(slackId)
+                    } else {
+                        logger.warn(
+                            "On-call user ${responder.userId} (${responder.userName}) has no Slack mapping " +
+                                "for schedule ${schedule.scheduleName}",
+                        )
+                    }
+                }
+                if (responders.isEmpty()) {
                     logger.warn("Schedule ${schedule.scheduleName} has no current on-call user")
                 }
             }.distinct().sorted() // Sort for consistent comparison

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/SlackUserGroupSyncService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/SlackUserGroupSyncService.kt
@@ -123,7 +123,7 @@ class SlackUserGroupSyncService(
         slackConfig: SlackConfig,
     ) {
         val responders =
-            onCallScheduleService.resolveCurrentResponders(
+            onCallScheduleService.resolveCurrentResponderRecords(
                 organizationId = schedule.organizationId,
                 scheduleIds = listOf(schedule.scheduleId),
                 all = true,
@@ -138,8 +138,9 @@ class SlackUserGroupSyncService(
                     if (slackId != null) {
                         add(slackId)
                     } else {
+                        val responderDescription = "${responder.model.userId} (${responder.model.userName})"
                         logger.warn(
-                            "On-call user ${responder.userId} (${responder.userName}) has no Slack mapping " +
+                            "On-call user $responderDescription has no Slack mapping " +
                                 "for schedule ${schedule.scheduleName}",
                         )
                     }

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/services/ScheduleRotationResolverTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/services/ScheduleRotationResolverTest.kt
@@ -1,0 +1,83 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.oncall.services
+
+import java.time.LocalTime
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Instant
+
+class ScheduleRotationResolverTest {
+    @Test
+    fun `daily rotation respects timezone handoff`() {
+        val definition = RotationDefinition("DAILY", LocalTime.of(9, 0), "America/New_York")
+
+        assertEquals(
+            0,
+            ScheduleRotationResolver.participantIndex(
+                definition,
+                participantCount = 2,
+                at = Instant.parse("2026-01-02T13:59:00Z"),
+            ),
+        )
+        assertEquals(
+            1,
+            ScheduleRotationResolver.participantIndex(
+                definition,
+                participantCount = 2,
+                at = Instant.parse("2026-01-02T14:00:00Z"),
+            ),
+        )
+    }
+
+    @Test
+    fun `weekly rotation remains deterministic across daylight saving transition`() {
+        val definition = RotationDefinition("WEEKLY", LocalTime.of(9, 0), "America/New_York")
+
+        val beforeHandoff =
+            ScheduleRotationResolver.participantIndex(
+                definition,
+                participantCount = 3,
+                at = Instant.parse("2026-03-08T12:59:59Z"),
+            )
+        val afterHandoff =
+            ScheduleRotationResolver.participantIndex(
+                definition,
+                participantCount = 3,
+                at = Instant.parse("2026-03-08T13:00:00Z"),
+            )
+
+        assertEquals(0, beforeHandoff)
+        assertEquals(0, afterHandoff)
+    }
+
+    @Test
+    fun `empty gaps and invalid zones resolve to no responder`() {
+        val at = Instant.parse("2026-03-08T13:00:00Z")
+
+        assertNull(
+            ScheduleRotationResolver.participantIndex(
+                RotationDefinition("DAILY", LocalTime.NOON, "UTC", explicitGap = true),
+                participantCount = 2,
+                at = at,
+            ),
+        )
+        assertNull(
+            ScheduleRotationResolver.participantIndex(
+                RotationDefinition("DAILY", LocalTime.NOON, "Not/AZone"),
+                participantCount = 2,
+                at = at,
+            ),
+        )
+        assertNull(
+            ScheduleRotationResolver.participantIndex(
+                RotationDefinition("DAILY", LocalTime.NOON, "UTC"),
+                participantCount = 0,
+                at = at,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
Adds layered schedules with deterministic timezone-aware responder resolution and public schedule-layer APIs.

Preserves single-rotation fallback, exposes primary/all responders, and syncs Slack groups with every current responder. Includes the V164 migration, dashboard API types, and focused resolver tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added layered on-call schedules with configurable rotations, handoff times, time zones, gaps, ordering, and participants.
  * Added tools to create, view, update, and delete schedule layers.
  * Added responder resolution for individual or multiple schedules.
  * Schedule responses now include configured layers.
  * Slack synchronization now supports all currently assigned responders.

* **Bug Fixes**
  * Improved rotation handling across time zones, handoffs, daylight-saving changes, and explicit gaps.
  * Improved seat-limit validation for layer participants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->