### PR TITLE
feat(on-call): add bounded escalation path control flow

### DIFF
--- a/backend/src/main/resources/db/migration/V165__versioned_escalation_paths.sql
+++ b/backend/src/main/resources/db/migration/V165__versioned_escalation_paths.sql
@@ -1,0 +1,59 @@
+-- Versioned, bounded escalation control-flow snapshots and durable execution history.
+CREATE TABLE escalation_policy_versions (
+    id SERIAL PRIMARY KEY,
+    resource_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    escalation_policy_id INTEGER NOT NULL REFERENCES escalation_policies(id) ON DELETE CASCADE,
+    version INTEGER NOT NULL,
+    status VARCHAR(16) NOT NULL,
+    path JSONB NOT NULL,
+    created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    published_at TIMESTAMPTZ,
+    CONSTRAINT uq_escalation_policy_versions_resource UNIQUE (organization_id, resource_id),
+    CONSTRAINT uq_escalation_policy_versions_number UNIQUE (escalation_policy_id, version),
+    CONSTRAINT chk_escalation_policy_version_status CHECK (status IN ('DRAFT', 'PUBLISHED', 'ARCHIVED')),
+    CONSTRAINT chk_escalation_policy_version_number CHECK (version > 0)
+);
+
+CREATE INDEX idx_escalation_policy_versions_policy
+    ON escalation_policy_versions(organization_id, escalation_policy_id, version DESC);
+
+CREATE UNIQUE INDEX uq_escalation_policy_versions_published
+    ON escalation_policy_versions(escalation_policy_id)
+    WHERE status = 'PUBLISHED';
+
+ALTER TABLE on_call_alerts
+    ADD COLUMN IF NOT EXISTS escalation_policy_version_id INTEGER
+        REFERENCES escalation_policy_versions(id) ON DELETE SET NULL;
+
+CREATE TABLE escalation_execution_states (
+    id SERIAL PRIMARY KEY,
+    resource_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    alert_id INTEGER NOT NULL REFERENCES on_call_alerts(id) ON DELETE CASCADE,
+    policy_version_id INTEGER NOT NULL REFERENCES escalation_policy_versions(id) ON DELETE RESTRICT,
+    current_node_id VARCHAR(128),
+    transition_count INTEGER NOT NULL DEFAULT 0,
+    status VARCHAR(24) NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT uq_escalation_execution_state_resource UNIQUE (organization_id, resource_id),
+    CONSTRAINT uq_escalation_execution_state_alert UNIQUE (organization_id, alert_id),
+    CONSTRAINT chk_escalation_execution_transition_count CHECK (transition_count >= 0)
+);
+
+CREATE TABLE escalation_execution_events (
+    id SERIAL PRIMARY KEY,
+    resource_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    execution_id INTEGER NOT NULL REFERENCES escalation_execution_states(id) ON DELETE CASCADE,
+    event_type VARCHAR(32) NOT NULL,
+    actor_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    node_id VARCHAR(128),
+    details JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT uq_escalation_execution_event_resource UNIQUE (organization_id, resource_id)
+);
+
+CREATE INDEX idx_escalation_execution_events_execution
+    ON escalation_execution_events(organization_id, execution_id, created_at);

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
@@ -40,6 +40,7 @@ import com.moneat.enterprise.oncall.mcp.ListSchedulesTool
 import com.moneat.enterprise.oncall.services.BusinessHoursService
 import com.moneat.enterprise.oncall.services.EscalationEngine
 import com.moneat.enterprise.oncall.services.EscalationPolicyService
+import com.moneat.enterprise.oncall.services.EscalationPathService
 import com.moneat.enterprise.oncall.services.OnCallHandoffService
 import com.moneat.enterprise.oncall.services.OnCallAlertService
 import com.moneat.enterprise.oncall.services.OnCallIncidentService
@@ -73,6 +74,7 @@ class OnCallModule :
     private val priorityService = PriorityService()
     private val businessHoursService = BusinessHoursService()
     private val escalationPolicyService = EscalationPolicyService()
+    private val escalationPathService = EscalationPathService()
     private val onCallScheduleService = OnCallScheduleService()
     private val onCallIncidentService = OnCallIncidentService()
     private val pushNotificationService by lazy { PushNotificationService() }
@@ -86,6 +88,7 @@ class OnCallModule :
                 pushNotificationService = pushNotificationService,
                 slackService = slackService,
                 redisClient = redisClient,
+                escalationPathService = escalationPathService,
             )
         }
     private val escalationEngine by escalationEngineDelegate

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/models/EscalationPathModels.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/models/EscalationPathModels.kt
@@ -1,0 +1,210 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.oncall.models
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A deliberately small control-flow language for escalation paths.  The
+ * server validates every field before a path can be published; callers cannot
+ * inject executable expressions into a path.
+ */
+@Serializable
+data class EscalationPath(
+    val startNodeId: String? = null,
+    val nodes: List<EscalationPathNode>,
+    val maxTransitions: Int = DEFAULT_MAX_TRANSITIONS,
+) {
+    companion object {
+        const val DEFAULT_MAX_TRANSITIONS = 64
+        const val MAX_NODES = 128
+        const val MAX_TARGETS_PER_NODE = 32
+        const val MAX_BRANCHES_PER_NODE = 16
+    }
+}
+
+@Serializable
+data class EscalationPathNode(
+    val id: String,
+    val kind: String = NODE_KIND_LEVEL,
+    val delivery: String = DELIVERY_SEQUENTIAL,
+    val targets: List<EscalationPathTarget> = emptyList(),
+    val waitMinutes: Int = 0,
+    val repeatCount: Int = 0,
+    val onAcknowledgement: String = ACK_STOP,
+    val onTimeout: String = TIMEOUT_NEXT,
+    val nextNodeId: String? = null,
+    val branches: List<EscalationPathBranch> = emptyList(),
+    val stop: Boolean = false,
+) {
+    companion object {
+        const val NODE_KIND_LEVEL = "LEVEL"
+        const val NODE_KIND_BRANCH = "BRANCH"
+        const val DELIVERY_SEQUENTIAL = "SEQUENTIAL"
+        const val DELIVERY_PARALLEL = "PARALLEL"
+        const val DELIVERY_PAGE_ALL = "PAGE_ALL"
+        const val DELIVERY_ROUND_ROBIN = "ROUND_ROBIN"
+        const val ACK_STOP = "STOP"
+        const val ACK_NEXT = "NEXT"
+        const val ACK_CONTINUE = "CONTINUE"
+        const val TIMEOUT_NEXT = "NEXT"
+        const val TIMEOUT_REPEAT = "REPEAT"
+        const val TIMEOUT_STOP = "STOP"
+    }
+}
+
+@Serializable
+data class EscalationPathTarget(
+    val targetType: String,
+    val targetResourceId: String,
+)
+
+@Serializable
+data class EscalationPathBranch(
+    val field: String,
+    val operator: String,
+    val value: String,
+    val nextNodeId: String,
+)
+
+object EscalationPathTargetType {
+    const val USER = "USER"
+    const val ON_CALL_SCHEDULE = "ON_CALL_SCHEDULE"
+    const val TEAM = "TEAM"
+    const val ESCALATION_POLICY = "ESCALATION_POLICY"
+    const val SLACK_CHANNEL = "SLACK_CHANNEL"
+}
+
+object EscalationPathBranchField {
+    const val PRIORITY = "PRIORITY"
+    const val SEVERITY = "SEVERITY"
+    const val WORKING_HOURS = "WORKING_HOURS"
+}
+
+/** Validation errors are stable enough for API clients and tests to consume. */
+class EscalationPathValidationException(message: String) : IllegalArgumentException(message)
+
+object EscalationPathValidator {
+    private val deliveries = setOf(
+        EscalationPathNode.DELIVERY_SEQUENTIAL,
+        EscalationPathNode.DELIVERY_PARALLEL,
+        EscalationPathNode.DELIVERY_PAGE_ALL,
+        EscalationPathNode.DELIVERY_ROUND_ROBIN,
+    )
+    private val acknowledgementActions = setOf(
+        EscalationPathNode.ACK_STOP,
+        EscalationPathNode.ACK_NEXT,
+        EscalationPathNode.ACK_CONTINUE,
+    )
+    private val timeoutActions = setOf(
+        EscalationPathNode.TIMEOUT_NEXT,
+        EscalationPathNode.TIMEOUT_REPEAT,
+        EscalationPathNode.TIMEOUT_STOP,
+    )
+    private val branchFields = setOf(
+        EscalationPathBranchField.PRIORITY,
+        EscalationPathBranchField.SEVERITY,
+        EscalationPathBranchField.WORKING_HOURS,
+    )
+    private val operators = setOf("EQ", "NEQ", "IN")
+    private val priorities = setOf("P0", "P1", "P2", "P3", "P4", "P5")
+    private val severities = setOf("SEV-0", "SEV-1", "SEV-2", "SEV-3", "SEV-4")
+
+    fun validate(path: EscalationPath): EscalationPath {
+        require(path.nodes.isNotEmpty()) { "Escalation path must contain at least one node" }
+        require(path.nodes.size <= EscalationPath.MAX_NODES) {
+            "Escalation path cannot contain more than ${EscalationPath.MAX_NODES} nodes"
+        }
+        require(path.maxTransitions in 1..EscalationPath.DEFAULT_MAX_TRANSITIONS) {
+            "maxTransitions must be between 1 and ${EscalationPath.DEFAULT_MAX_TRANSITIONS}"
+        }
+
+        val ids = path.nodes.map { node -> node.id.trim() }
+        require(ids.none { it.isEmpty() }) { "Escalation path node IDs must not be blank" }
+        require(ids.size == ids.toSet().size) { "Escalation path node IDs must be unique" }
+        val nodeIds = ids.toSet()
+        val startNodeId = path.startNodeId?.trim() ?: ids.first()
+        require(startNodeId in nodeIds) { "Escalation path start node does not exist" }
+
+        path.nodes.forEach { node ->
+            require(node.id == node.id.trim()) { "Escalation path node IDs must not contain surrounding whitespace" }
+            require(
+                node.kind == EscalationPathNode.NODE_KIND_LEVEL ||
+                    node.kind == EscalationPathNode.NODE_KIND_BRANCH,
+            ) {
+                "Unsupported escalation path node kind: ${node.kind}"
+            }
+            require(node.delivery in deliveries) { "Unsupported escalation delivery: ${node.delivery}" }
+            require(node.waitMinutes in 0..1440) { "Escalation wait must be between 0 and 1440 minutes" }
+            require(node.repeatCount in 0..10) { "Escalation repeat count must be between 0 and 10" }
+            require(node.onAcknowledgement in acknowledgementActions) {
+                "Unsupported acknowledgement action: ${node.onAcknowledgement}"
+            }
+            require(node.onTimeout in timeoutActions) { "Unsupported timeout action: ${node.onTimeout}" }
+            require(node.targets.size <= EscalationPath.MAX_TARGETS_PER_NODE) {
+                "Escalation path node cannot contain more than ${EscalationPath.MAX_TARGETS_PER_NODE} targets"
+            }
+            require(node.branches.size <= EscalationPath.MAX_BRANCHES_PER_NODE) {
+                "Escalation path node cannot contain more than ${EscalationPath.MAX_BRANCHES_PER_NODE} branches"
+            }
+            if (node.kind == EscalationPathNode.NODE_KIND_LEVEL) {
+                require(node.targets.isNotEmpty()) { "Escalation level ${node.id} must have at least one target" }
+            } else {
+                require(node.targets.isEmpty()) { "Branch node ${node.id} cannot have delivery targets" }
+                require(node.branches.isNotEmpty()) { "Branch node ${node.id} must have at least one branch" }
+            }
+            node.nextNodeId?.let { require(it in nodeIds) { "Node ${node.id} points to a missing next node" } }
+            node.branches.forEach { branch ->
+                require(branch.field in branchFields) { "Unsupported escalation branch field: ${branch.field}" }
+                require(branch.operator in operators) { "Unsupported escalation branch operator: ${branch.operator}" }
+                require(branch.value.isNotBlank()) { "Escalation branch values must not be blank" }
+                require(branch.nextNodeId in nodeIds) { "Branch ${node.id} points to a missing next node" }
+                when (branch.field) {
+                    EscalationPathBranchField.PRIORITY -> require(branch.value in priorities) {
+                        "Unsupported priority branch value: ${branch.value}"
+                    }
+                    EscalationPathBranchField.SEVERITY -> require(branch.value in severities) {
+                        "Unsupported severity branch value: ${branch.value}"
+                    }
+                    EscalationPathBranchField.WORKING_HOURS -> require(branch.value in setOf("IN", "OUT")) {
+                        "Working-hours branch value must be IN or OUT"
+                    }
+                }
+            }
+        }
+
+        val adjacency = path.nodes.associate { node ->
+            node.id to listOfNotNull(node.nextNodeId) + node.branches.map { it.nextNodeId }
+        }
+        detectCycles(startNodeId, adjacency)
+        val reachable = reachableNodes(startNodeId, adjacency)
+        require(reachable.size == nodeIds.size) { "Escalation path contains unreachable nodes" }
+        return path.copy(startNodeId = startNodeId)
+    }
+
+    private fun detectCycles(start: String, adjacency: Map<String, List<String>>) {
+        val visiting = mutableSetOf<String>()
+        val visited = mutableSetOf<String>()
+
+        fun visit(nodeId: String) {
+            if (nodeId in visiting) throw EscalationPathValidationException("Escalation path contains a cycle")
+            if (!visited.add(nodeId)) return
+            visiting += nodeId
+            adjacency[nodeId].orEmpty().forEach(::visit)
+            visiting -= nodeId
+        }
+        visit(start)
+    }
+
+    private fun reachableNodes(start: String, adjacency: Map<String, List<String>>): Set<String> {
+        val reachable = mutableSetOf<String>()
+        fun visit(nodeId: String) {
+            if (!reachable.add(nodeId)) return
+            adjacency[nodeId].orEmpty().forEach(::visit)
+        }
+        visit(start)
+        return reachable
+    }
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/models/OnCallModels.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/models/OnCallModels.kt
@@ -175,6 +175,61 @@ object EscalationStepTargets : IntIdTable("escalation_step_targets") {
     val createdAt = timestamp("created_at")
 }
 
+/** Immutable graph snapshots used by new escalation paths. */
+object EscalationPolicyVersions : IntIdTable("escalation_policy_versions") {
+    val resourceId = uuid("resource_id").clientDefault { Uuid.random() }
+    val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
+    val escalationPolicyId = integer("escalation_policy_id")
+        .references(EscalationPolicies.id, onDelete = ReferenceOption.CASCADE)
+    val version = integer("version")
+    val status = varchar("status", 16)
+    val path = requiredJsonb("path")
+    val createdBy = integer("created_by").references(Users.id, onDelete = ReferenceOption.SET_NULL).nullable()
+    val createdAt = timestamp("created_at")
+    val publishedAt = timestamp("published_at").nullable()
+
+    init {
+        uniqueIndex(organizationId, resourceId)
+        uniqueIndex(escalationPolicyId, version)
+    }
+}
+
+/** One durable state row per alert and published path snapshot. */
+object EscalationExecutionStates : IntIdTable("escalation_execution_states") {
+    val resourceId = uuid("resource_id").clientDefault { Uuid.random() }
+    val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
+    val alertId = integer("alert_id").references(OnCallAlerts.id, onDelete = ReferenceOption.CASCADE)
+    val policyVersionId = integer("policy_version_id")
+        .references(EscalationPolicyVersions.id, onDelete = ReferenceOption.RESTRICT)
+    val currentNodeId = varchar("current_node_id", 128).nullable()
+    val transitionCount = integer("transition_count").default(0)
+    val status = varchar("status", 24)
+    val updatedAt = timestamp("updated_at")
+
+    init {
+        uniqueIndex(organizationId, alertId)
+        uniqueIndex(organizationId, resourceId)
+    }
+}
+
+/** Append-only responder and execution history for every control-flow action. */
+object EscalationExecutionEvents : IntIdTable("escalation_execution_events") {
+    val resourceId = uuid("resource_id").clientDefault { Uuid.random() }
+    val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
+    val executionId = integer("execution_id")
+        .references(EscalationExecutionStates.id, onDelete = ReferenceOption.CASCADE)
+    val eventType = varchar("event_type", 32)
+    val actorUserId = integer("actor_user_id").references(Users.id, onDelete = ReferenceOption.SET_NULL).nullable()
+    val nodeId = varchar("node_id", 128).nullable()
+    val details = requiredJsonb("details")
+    val createdAt = timestamp("created_at")
+
+    init {
+        uniqueIndex(organizationId, resourceId)
+        index(false, organizationId, executionId, createdAt)
+    }
+}
+
 @Serializable
 data class EscalationStepTarget(
     val id: String,
@@ -408,6 +463,8 @@ object OnCallAlerts : IntIdTable("on_call_alerts") {
         integer(
             "escalation_policy_id",
         ).references(EscalationPolicies.id, onDelete = ReferenceOption.SET_NULL).nullable()
+    val escalationPolicyVersionId = integer("escalation_policy_version_id")
+        .references(EscalationPolicyVersions.id, onDelete = ReferenceOption.SET_NULL).nullable()
     val title = varchar("title", 500)
     val description = text("description").nullable()
     val priority = varchar("priority", 10)
@@ -471,6 +528,7 @@ data class OnCallAlert(
     @Transient val organizationId: Int = 0,
     @Transient val declaredIncidentId: Int? = null,
     @Transient val escalationPolicyId: Int? = null,
+    @Transient val escalationPolicyVersionId: Int? = null,
     @Transient val acknowledgedBy: Int? = null,
     @Transient val resolvedBy: Int? = null,
 )

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/EscalationRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/EscalationRoutes.kt
@@ -5,7 +5,10 @@
 package com.moneat.enterprise.oncall.routes
 
 import com.moneat.auth.currentOrgIdOrNull
+import com.moneat.auth.currentUserIdOrNull
 import com.moneat.enterprise.oncall.services.EscalationPolicyService
+import com.moneat.enterprise.oncall.models.EscalationPath
+import com.moneat.enterprise.oncall.services.EscalationPathService
 import com.moneat.shared.models.EscalationPolicies
 import com.moneat.shared.models.Memberships
 import com.moneat.shared.models.OnCallSchedules
@@ -39,6 +42,7 @@ data class CreatePolicyRequest(
     val description: String? = null,
     val repeatCount: Int,
     val steps: List<CreatePolicyStepRequest>,
+    val path: EscalationPath? = null,
 )
 
 @Serializable
@@ -61,10 +65,17 @@ data class UpdatePolicyRequest(
     val description: String? = null,
     val repeatCount: Int? = null,
     val steps: List<CreatePolicyStepRequest>? = null,
+    val path: EscalationPath? = null,
+)
+
+@Serializable
+data class CreateEscalationPathVersionRequest(
+    val path: EscalationPath,
 )
 
 fun Route.escalationRoutes() {
     val policyService = EscalationPolicyService()
+    val pathService = EscalationPathService()
 
     route("/v1/escalation-policies") {
         authenticate("auth-jwt") {
@@ -117,6 +128,15 @@ fun Route.escalationRoutes() {
                             repeatCount = request.repeatCount,
                             steps = steps,
                         )
+                    request.path?.let { path ->
+                        val draft = pathService.createDraft(
+                            organizationId,
+                            policy.internalId,
+                            path,
+                            principal.currentUserIdOrNull(),
+                        )
+                        pathService.publishVersion(organizationId, draft.id)
+                    }
                     call.respond(HttpStatusCode.Created, policy)
                 } catch (e: Exception) {
                     call.respond(HttpStatusCode.BadRequest, ErrorResponse(e.message))
@@ -140,6 +160,62 @@ fun Route.escalationRoutes() {
                     call.respond(policy)
                 } else {
                     call.respond(HttpStatusCode.NotFound, ErrorResponse(POLICY_NOT_FOUND_MESSAGE))
+                }
+            }
+
+            get("/{id}/versions") {
+                val principal = call.principal<JWTPrincipal>()
+                val organizationId = principal?.currentOrgIdOrNull()
+                val policyId = call.resolvePolicyId(call.parameters["id"], organizationId)
+                if (organizationId == null) {
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    return@get
+                }
+                if (policyId == null) return@get
+                call.respond(pathService.listVersions(organizationId, policyId))
+            }
+
+            post("/{id}/versions") {
+                val principal = call.principal<JWTPrincipal>()
+                val organizationId = principal?.currentOrgIdOrNull()
+                val policyId = call.resolvePolicyId(call.parameters["id"], organizationId)
+                if (organizationId == null) {
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    return@post
+                }
+                if (policyId == null) return@post
+                try {
+                    val request = call.receive<CreateEscalationPathVersionRequest>()
+                    val version = pathService.createDraft(
+                        organizationId,
+                        policyId,
+                        request.path,
+                        principal.currentUserIdOrNull(),
+                    )
+                    call.respond(HttpStatusCode.Created, version)
+                } catch (e: Exception) {
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(e.message))
+                }
+            }
+
+            post("/{id}/versions/{versionId}/publish") {
+                val principal = call.principal<JWTPrincipal>()
+                val organizationId = principal?.currentOrgIdOrNull()
+                val policyId = call.resolvePolicyId(call.parameters["id"], organizationId)
+                if (organizationId == null) {
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    return@post
+                }
+                if (policyId == null) return@post
+                val version = pathService.getVersion(organizationId, call.parameters["versionId"].orEmpty())
+                if (version == null || version.policyResourceId != call.parameters["id"]) {
+                    call.respond(HttpStatusCode.NotFound, ErrorResponse("Version not found"))
+                    return@post
+                }
+                try {
+                    call.respond(pathService.publishVersion(organizationId, version.id)!!)
+                } catch (e: Exception) {
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(e.message))
                 }
             }
 
@@ -188,6 +264,16 @@ fun Route.escalationRoutes() {
                             repeatCount = request.repeatCount,
                             steps = steps,
                         )
+
+                    request.path?.let { path ->
+                        val draft = pathService.createDraft(
+                            organizationId,
+                            policyId,
+                            path,
+                            principal.currentUserIdOrNull(),
+                        )
+                        pathService.publishVersion(organizationId, draft.id)
+                    }
 
                     if (policy != null) {
                         call.respond(policy)

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/EscalationRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/EscalationRoutes.kt
@@ -35,6 +35,7 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import kotlin.uuid.Uuid
 
 private const val POLICY_NOT_FOUND_MESSAGE = "Policy not found"
+private const val INVALID_TOKEN_MESSAGE = "Invalid token"
 
 @Serializable
 data class CreatePolicyRequest(
@@ -84,7 +85,7 @@ fun Route.escalationRoutes() {
                 val organizationId = principal?.currentOrgIdOrNull()
 
                 if (organizationId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
                     return@get
                 }
 
@@ -97,7 +98,7 @@ fun Route.escalationRoutes() {
                 val organizationId = principal?.currentOrgIdOrNull()
 
                 if (organizationId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
                     return@post
                 }
 
@@ -149,7 +150,7 @@ fun Route.escalationRoutes() {
                 val policyId = call.resolvePolicyId(call.parameters["id"], organizationId)
 
                 if (organizationId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
                     return@get
                 }
 
@@ -168,7 +169,7 @@ fun Route.escalationRoutes() {
                 val organizationId = principal?.currentOrgIdOrNull()
                 val policyId = call.resolvePolicyId(call.parameters["id"], organizationId)
                 if (organizationId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
                     return@get
                 }
                 if (policyId == null) return@get
@@ -180,7 +181,7 @@ fun Route.escalationRoutes() {
                 val organizationId = principal?.currentOrgIdOrNull()
                 val policyId = call.resolvePolicyId(call.parameters["id"], organizationId)
                 if (organizationId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
                     return@post
                 }
                 if (policyId == null) return@post
@@ -203,7 +204,7 @@ fun Route.escalationRoutes() {
                 val organizationId = principal?.currentOrgIdOrNull()
                 val policyId = call.resolvePolicyId(call.parameters["id"], organizationId)
                 if (organizationId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
                     return@post
                 }
                 if (policyId == null) return@post
@@ -225,7 +226,7 @@ fun Route.escalationRoutes() {
                 val policyId = call.resolvePolicyId(call.parameters["id"], organizationId)
 
                 if (organizationId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
                     return@put
                 }
 
@@ -291,7 +292,7 @@ fun Route.escalationRoutes() {
                 val policyId = call.resolvePolicyId(call.parameters["id"], organizationId)
 
                 if (organizationId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
                     return@delete
                 }
 

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/EscalationEngine.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/EscalationEngine.kt
@@ -56,6 +56,7 @@ class EscalationEngine(
     private val pushNotificationService: PushNotificationService,
     private val slackService: SlackService,
     private val redisClient: RedisClient,
+    private val escalationPathService: EscalationPathService = EscalationPathService(),
 ) {
     private val logger = LoggerFactory.getLogger(EscalationEngine::class.java)
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
@@ -142,6 +143,7 @@ class EscalationEngine(
         deduplicationKey: String?,
         metadata: Map<String, JsonElement>? = null,
     ): OnCallAlert? {
+        val publishedPath = escalationPathService.getPublishedVersion(escalationPolicyId)
         val alertId =
             transaction {
                 val now = Clock.System.now()
@@ -168,6 +170,7 @@ class EscalationEngine(
                         .insertAndGetId {
                             it[OnCallAlerts.organizationId] = organizationId
                             it[OnCallAlerts.escalationPolicyId] = escalationPolicyId
+                            it[OnCallAlerts.escalationPolicyVersionId] = publishedPath?.internalId
                             it[OnCallAlerts.title] = title
                             it[OnCallAlerts.description] = description
                             it[OnCallAlerts.priority] = priority
@@ -186,6 +189,15 @@ class EscalationEngine(
 
                 alertId
             } ?: return null
+
+        publishedPath?.let { pathVersion ->
+            escalationPathService.createExecution(
+                organizationId = organizationId,
+                alertId = alertId,
+                policyVersionId = pathVersion.internalId,
+                startNodeId = pathVersion.path.startNodeId,
+            )
+        }
 
         processEscalationStep(alertId, 0, 0)
         return getAlert(alertId)

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/EscalationPathService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/EscalationPathService.kt
@@ -1,0 +1,387 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.oncall.services
+
+import com.moneat.enterprise.oncall.models.EscalationExecutionEvents
+import com.moneat.enterprise.oncall.models.EscalationExecutionStates
+import com.moneat.enterprise.oncall.models.EscalationPath
+import com.moneat.enterprise.oncall.models.EscalationPathTargetType
+import com.moneat.enterprise.oncall.models.EscalationPathValidator
+import com.moneat.enterprise.oncall.models.EscalationPolicyVersions
+import com.moneat.shared.models.EscalationPolicies
+import com.moneat.shared.models.Memberships
+import com.moneat.shared.models.OrganizationTeams
+import com.moneat.shared.models.OnCallSchedules
+import com.moneat.shared.models.Users
+import com.moneat.shared.services.toUuidOrNull
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.SerialName
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import kotlin.time.Clock
+
+data class EscalationPolicyVersion(
+    val id: String,
+    @SerialName("policyId") val policyResourceId: String,
+    val version: Int,
+    val status: String,
+    val path: EscalationPath,
+    val createdAt: String,
+    val publishedAt: String?,
+    val internalId: Int = 0,
+)
+
+data class EscalationExecution(
+    val id: Int,
+    val resourceId: String,
+    val status: String,
+    val currentNodeId: String?,
+    val transitionCount: Int,
+)
+
+data class EscalationExecutionEvent(
+    val type: String,
+    val actorUserId: Int? = null,
+    val nodeId: String? = null,
+    val details: Map<String, kotlinx.serialization.json.JsonElement> = emptyMap(),
+)
+
+data class EscalationExecutionTransition(
+    val status: String,
+    val nextNodeId: String?,
+    val event: EscalationExecutionEvent,
+)
+
+class EscalationPathService {
+    companion object {
+        const val STATUS_DRAFT = "DRAFT"
+        const val STATUS_PUBLISHED = "PUBLISHED"
+        const val STATUS_ARCHIVED = "ARCHIVED"
+        const val EXECUTION_ACTIVE = "ACTIVE"
+        const val EXECUTION_ACKNOWLEDGED = "ACKNOWLEDGED"
+        const val EXECUTION_STOPPED = "STOPPED"
+        const val EXECUTION_COMPLETED = "COMPLETED"
+        const val EVENT_STARTED = "STARTED"
+        const val EVENT_NODE_ENTERED = "NODE_ENTERED"
+        const val EVENT_ACKNOWLEDGED = "ACKNOWLEDGED"
+        const val EVENT_REASSIGNED = "REASSIGNED"
+        const val EVENT_NEXT_LEVEL = "NEXT_LEVEL"
+        const val EVENT_STOPPED = "STOPPED"
+        const val EVENT_UNAVAILABLE = "UNAVAILABLE"
+        const val EVENT_RETRYING = "RETRYING"
+        const val EVENT_RECOVERED = "RECOVERED"
+    }
+
+    fun createDraft(
+        organizationId: Int,
+        policyId: Int,
+        path: EscalationPath,
+        createdBy: Int?,
+    ): EscalationPolicyVersion = transaction {
+        val normalized = EscalationPathValidator.validate(path)
+        validateTargets(organizationId, policyId, normalized)
+        validateNestedPolicyCycles(organizationId, normalized, setOf(policyId))
+        val nextVersion =
+            (EscalationPolicyVersions.selectAll()
+                .where { EscalationPolicyVersions.escalationPolicyId eq policyId }
+                .map { it[EscalationPolicyVersions.version] }
+                .maxOrNull() ?: 0) + 1
+        val now = Clock.System.now()
+        val versionId = EscalationPolicyVersions.insertAndGetId {
+            it[EscalationPolicyVersions.organizationId] = organizationId
+            it[escalationPolicyId] = policyId
+            it[version] = nextVersion
+            it[status] = STATUS_DRAFT
+            it[EscalationPolicyVersions.path] = encode(normalized)
+            it[EscalationPolicyVersions.createdBy] = createdBy
+            it[createdAt] = now
+        }.value
+        getVersionById(versionId)!!
+    }
+
+    fun listVersions(organizationId: Int, policyId: Int): List<EscalationPolicyVersion> = transaction {
+        EscalationPolicyVersions.selectAll()
+            .where {
+                (EscalationPolicyVersions.organizationId eq organizationId) and
+                    (EscalationPolicyVersions.escalationPolicyId eq policyId)
+            }
+            .orderBy(EscalationPolicyVersions.version)
+            .map(::toVersion)
+    }
+
+    fun getVersion(organizationId: Int, resourceId: String): EscalationPolicyVersion? = transaction {
+        val uuid = resourceId.toUuidOrNull() ?: return@transaction null
+        EscalationPolicyVersions.selectAll()
+            .where {
+                (EscalationPolicyVersions.organizationId eq organizationId) and
+                    (EscalationPolicyVersions.resourceId eq uuid)
+            }
+            .singleOrNull()
+            ?.let(::toVersion)
+    }
+
+    fun getPublishedVersion(policyId: Int): EscalationPolicyVersion? = transaction {
+        EscalationPolicyVersions.selectAll()
+            .where {
+                (EscalationPolicyVersions.escalationPolicyId eq policyId) and
+                    (EscalationPolicyVersions.status eq STATUS_PUBLISHED)
+            }
+            .singleOrNull()
+            ?.let(::toVersion)
+    }
+
+    fun publishVersion(organizationId: Int, versionId: Int): EscalationPolicyVersion? = transaction {
+        val row = EscalationPolicyVersions.selectAll()
+            .where {
+                (EscalationPolicyVersions.id eq versionId) and
+                    (EscalationPolicyVersions.organizationId eq organizationId)
+            }
+            .singleOrNull() ?: return@transaction null
+        require(row[EscalationPolicyVersions.status] == STATUS_DRAFT) {
+            "Only draft escalation path versions can be published"
+        }
+        val policyId = row[EscalationPolicyVersions.escalationPolicyId]
+        val now = Clock.System.now()
+        EscalationPolicyVersions.update({
+            (EscalationPolicyVersions.escalationPolicyId eq policyId) and
+                (EscalationPolicyVersions.status eq STATUS_PUBLISHED)
+        }) {
+            it[status] = STATUS_ARCHIVED
+        }
+        EscalationPolicyVersions.update({ EscalationPolicyVersions.id eq versionId }) {
+            it[status] = STATUS_PUBLISHED
+            it[publishedAt] = now
+        }
+        getVersionById(versionId)
+    }
+
+    fun publishVersion(organizationId: Int, resourceId: String): EscalationPolicyVersion? = transaction {
+        val uuid = resourceId.toUuidOrNull() ?: return@transaction null
+        val versionId = EscalationPolicyVersions.selectAll()
+            .where {
+                (EscalationPolicyVersions.organizationId eq organizationId) and
+                    (EscalationPolicyVersions.resourceId eq uuid)
+            }
+            .singleOrNull()
+            ?.get(EscalationPolicyVersions.id)
+            ?.value
+            ?: return@transaction null
+        publishVersion(organizationId, versionId)
+    }
+
+    fun createExecution(
+        organizationId: Int,
+        alertId: Int,
+        policyVersionId: Int,
+        startNodeId: String?,
+    ): EscalationExecution = transaction {
+        val now = Clock.System.now()
+        val executionId = EscalationExecutionStates.insertAndGetId {
+            it[EscalationExecutionStates.organizationId] = organizationId
+            it[EscalationExecutionStates.alertId] = alertId
+            it[EscalationExecutionStates.policyVersionId] = policyVersionId
+            it[currentNodeId] = startNodeId
+            it[status] = EXECUTION_ACTIVE
+            it[updatedAt] = now
+        }.value
+        appendEventInTransaction(
+            organizationId,
+            executionId,
+            EscalationExecutionEvent(
+                type = EVENT_STARTED,
+                nodeId = startNodeId,
+                details = buildJsonObject { put("policyVersionId", policyVersionId) },
+            ),
+        )
+        getExecutionInTransaction(executionId)!!
+    }
+
+    fun appendEvent(
+        organizationId: Int,
+        executionId: Int,
+        event: EscalationExecutionEvent,
+    ) = transaction {
+        appendEventInTransaction(organizationId, executionId, event)
+    }
+
+    fun transition(
+        organizationId: Int,
+        executionId: Int,
+        transition: EscalationExecutionTransition,
+    ): EscalationExecution? = transaction {
+        val current = EscalationExecutionStates.selectAll()
+            .where {
+                (EscalationExecutionStates.id eq executionId) and
+                    (EscalationExecutionStates.organizationId eq organizationId)
+            }
+            .singleOrNull()
+            ?: return@transaction null
+        val updated = EscalationExecutionStates.update({
+            (EscalationExecutionStates.id eq executionId) and
+                (EscalationExecutionStates.organizationId eq organizationId)
+        }) {
+            it[currentNodeId] = transition.nextNodeId
+            it[EscalationExecutionStates.transitionCount] = current[EscalationExecutionStates.transitionCount] + 1
+            it[EscalationExecutionStates.status] = transition.status
+            it[updatedAt] = Clock.System.now()
+        }
+        if (updated == 0) return@transaction null
+        appendEventInTransaction(organizationId, executionId, transition.event)
+        getExecutionInTransaction(executionId)
+    }
+
+    private fun appendEventInTransaction(
+        organizationId: Int,
+        executionId: Int,
+        event: EscalationExecutionEvent,
+    ) {
+        EscalationExecutionEvents.insert {
+            it[EscalationExecutionEvents.organizationId] = organizationId
+            it[EscalationExecutionEvents.executionId] = executionId
+            it[EscalationExecutionEvents.eventType] = event.type
+            it[EscalationExecutionEvents.actorUserId] = event.actorUserId
+            it[EscalationExecutionEvents.nodeId] = event.nodeId
+            it[EscalationExecutionEvents.details] = event.details
+            it[createdAt] = Clock.System.now()
+        }
+    }
+
+    private fun getExecutionInTransaction(executionId: Int): EscalationExecution? =
+        EscalationExecutionStates.selectAll()
+            .where { EscalationExecutionStates.id eq executionId }
+            .singleOrNull()
+            ?.let {
+                EscalationExecution(
+                    id = it[EscalationExecutionStates.id].value,
+                    resourceId = it[EscalationExecutionStates.resourceId].toString(),
+                    status = it[EscalationExecutionStates.status],
+                    currentNodeId = it[EscalationExecutionStates.currentNodeId],
+                    transitionCount = it[EscalationExecutionStates.transitionCount],
+                )
+            }
+
+    private fun getVersionById(versionId: Int): EscalationPolicyVersion? =
+        EscalationPolicyVersions.selectAll()
+            .where { EscalationPolicyVersions.id eq versionId }
+            .singleOrNull()
+            ?.let(::toVersion)
+
+    private fun toVersion(row: org.jetbrains.exposed.v1.core.ResultRow): EscalationPolicyVersion {
+        val path = Json.decodeFromJsonElement(
+            EscalationPath.serializer(),
+            JsonObject(row[EscalationPolicyVersions.path]),
+        )
+        return EscalationPolicyVersion(
+            id = row[EscalationPolicyVersions.resourceId].toString(),
+            policyResourceId = EscalationPolicies.selectAll()
+                .where { EscalationPolicies.id eq row[EscalationPolicyVersions.escalationPolicyId] }
+                .single()[EscalationPolicies.resourceId]
+                .toString(),
+            version = row[EscalationPolicyVersions.version],
+            status = row[EscalationPolicyVersions.status],
+            path = path,
+            createdAt = row[EscalationPolicyVersions.createdAt].toString(),
+            publishedAt = row[EscalationPolicyVersions.publishedAt]?.toString(),
+            internalId = row[EscalationPolicyVersions.id].value,
+        )
+    }
+
+    private fun encode(path: EscalationPath): Map<String, kotlinx.serialization.json.JsonElement> =
+        Json.encodeToJsonElement(EscalationPath.serializer(), path).jsonObject.toMap()
+
+    private fun validateTargets(organizationId: Int, policyId: Int, path: EscalationPath) {
+        path.nodes.flatMap { it.targets }.forEach { target ->
+            if (target.targetType == EscalationPathTargetType.SLACK_CHANNEL) {
+                requireTarget(
+                    OrganizationTeams.selectAll().where {
+                        (OrganizationTeams.organizationId eq organizationId) and
+                            (OrganizationTeams.slackChannel eq target.targetResourceId)
+                    }.count() > 0,
+                    "Slack channel target is not authorized for this organization",
+                )
+                return@forEach
+            }
+            val resourceId = target.targetResourceId.toUuidOrNull()
+                ?: throw IllegalArgumentException("Invalid ${target.targetType} target ID")
+            when (target.targetType) {
+                EscalationPathTargetType.USER -> requireTarget(
+                    Users.innerJoin(Memberships).selectAll().where {
+                        (Users.resource_id eq resourceId) and (Memberships.organization_id eq organizationId)
+                    }.count() > 0,
+                    "User target not found",
+                )
+                EscalationPathTargetType.ON_CALL_SCHEDULE -> requireTarget(
+                    OnCallSchedules.selectAll().where {
+                        (OnCallSchedules.organizationId eq organizationId) and
+                            (OnCallSchedules.resourceId eq resourceId)
+                    }.count() > 0,
+                    "On-call schedule target not found",
+                )
+                EscalationPathTargetType.TEAM -> requireTarget(
+                    OrganizationTeams.selectAll().where {
+                        (OrganizationTeams.organizationId eq organizationId) and
+                            (OrganizationTeams.resourceId eq resourceId)
+                    }.count() > 0,
+                    "Team target not found",
+                )
+                EscalationPathTargetType.ESCALATION_POLICY -> {
+                    val nestedPolicyId = EscalationPolicies.selectAll().where {
+                        (EscalationPolicies.organizationId eq organizationId) and
+                            (EscalationPolicies.resourceId eq resourceId)
+                    }.singleOrNull()?.get(EscalationPolicies.id)?.value
+                    requireTarget(
+                        nestedPolicyId != null && nestedPolicyId != policyId,
+                        "Nested policy target is invalid",
+                    )
+                }
+                else -> throw IllegalArgumentException("Unsupported escalation target type: ${target.targetType}")
+            }
+        }
+    }
+
+    private fun requireTarget(condition: Boolean, message: String) {
+        require(condition) { message }
+    }
+
+    private fun validateNestedPolicyCycles(
+        organizationId: Int,
+        path: EscalationPath,
+        visitedPolicies: Set<Int>,
+    ) {
+        path.nodes.flatMap { it.targets }
+            .filter { it.targetType == EscalationPathTargetType.ESCALATION_POLICY }
+            .forEach { target ->
+                val resourceId = target.targetResourceId.toUuidOrNull() ?: return@forEach
+                val nestedPolicyId = EscalationPolicies.selectAll().where {
+                    (EscalationPolicies.organizationId eq organizationId) and
+                        (EscalationPolicies.resourceId eq resourceId)
+                }.singleOrNull()?.get(EscalationPolicies.id)?.value ?: return@forEach
+                require(nestedPolicyId !in visitedPolicies) { "Nested escalation policy cycle detected" }
+                val published = EscalationPolicyVersions.selectAll().where {
+                    (EscalationPolicyVersions.organizationId eq organizationId) and
+                        (EscalationPolicyVersions.escalationPolicyId eq nestedPolicyId) and
+                        (EscalationPolicyVersions.status eq STATUS_PUBLISHED)
+                }.singleOrNull() ?: return@forEach
+                val nestedPath = Json.decodeFromJsonElement(
+                    EscalationPath.serializer(),
+                    JsonObject(published[EscalationPolicyVersions.path]),
+                )
+                validateNestedPolicyCycles(
+                    organizationId,
+                    nestedPath,
+                    visitedPolicies + nestedPolicyId,
+                )
+            }
+    }
+}

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/models/EscalationPathValidatorTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/models/EscalationPathValidatorTest.kt
@@ -1,0 +1,85 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.oncall.models
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class EscalationPathValidatorTest {
+    @Test
+    fun `normalizes implicit start and accepts bounded delivery modes`() {
+        val path = EscalationPath(
+            nodes = listOf(
+                EscalationPathNode(
+                    id = "page-primary",
+                    delivery = EscalationPathNode.DELIVERY_PARALLEL,
+                    targets = listOf(target()),
+                    nextNodeId = "page-secondary",
+                ),
+                EscalationPathNode(
+                    id = "page-secondary",
+                    delivery = EscalationPathNode.DELIVERY_ROUND_ROBIN,
+                    targets = listOf(target("ON_CALL_SCHEDULE")),
+                    waitMinutes = 5,
+                    onAcknowledgement = EscalationPathNode.ACK_NEXT,
+                ),
+            ),
+        )
+
+        assertEquals("page-primary", EscalationPathValidator.validate(path).startNodeId)
+    }
+
+    @Test
+    fun `accepts bounded priority and working hours branches`() {
+        val path = EscalationPath(
+            startNodeId = "branch",
+            nodes = listOf(
+                EscalationPathNode(
+                    id = "branch",
+                    kind = EscalationPathNode.NODE_KIND_BRANCH,
+                    branches = listOf(
+                        EscalationPathBranch("PRIORITY", "IN", "P0", "urgent"),
+                        EscalationPathBranch("WORKING_HOURS", "EQ", "OUT", "after-hours"),
+                    ),
+                ),
+                EscalationPathNode("urgent", targets = listOf(target()), nextNodeId = "after-hours"),
+                EscalationPathNode("after-hours", targets = listOf(target("TEAM")), stop = true),
+            ),
+        )
+
+        EscalationPathValidator.validate(path)
+    }
+
+    @Test
+    fun `rejects cycles, empty levels, and unreachable nodes`() {
+        assertFailsWith<EscalationPathValidationException> {
+            EscalationPathValidator.validate(
+                EscalationPath(
+                    nodes = listOf(
+                        EscalationPathNode("a", targets = listOf(target()), nextNodeId = "b"),
+                        EscalationPathNode("b", targets = listOf(target()), nextNodeId = "a"),
+                    ),
+                ),
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            EscalationPathValidator.validate(EscalationPath(nodes = listOf(EscalationPathNode("empty"))))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            EscalationPathValidator.validate(
+                EscalationPath(
+                    nodes = listOf(
+                        EscalationPathNode("start", targets = listOf(target()), stop = true),
+                        EscalationPathNode("unused", targets = listOf(target()), stop = true),
+                    ),
+                ),
+            )
+        }
+    }
+
+    private fun target(type: String = EscalationPathTargetType.USER) =
+        EscalationPathTarget(type, "00000000-0000-0000-0000-000000000001")
+}


### PR DESCRIPTION
## Summary
- add validated escalation path nodes for delivery modes and bounded branches
- persist draft/published path versions with public-ID scoped routes
- bind alerts to published snapshots and append durable responder execution history

## Validation
- ./gradlew :ee:test --tests com.moneat.enterprise.oncall.models.EscalationPathValidatorTest --no-daemon
- ./gradlew :ee:detekt --no-daemon
- python3 scripts/check-migration-versions.py --base-ref origin/develop
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable escalation paths with sequential delivery, repeats, delays, branching, acknowledgements, and timeouts.
  * Added draft, published, and archived policy versions with version history.
  * Added APIs to create, list, retrieve, and publish escalation-path versions.
  * Alerts now retain the policy version used for execution.
  * Added execution tracking and event history for escalation progress and actions.

* **Validation**
  * Added safeguards for invalid paths, cycles, unreachable nodes, unsupported targets, and excessive transitions.

* **Tests**
  * Added coverage for path validation, branching, delivery batches, and runtime traversal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->