### PR TITLE
feat(slack): add durable inbound gateway

### DIFF
--- a/backend/src/main/kotlin/com/moneat/di/AppModules.kt
+++ b/backend/src/main/kotlin/com/moneat/di/AppModules.kt
@@ -34,6 +34,7 @@ import com.moneat.notifications.services.DiscordService
 import com.moneat.notifications.services.EmailService
 import com.moneat.notifications.services.NotificationService
 import com.moneat.notifications.services.SlackService
+import com.moneat.notifications.services.SlackInboundGateway
 import com.moneat.shared.repositories.MembershipRepository
 import com.moneat.shared.repositories.MembershipRepositoryImpl
 import com.moneat.shared.repositories.OrganizationRepository
@@ -55,6 +56,7 @@ val sharedModule = module {
 
     single { EmailService() }
     single { SlackService() }
+    single { SlackInboundGateway() }
     single { DiscordService() }
     single { AlertNotificationPreferencesService() }
     single { AlertSilenceService() }

--- a/backend/src/main/kotlin/com/moneat/ingestion/queue/IngestionPipeline.kt
+++ b/backend/src/main/kotlin/com/moneat/ingestion/queue/IngestionPipeline.kt
@@ -38,6 +38,7 @@ enum class IngestionPipeline(
     DD_MISC("dd-misc", "Misc"),
     DD_NDM("dd-ndm", "NDM"),
     DD_SECURITY("dd-security", "Security"),
+    SLACK_INBOUND("slack-inbound", "Slack inbound"),
     CONNECTOR_EVENTS("connector-events", "Connector event"),
     CONNECTOR_IMPORTS("connector-imports", "Connector import");
 

--- a/backend/src/main/kotlin/com/moneat/notifications/services/SlackInboundGateway.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/SlackInboundGateway.kt
@@ -1,0 +1,438 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.notifications.services
+
+import com.moneat.config.EnvConfig
+import com.moneat.ingestion.queue.IngestionPipeline
+import com.moneat.ingestion.queue.IngestionQueueClient
+import com.moneat.shared.models.SlackInboundDeliveries
+import com.moneat.shared.models.SlackInboundDeliveryStatus
+import io.ktor.http.Headers
+import io.ktor.http.Parameters
+import io.ktor.http.parseQueryString
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.insertIgnore
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import org.slf4j.LoggerFactory
+import java.security.MessageDigest
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import kotlin.math.abs
+import kotlin.time.Clock
+import kotlin.uuid.Uuid
+
+private const val SIGNATURE_VERSION = "v0"
+private const val SIGNATURE_HEADER = "X-Slack-Signature"
+private const val TIMESTAMP_HEADER = "X-Slack-Request-Timestamp"
+private const val REQUEST_ID_HEADER = "X-Slack-Request-ID"
+private const val MAX_REQUEST_AGE_SECONDS = 300L
+private const val MAX_BODY_CHARS = 1_000_000
+private const val SHA256_HEX_LENGTH = 64
+private const val DEFAULT_QUEUE_KEY = "slack-inbound"
+private const val EVENT_URL_VERIFICATION = "url_verification"
+private const val EVENT_ID_FIELD = "event_id"
+private const val TYPE_FIELD = "type"
+private const val PAYLOAD_FIELD = "payload"
+
+private val json = Json { ignoreUnknownKeys = true }
+private val logger = LoggerFactory.getLogger(SlackInboundGateway::class.java)
+
+enum class SlackInboundRequestType(val wire: String) {
+    COMMAND("commands"),
+    EVENT("events"),
+    SHORTCUT("shortcuts"),
+    MENTION("mentions"),
+    INTERACTION("interactions"),
+}
+
+@Serializable
+data class SlackInboundAcceptance(
+    val deliveryId: String?,
+    val duplicate: Boolean,
+    val requestType: String,
+    val challenge: String? = null,
+)
+
+class SlackInboundRequestException(
+    val reason: SlackInboundRequestRejection,
+    override val message: String,
+    cause: Throwable? = null,
+) : IllegalArgumentException(message, cause)
+
+enum class SlackInboundRequestRejection {
+    INVALID_SIGNATURE,
+    INVALID_BODY,
+    QUEUE_UNAVAILABLE,
+}
+
+data class SlackInboundContext(
+    val deliveryKey: String,
+    val requestType: SlackInboundRequestType,
+    val payload: String,
+    val teamId: String?,
+    val enterpriseId: String?,
+    val channelId: String?,
+    val userId: String?,
+    val messageTs: String?,
+    val threadTs: String?,
+    val viewId: String?,
+    val challenge: String?,
+)
+
+private data class ParsedSlackPayload(
+    val root: JsonObject,
+    val form: Parameters,
+)
+
+private data class SlackContextIdentifiers(
+    val teamId: String?,
+    val enterpriseId: String?,
+    val channelId: String?,
+    val userId: String?,
+    val messageTs: String?,
+    val threadTs: String?,
+    val viewId: String?,
+)
+
+/**
+ * Authenticates and durably admits Slack deliveries before any organization lookup.
+ * The persisted row is the audit/context record; the Redis stream is only the
+ * asynchronous wake-up for the worker that completes ingress processing.
+ */
+class SlackInboundGateway(
+    private val queueKey: String = EnvConfig.get("SLACK_INBOUND_QUEUE_KEY") ?: DEFAULT_QUEUE_KEY,
+    private val signingSecret: String? = EnvConfig.get("SLACK_SIGNING_SECRET")?.takeIf { it.isNotBlank() },
+) {
+    fun accept(
+        headers: Headers,
+        rawBody: String,
+        requestType: SlackInboundRequestType,
+    ): SlackInboundAcceptance {
+        val context = authenticateAndParse(headers, rawBody, requestType)
+        if (context.challenge != null) {
+            return SlackInboundAcceptance(
+                deliveryId = null,
+                duplicate = false,
+                requestType = requestType.wire,
+                challenge = context.challenge,
+            )
+        }
+        val existing = findOrInsert(context)
+        if (!existing.inserted && existing.status != SlackInboundDeliveryStatus.RETRY.wire) {
+            return SlackInboundAcceptance(
+                deliveryId = existing.resourceId,
+                duplicate = true,
+                requestType = requestType.wire,
+                challenge = context.challenge,
+            )
+        }
+
+        val resourceId = existing.resourceId
+            ?: throw SlackInboundRequestException(
+                SlackInboundRequestRejection.INVALID_BODY,
+                "Slack delivery could not be persisted",
+            )
+        try {
+            IngestionQueueClient.enqueue(IngestionPipeline.SLACK_INBOUND, queueKey, resourceId)
+            markQueued(resourceId)
+        } catch (error: Exception) {
+            markRetry(resourceId, error.message)
+            throw SlackInboundRequestException(
+                SlackInboundRequestRejection.QUEUE_UNAVAILABLE,
+                "Slack delivery queue is temporarily unavailable",
+                error,
+            )
+        }
+
+        return SlackInboundAcceptance(
+            deliveryId = resourceId,
+            duplicate = false,
+            requestType = requestType.wire,
+            challenge = context.challenge,
+        )
+    }
+
+    /** Completes ingress processing for a queued delivery. Domain consumers can read the durable row. */
+    fun process(resourceId: String) {
+        val parsedId = resourceId.toUuidOrNull()
+            ?: throw IllegalArgumentException("Invalid Slack delivery resource ID")
+        val claimed = transaction {
+            val row = SlackInboundDeliveries
+                .selectAll()
+                .where { SlackInboundDeliveries.resourceId eq parsedId }
+                .firstOrNull()
+                ?: return@transaction false
+            if (row[SlackInboundDeliveries.status] == SlackInboundDeliveryStatus.PROCESSED.wire) {
+                return@transaction true
+            }
+            SlackInboundDeliveries.update({ SlackInboundDeliveries.resourceId eq parsedId }) {
+                it[status] = SlackInboundDeliveryStatus.PROCESSING.wire
+                it[attemptCount] = row[SlackInboundDeliveries.attemptCount] + 1
+                it[leasedAt] = Clock.System.now()
+                it[updatedAt] = Clock.System.now()
+            }
+            true
+        }
+        if (!claimed) return
+
+        transaction {
+            SlackInboundDeliveries.update({ SlackInboundDeliveries.resourceId eq parsedId }) {
+                it[status] = SlackInboundDeliveryStatus.PROCESSED.wire
+                it[processedAt] = Clock.System.now()
+                it[leasedAt] = null
+                it[updatedAt] = Clock.System.now()
+            }
+        }
+    }
+
+    private fun authenticateAndParse(
+        headers: Headers,
+        rawBody: String,
+        requestType: SlackInboundRequestType,
+    ): SlackInboundContext {
+        if (rawBody.length > MAX_BODY_CHARS) {
+            throw SlackInboundRequestException(
+                SlackInboundRequestRejection.INVALID_BODY,
+                "Slack request body is too large",
+            )
+        }
+        if (!verifySlackSignature(headers, rawBody, currentTimestampSeconds(), signingSecret)) {
+            throw SlackInboundRequestException(
+                SlackInboundRequestRejection.INVALID_SIGNATURE,
+                "Invalid Slack signature",
+            )
+        }
+
+        return try {
+            parseContext(headers, rawBody, requestType)
+        } catch (error: Exception) {
+            throw SlackInboundRequestException(
+                SlackInboundRequestRejection.INVALID_BODY,
+                "Invalid Slack request body",
+                error,
+            )
+        }
+    }
+
+    private fun parseContext(
+        headers: Headers,
+        rawBody: String,
+        requestType: SlackInboundRequestType,
+    ): SlackInboundContext {
+        val parsed = parsePayload(rawBody)
+        val root = parsed.root
+        val event = eventObject(root)
+        val identifiers = parseIdentifiers(root, event, parsed.form)
+        val identity = deliveryIdentity(root, parsed.form, identifiers.viewId, headers, rawBody)
+
+        return SlackInboundContext(
+            deliveryKey = "${identifiers.teamId ?: "unknown"}:${requestType.wire}:$identity"
+                .take(MAX_DELIVERY_KEY_CHARS),
+            requestType = requestType,
+            payload = rawBody,
+            teamId = identifiers.teamId,
+            enterpriseId = identifiers.enterpriseId,
+            channelId = identifiers.channelId,
+            userId = identifiers.userId,
+            messageTs = identifiers.messageTs,
+            threadTs = identifiers.threadTs,
+            viewId = identifiers.viewId,
+            challenge = challenge(root),
+        )
+    }
+
+    private fun parsePayload(rawBody: String): ParsedSlackPayload {
+        val form = parseQueryString(rawBody)
+        val root = form[PAYLOAD_FIELD]?.let(::parseJsonObject)
+            ?: rawBody.trimStart().takeIf { it.startsWith("{") }?.let(::parseJsonObject)
+            ?: JsonObject(emptyMap())
+        return ParsedSlackPayload(root, form)
+    }
+
+    private fun eventObject(root: JsonObject): JsonObject = root["event"]?.jsonObject ?: root
+
+    private fun parseIdentifiers(
+        root: JsonObject,
+        event: JsonObject,
+        form: Parameters,
+    ): SlackContextIdentifiers {
+        val container = root["container"]?.jsonObject
+        val view = root["view"]?.jsonObject
+        return SlackContextIdentifiers(
+            teamId = firstValue(value(root, "team", "id"), value(event, "team_id"), form["team_id"]),
+            enterpriseId = firstValue(value(root, "enterprise", "id"), form["enterprise_id"]),
+            channelId = firstValue(value(root, "channel", "id"), value(event, "channel_id"), form["channel_id"]),
+            userId = firstValue(value(root, "user", "id"), value(event, "user_id"), form["user_id"]),
+            messageTs = firstValue(value(container, "message_ts"), value(event, "message_ts"), form["message_ts"]),
+            threadTs = firstValue(value(container, "thread_ts"), value(event, "thread_ts"), form["thread_ts"]),
+            viewId = firstValue(value(view, "id"), form["view_id"]),
+        )
+    }
+
+    private fun deliveryIdentity(
+        root: JsonObject,
+        form: Parameters,
+        viewId: String?,
+        headers: Headers,
+        rawBody: String,
+    ): String {
+        val eventId = firstValue(value(root, EVENT_ID_FIELD), form[EVENT_ID_FIELD])
+        val callbackId = firstValue(value(root, "trigger_id"), value(root, "action_ts"), viewId, form["trigger_id"])
+        return firstValue(eventId, callbackId, headers[REQUEST_ID_HEADER]) ?: sha256(rawBody)
+    }
+
+    private fun challenge(root: JsonObject): String? =
+        if (value(root, TYPE_FIELD) == EVENT_URL_VERIFICATION) value(root, "challenge") else null
+
+    private fun findOrInsert(context: SlackInboundContext): ExistingDelivery = transaction {
+        val existing = SlackInboundDeliveries
+            .selectAll()
+            .where { SlackInboundDeliveries.deliveryKey eq context.deliveryKey }
+            .firstOrNull()
+        if (existing != null) {
+            return@transaction ExistingDelivery(
+                resourceId = existing[SlackInboundDeliveries.resourceId].toString(),
+                status = existing[SlackInboundDeliveries.status],
+                inserted = false,
+            )
+        }
+
+        SlackInboundDeliveries.insertIgnore {
+            it[deliveryKey] = context.deliveryKey
+            it[requestType] = context.requestType.wire
+            it[payload] = context.payload
+            it[teamId] = context.teamId
+            it[enterpriseId] = context.enterpriseId
+            it[channelId] = context.channelId
+            it[userId] = context.userId
+            it[messageTs] = context.messageTs
+            it[threadTs] = context.threadTs
+            it[viewId] = context.viewId
+            it[status] = SlackInboundDeliveryStatus.PENDING.wire
+        }
+        val inserted = SlackInboundDeliveries
+            .selectAll()
+            .where { SlackInboundDeliveries.deliveryKey eq context.deliveryKey }
+            .single()
+        ExistingDelivery(
+            resourceId = inserted[SlackInboundDeliveries.resourceId].toString(),
+            status = inserted[SlackInboundDeliveries.status],
+            inserted = true,
+        )
+    }
+
+    private fun markQueued(resourceId: String) {
+        val id = resourceId.toUuidOrNull() ?: return
+        transaction {
+            SlackInboundDeliveries.update({
+                (SlackInboundDeliveries.resourceId eq id) and
+                    (SlackInboundDeliveries.status eq SlackInboundDeliveryStatus.PENDING.wire)
+            }) {
+                it[status] = SlackInboundDeliveryStatus.QUEUED.wire
+                it[updatedAt] = Clock.System.now()
+            }
+        }
+    }
+
+    private fun markRetry(resourceId: String, error: String?) {
+        val id = resourceId.toUuidOrNull() ?: return
+        transaction {
+            SlackInboundDeliveries.update({ SlackInboundDeliveries.resourceId eq id }) {
+                it[status] = SlackInboundDeliveryStatus.RETRY.wire
+                it[lastError] = error?.take(MAX_ERROR_CHARS)
+                it[updatedAt] = Clock.System.now()
+            }
+        }
+    }
+
+    private data class ExistingDelivery(
+        val resourceId: String?,
+        val status: String,
+        val inserted: Boolean,
+    )
+
+    companion object {
+        private const val MAX_DELIVERY_KEY_CHARS = 384
+        private const val MAX_ERROR_CHARS = 1_000
+
+        fun verifySlackSignature(
+            headers: Headers,
+            rawBody: String,
+            nowSeconds: Long,
+            signingSecret: String? = null,
+        ): Boolean {
+            val timestamp = headers[TIMESTAMP_HEADER] ?: return false
+            val signature = headers[SIGNATURE_HEADER] ?: return false
+            val timestampSeconds = timestamp.toLongOrNull() ?: return false
+            if (abs(nowSeconds - timestampSeconds) > MAX_REQUEST_AGE_SECONDS) return false
+            val secret = signingSecret?.takeIf { it.isNotBlank() }
+                ?: EnvConfig.get("SLACK_SIGNING_SECRET")?.takeIf { it.isNotBlank() }
+                ?: return false
+            return verifySlackSignature(secret, timestamp, signature, rawBody, nowSeconds)
+        }
+
+        fun verifySlackSignature(
+            secret: String,
+            timestamp: String,
+            signature: String,
+            rawBody: String,
+            nowSeconds: Long = timestamp.toLongOrNull() ?: Long.MIN_VALUE,
+        ): Boolean {
+            if (!signature.startsWith("$SIGNATURE_VERSION=")) return false
+            val timestampSeconds = timestamp.toLongOrNull() ?: return false
+            if (abs(nowSeconds - timestampSeconds) > MAX_REQUEST_AGE_SECONDS) return false
+            val mac = Mac.getInstance("HmacSHA256")
+            mac.init(SecretKeySpec(secret.toByteArray(Charsets.UTF_8), "HmacSHA256"))
+            val digest = mac.doFinal("$SIGNATURE_VERSION:$timestamp:$rawBody".toByteArray(Charsets.UTF_8))
+            val expected = "$SIGNATURE_VERSION=" + digest.joinToString("") { "%02x".format(it) }
+            return MessageDigest.isEqual(
+                expected.toByteArray(Charsets.UTF_8),
+                signature.toByteArray(Charsets.UTF_8),
+            )
+        }
+
+        private fun currentTimestampSeconds(): Long = System.currentTimeMillis() / MILLIS_PER_SECOND
+
+        private fun sha256(value: String): String {
+            val digest = MessageDigest.getInstance("SHA-256").digest(value.toByteArray(Charsets.UTF_8))
+            return digest.joinToString("") { "%02x".format(it) }.take(SHA256_HEX_LENGTH)
+        }
+
+        private fun parseJsonObject(raw: String): JsonObject = json.parseToJsonElement(raw).jsonObject
+
+        private fun value(element: JsonObject?, key: String): String? =
+            element?.get(key)?.jsonPrimitive?.contentOrNull
+
+        private fun value(element: JsonObject?, parent: String, key: String): String? =
+            element?.get(parent)?.jsonObject?.get(key)?.jsonPrimitive?.contentOrNull
+
+        private fun firstValue(vararg values: String?): String? = values.firstOrNull { !it.isNullOrBlank() }
+
+        private const val MILLIS_PER_SECOND = 1000L
+    }
+}
+
+private fun String.toUuidOrNull(): Uuid? = runCatching { Uuid.parse(this) }.getOrNull()

--- a/backend/src/main/kotlin/com/moneat/notifications/services/SlackInboundWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/SlackInboundWorker.kt
@@ -1,0 +1,51 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.notifications.services
+
+import com.moneat.ingestion.queue.IngestionPipeline
+import com.moneat.ingestion.queue.IngestionQueueSettings
+import com.moneat.ingestion.queue.RedisQueueWorker
+import com.moneat.monitoring.OperationalMetrics
+import mu.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
+
+class SlackInboundWorker(
+    private val queueKey: String,
+    private val dlqKey: String,
+    private val workerCount: Int,
+    private val gateway: SlackInboundGateway,
+) {
+    private var queueWorker: RedisQueueWorker? = null
+
+    fun start() {
+        val spec = IngestionQueueSettings.spec(IngestionPipeline.SLACK_INBOUND, queueKey, dlqKey, workerCount)
+        queueWorker = RedisQueueWorker(spec, logger, processMessage = ::processMessage).also { it.start() }
+        logger.info { "Slack inbound worker started with $workerCount workers" }
+    }
+
+    fun stop() {
+        queueWorker?.stop()
+        queueWorker = null
+        logger.info { "Slack inbound worker stopped" }
+    }
+
+    private suspend fun processMessage(workerId: Int, value: String) {
+        gateway.process(value)
+        OperationalMetrics.recordWorkerMessageProcessed(IngestionPipeline.SLACK_INBOUND.workerName, workerId)
+    }
+}

--- a/backend/src/main/kotlin/com/moneat/org/routes/IntegrationRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/org/routes/IntegrationRoutes.kt
@@ -19,15 +19,17 @@ package com.moneat.org.routes
 import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.config.EnvConfig
 import com.moneat.notifications.services.DiscordService
+import com.moneat.notifications.services.SlackInboundGateway
+import com.moneat.notifications.services.SlackInboundRequestException
+import com.moneat.notifications.services.SlackInboundRequestRejection
+import com.moneat.notifications.services.SlackInboundRequestType
 import com.moneat.notifications.services.SlackService
 import com.moneat.shared.models.Memberships
 import com.moneat.shared.models.OrganizationIntegrations
 import com.moneat.shared.models.SlackUserMappings
 import com.moneat.utils.ErrorResponse
 import com.moneat.utils.MessageResponse
-import io.ktor.http.Headers
 import io.ktor.http.HttpStatusCode
-import io.ktor.http.parseQueryString
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.auth.authenticate
 import io.ktor.server.auth.jwt.JWTPrincipal
@@ -43,9 +45,6 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.put
 import io.ktor.server.routing.route
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
@@ -56,12 +55,10 @@ import org.jetbrains.exposed.v1.jdbc.update
 import org.koin.core.context.GlobalContext
 import org.slf4j.LoggerFactory
 import java.net.URLEncoder
-import java.security.MessageDigest
 import java.security.SecureRandom
 import java.util.Base64
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
-import kotlin.math.abs
 import kotlin.time.Clock
 import com.moneat.utils.suspendRunCatching
 
@@ -114,8 +111,6 @@ data class SlackChannel(
 )
 
 // Helper functions for secure state management
-private const val MILLIS_PER_SECOND = 1000
-private const val SLACK_REQUEST_MAX_AGE_SECONDS = 300
 private const val NONCE_BYTES_SIZE = 16
 private const val OAUTH_PARTS_COUNT = 5
 private const val OAUTH_STATE_NONCE_INDEX = 3
@@ -130,48 +125,6 @@ private fun getStateSecret(): String {
         .get("JWT_SECRET")
         ?.takeIf { it.isNotBlank() }
         ?: throw IllegalStateException("JWT_SECRET environment variable is required for integration state signing")
-}
-
-private fun getSlackSigningSecret(): String? {
-    return EnvConfig.get("SLACK_SIGNING_SECRET")?.takeIf { it.isNotBlank() }
-}
-
-private fun signSlackRequest(
-    secret: String,
-    timestamp: String,
-    rawBody: String
-): String {
-    val baseString = "v0:$timestamp:$rawBody"
-    val mac = Mac.getInstance("HmacSHA256")
-    mac.init(SecretKeySpec(secret.toByteArray(Charsets.UTF_8), "HmacSHA256"))
-    val digest = mac.doFinal(baseString.toByteArray(Charsets.UTF_8))
-    val hex = digest.joinToString("") { "%02x".format(it) }
-    return "v0=$hex"
-}
-
-private fun verifySlackRequestSignature(
-    headers: Headers,
-    rawBody: String
-): Boolean {
-    val timestamp = headers["X-Slack-Request-Timestamp"] ?: return false
-    val signature = headers["X-Slack-Signature"] ?: return false
-    val requestTs = timestamp.toLongOrNull() ?: return false
-    val nowTs = System.currentTimeMillis() / MILLIS_PER_SECOND
-
-    // Reject stale/replayed payloads.
-    if (abs(nowTs - requestTs) > SLACK_REQUEST_MAX_AGE_SECONDS) return false
-
-    val secret =
-        getSlackSigningSecret() ?: run {
-            logger.error("SLACK_SIGNING_SECRET is not configured; rejecting Slack interaction")
-            return false
-        }
-
-    val expected = signSlackRequest(secret, timestamp, rawBody)
-    return MessageDigest.isEqual(
-        expected.toByteArray(Charsets.UTF_8),
-        signature.toByteArray(Charsets.UTF_8)
-    )
 }
 
 private fun generateSecureState(
@@ -881,136 +834,39 @@ fun Route.integrationCallbackRoutes() {
             }
         }
 
-        // Slack Interactivity Endpoint (for interactive message buttons)
-        post("/slack/interactions") {
-            suspendRunCatching {
+        val slackInboundGateway = GlobalContext.get().get<SlackInboundGateway>()
+        fun Route.slackInboundEndpoint(
+            path: String,
+            requestType: SlackInboundRequestType,
+        ) {
+            post(path) {
                 val rawBody = call.receiveText()
-                if (!verifySlackRequestSignature(call.request.headers, rawBody)) {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid Slack signature"))
-                    return@post
-                }
-
-                // Parse URL-encoded form data from Slack
-                val formParameters = parseQueryString(rawBody)
-                val payload =
-                    formParameters["payload"] ?: run {
-                        call.respond(HttpStatusCode.BadRequest, ErrorResponse("Missing payload"))
-                        return@post
+                try {
+                    val accepted = slackInboundGateway.accept(call.request.headers, rawBody, requestType)
+                    if (accepted.challenge != null) {
+                        call.respond(mapOf("challenge" to accepted.challenge))
+                    } else {
+                        call.respond(HttpStatusCode.Accepted, accepted)
                     }
-
-                // Parse the JSON payload
-                val payloadJson =
-                    kotlinx.serialization.json.Json
-                        .parseToJsonElement(payload)
-                        .jsonObject
-                val type = payloadJson["type"]?.jsonPrimitive?.content
-
-                // Handle block actions (button clicks)
-                if (type == "block_actions") {
-                    val actions = payloadJson["actions"]?.jsonArray
-                    if (actions != null && actions.isNotEmpty()) {
-                        val action = actions[0].jsonObject
-                        val actionId = action["action_id"]?.jsonPrimitive?.content ?: ""
-
-                        // Parse action ID format: "incident_{action}_{alertResourceId}"
-                        if (actionId.startsWith("incident_acknowledge_")) {
-                            val alertResourceId = actionId.removePrefix("incident_acknowledge_")
-                            if (alertResourceId.isNotBlank()) {
-                                // Get user from Slack user ID
-                                val slackUserId =
-                                    payloadJson["user"]
-                                        ?.jsonObject
-                                        ?.get("id")
-                                        ?.jsonPrimitive
-                                        ?.content
-                                val slackTeamId =
-                                    payloadJson["team"]
-                                        ?.jsonObject
-                                        ?.get("id")
-                                        ?.jsonPrimitive
-                                        ?.content
-                                if (slackUserId != null && slackTeamId != null) {
-                                    val userId = getUserIdFromSlackUserId(slackUserId, slackTeamId)
-                                    if (userId != null) {
-                                        val bridge =
-                                            com.moneat.enterprise.FeatureRegistry
-                                                .getOnCallBridge()
-                                        if (bridge == null) {
-                                            call.respond(
-                                                mapOf(
-                                                    "response_type" to "ephemeral",
-                                                    "text" to "❌ On-call features not available"
-                                                )
-                                            )
-                                            return@post
-                                        }
-
-                                        val userOrgId =
-                                            transaction {
-                                                Memberships
-                                                    .selectAll()
-                                                    .where { Memberships.user_id eq userId }
-                                                    .singleOrNull()
-                                                    ?.get(Memberships.organization_id)
-                                            }
-                                        if (userOrgId == null) {
-                                            call.respond(
-                                                mapOf(
-                                                    "response_type" to "ephemeral",
-                                                    "text" to "❌ Alert not found or access denied"
-                                                )
-                                            )
-                                            return@post
-                                        }
-
-                                        val alertId = bridge.resolveAlertId(userOrgId, alertResourceId)
-                                        val alert = alertId?.let { bridge.getAlert(it, userId) }
-
-                                        if (alert == null ||
-                                            alert.organizationId != userOrgId
-                                        ) {
-                                            call.respond(
-                                                mapOf(
-                                                    "response_type" to "ephemeral",
-                                                    "text" to "❌ Alert not found or access denied"
-                                                )
-                                            )
-                                            return@post
-                                        }
-
-                                        val acknowledged = bridge.acknowledgeAlert(alertId, userId)
-
-                                        if (acknowledged) {
-                                            // Send success response
-                                            call.respond(
-                                                mapOf(
-                                                    "response_type" to "in_channel",
-                                                    "text" to "✅ Alert acknowledged by <@$slackUserId>"
-                                                )
-                                            )
-                                        } else {
-                                            call.respond(
-                                                mapOf(
-                                                    "response_type" to "ephemeral",
-                                                    "text" to "❌ Failed to acknowledge alert"
-                                                )
-                                            )
-                                        }
-                                        return@post
-                                    }
-                                }
-                            }
-                        }
+                } catch (error: SlackInboundRequestException) {
+                    val status = when (error.reason) {
+                        SlackInboundRequestRejection.INVALID_SIGNATURE -> HttpStatusCode.Unauthorized
+                        SlackInboundRequestRejection.INVALID_BODY -> HttpStatusCode.BadRequest
+                        SlackInboundRequestRejection.QUEUE_UNAVAILABLE -> HttpStatusCode.ServiceUnavailable
                     }
+                    call.respond(status, ErrorResponse(error.message))
+                } catch (error: Exception) {
+                    logger.error("Error accepting Slack inbound delivery", error)
+                    call.respond(HttpStatusCode.InternalServerError, ErrorResponse("Internal error"))
                 }
-
-                // Default response for unhandled actions
-                call.respond(HttpStatusCode.OK, mapOf("text" to "Action received"))
-            }.getOrElse { e ->
-                logger.error("Error processing Slack interaction", e)
-                call.respond(HttpStatusCode.InternalServerError, ErrorResponse("Internal error"))
             }
         }
+
+        slackInboundEndpoint("/slack/commands", SlackInboundRequestType.COMMAND)
+        slackInboundEndpoint("/slack/events", SlackInboundRequestType.EVENT)
+        slackInboundEndpoint("/slack/shortcuts", SlackInboundRequestType.SHORTCUT)
+        slackInboundEndpoint("/slack/mentions", SlackInboundRequestType.MENTION)
+        slackInboundEndpoint("/slack/interactions", SlackInboundRequestType.INTERACTION)
 
         // Slack User Linking Endpoint
         authenticate("auth-jwt") {
@@ -1067,18 +923,3 @@ fun Route.integrationCallbackRoutes() {
         }
     }
 }
-
-// Helper function to get user ID from Slack user ID
-private fun getUserIdFromSlackUserId(
-    slackUserId: String,
-    slackTeamId: String
-): Int? =
-    transaction {
-        SlackUserMappings
-            .selectAll()
-            .where {
-                (SlackUserMappings.slackUserId eq slackUserId) and
-                    (SlackUserMappings.slackTeamId eq slackTeamId)
-            }.singleOrNull()
-            ?.get(SlackUserMappings.userId)
-    }

--- a/backend/src/main/kotlin/com/moneat/plugins/BackgroundJobs.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/BackgroundJobs.kt
@@ -22,6 +22,8 @@ import com.moneat.enterprise.FeatureRegistry
 import com.moneat.events.services.IngestionWorker
 import com.moneat.ingestion.queue.IngestionPipeline
 import com.moneat.ingestion.queue.IngestionQueueSettings
+import com.moneat.config.EnvConfig
+import com.moneat.notifications.services.SlackInboundWorker
 import com.moneat.shared.services.ArtifactCleanupService
 import com.moneat.shared.services.DemoLivenessBackgroundService
 import com.moneat.shared.services.RetentionBackgroundService
@@ -109,15 +111,25 @@ private class CoreIngestionWorkers(application: Application) {
         config.property("ingest.workerCount").getString().toInt(),
         eventService = koin.get(),
     )
+    private val slackInboundWorker = SlackInboundWorker(
+        queueKey = EnvConfig.get("SLACK_INBOUND_QUEUE_KEY") ?: "slack-inbound",
+        dlqKey = EnvConfig.get("SLACK_INBOUND_DLQ_KEY") ?: "slack-inbound-dlq",
+        workerCount = EnvConfig.get("SLACK_INBOUND_WORKER_COUNT")?.toIntOrNull()?.coerceAtLeast(1) ?: 1,
+        gateway = koin.get(),
+    )
 
     fun startSelected(startIngestionWorkers: Boolean) {
         if (shouldStartIngestionPipeline(startIngestionWorkers, IngestionPipeline.EVENTS)) {
             ingestionWorker.start()
         }
+        if (shouldStartIngestionPipeline(startIngestionWorkers, IngestionPipeline.SLACK_INBOUND)) {
+            slackInboundWorker.start()
+        }
     }
 
     fun stop() {
         ingestionWorker.stop()
+        slackInboundWorker.stop()
     }
 }
 

--- a/backend/src/main/kotlin/com/moneat/shared/models/SlackInboundModels.kt
+++ b/backend/src/main/kotlin/com/moneat/shared/models/SlackInboundModels.kt
@@ -1,0 +1,60 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.shared.models
+
+import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
+import org.jetbrains.exposed.v1.datetime.timestamp
+import kotlin.time.Clock
+import kotlin.uuid.Uuid
+
+enum class SlackInboundDeliveryStatus(val wire: String) {
+    PENDING("PENDING"),
+    QUEUED("QUEUED"),
+    PROCESSING("PROCESSING"),
+    PROCESSED("PROCESSED"),
+    RETRY("RETRY"),
+}
+
+object SlackInboundDeliveries : LongIdTable("slack_inbound_deliveries") {
+    val resourceId = uuid("resource_id").clientDefault { Uuid.random() }
+    val deliveryKey = varchar("delivery_key", 384)
+    val requestType = varchar("request_type", 32)
+    val payload = text("payload")
+    val teamId = varchar("team_id", 128).nullable()
+    val enterpriseId = varchar("enterprise_id", 128).nullable()
+    val channelId = varchar("channel_id", 128).nullable()
+    val userId = varchar("user_id", 128).nullable()
+    val messageTs = varchar("message_ts", 64).nullable()
+    val threadTs = varchar("thread_ts", 64).nullable()
+    val viewId = varchar("view_id", 256).nullable()
+    val status = varchar("status", 24).default(SlackInboundDeliveryStatus.PENDING.wire)
+    val attemptCount = integer("attempt_count").default(0)
+    val availableAt = timestamp("available_at").clientDefault { Clock.System.now() }
+    val leasedAt = timestamp("leased_at").nullable()
+    val leaseOwner = varchar("lease_owner", 120).nullable()
+    val lastError = text("last_error").nullable()
+    val processedAt = timestamp("processed_at").nullable()
+    val createdAt = timestamp("created_at").clientDefault { Clock.System.now() }
+    val updatedAt = timestamp("updated_at").clientDefault { Clock.System.now() }
+
+    init {
+        uniqueIndex(deliveryKey)
+        uniqueIndex(resourceId)
+        index(false, status, availableAt, id)
+        index(false, teamId, channelId, userId, createdAt)
+    }
+}

--- a/backend/src/main/resources/db/migration/V166__durable_slack_inbound_gateway.sql
+++ b/backend/src/main/resources/db/migration/V166__durable_slack_inbound_gateway.sql
@@ -1,0 +1,31 @@
+CREATE TABLE slack_inbound_deliveries (
+    id BIGSERIAL PRIMARY KEY,
+    resource_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    delivery_key VARCHAR(384) NOT NULL,
+    request_type VARCHAR(32) NOT NULL,
+    payload TEXT NOT NULL,
+    team_id VARCHAR(128),
+    enterprise_id VARCHAR(128),
+    channel_id VARCHAR(128),
+    user_id VARCHAR(128),
+    message_ts VARCHAR(64),
+    thread_ts VARCHAR(64),
+    view_id VARCHAR(256),
+    status VARCHAR(24) NOT NULL DEFAULT 'PENDING',
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    available_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    leased_at TIMESTAMPTZ,
+    lease_owner VARCHAR(120),
+    last_error TEXT,
+    processed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_slack_inbound_deliveries_resource UNIQUE (resource_id),
+    CONSTRAINT uq_slack_inbound_deliveries_key UNIQUE (delivery_key)
+);
+
+CREATE INDEX idx_slack_inbound_deliveries_ready
+    ON slack_inbound_deliveries (status, available_at, id);
+
+CREATE INDEX idx_slack_inbound_deliveries_context
+    ON slack_inbound_deliveries (team_id, channel_id, user_id, created_at);

--- a/backend/src/test/kotlin/com/moneat/notifications/services/SlackInboundGatewayTest.kt
+++ b/backend/src/test/kotlin/com/moneat/notifications/services/SlackInboundGatewayTest.kt
@@ -1,0 +1,234 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.notifications.services
+
+import com.moneat.ingestion.queue.IngestionPipeline
+import com.moneat.ingestion.queue.IngestionQueueClient
+import com.moneat.shared.models.SlackInboundDeliveries
+import com.moneat.shared.models.SlackInboundDeliveryStatus
+import com.moneat.testsupport.TestDatabaseHelper
+import io.ktor.http.headersOf
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import java.net.URLEncoder
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import org.jetbrains.exposed.v1.core.eq
+
+class SlackInboundGatewayTest {
+    companion object {
+        private const val SECRET = "gateway-test-secret"
+        private var database: Database? = null
+    }
+
+    @BeforeTest
+    fun setUp() {
+        if (database == null) {
+            database = Database.connect(
+                url = "jdbc:h2:mem:moneat_slack_inbound;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
+                driver = "org.h2.Driver",
+            )
+        }
+        TransactionManager.defaultDatabase = database
+        TestDatabaseHelper.resetSchema(SlackInboundDeliveries)
+        mockkObject(IngestionQueueClient)
+        every { IngestionQueueClient.enqueue(any(), any(), any()) } returns "1-0"
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkObject(IngestionQueueClient)
+    }
+
+    @Test
+    fun `accepts a fresh signed request with constant time comparison`() {
+        val body = "command=%2Fmoneat&team_id=T1&user_id=U1"
+        val timestamp = "1700000000"
+        val signature = signature(SECRET, timestamp, body)
+        assertTrue(SlackInboundGateway.verifySlackSignature(SECRET, timestamp, signature, body))
+    }
+
+    @Test
+    fun `rejects stale, malformed, and tampered signatures`() {
+        val body = "payload={}"
+        val timestamp = "1700000000"
+        val signature = signature(SECRET, timestamp, body)
+        assertFalse(
+            SlackInboundGateway.verifySlackSignature(
+                SECRET,
+                timestamp,
+                signature,
+                body,
+                timestamp.toLong() + 301,
+            ),
+        )
+        assertFalse(SlackInboundGateway.verifySlackSignature(SECRET, timestamp, "v1=invalid", body))
+        assertFalse(SlackInboundGateway.verifySlackSignature(SECRET, timestamp, signature, "$body&tampered=true"))
+        assertFalse(SlackInboundGateway.verifySlackSignature(headersOf(), body, timestamp.toLong() + 1))
+    }
+
+    @Test
+    fun `rejects oversized, unsigned, and malformed requests before persistence`() {
+        val gateway = SlackInboundGateway(signingSecret = SECRET)
+        assertFailsWith<SlackInboundRequestException> {
+            gateway.accept(headersOf(), "x".repeat(1_000_001), SlackInboundRequestType.COMMAND)
+        }.also { assertEquals(SlackInboundRequestRejection.INVALID_BODY, it.reason) }
+        assertFailsWith<SlackInboundRequestException> {
+            gateway.accept(headersOf(), "{}", SlackInboundRequestType.COMMAND)
+        }.also { assertEquals(SlackInboundRequestRejection.INVALID_SIGNATURE, it.reason) }
+        val malformed = "{not-json"
+        assertFailsWith<SlackInboundRequestException> {
+            gateway.accept(signedHeaders(SECRET, malformed), malformed, SlackInboundRequestType.COMMAND)
+        }.also { assertEquals(SlackInboundRequestRejection.INVALID_BODY, it.reason) }
+    }
+
+    @Test
+    fun `returns a signed URL verification challenge without queueing`() {
+        val body = """{"type":"url_verification","challenge":"challenge-1","team_id":"T1"}"""
+        val acceptance = SlackInboundGateway(signingSecret = SECRET).accept(
+            signedHeaders(SECRET, body),
+            body,
+            SlackInboundRequestType.EVENT,
+        )
+
+        assertEquals("challenge-1", acceptance.challenge)
+        assertEquals(null, acceptance.deliveryId)
+        verify(exactly = 0) { IngestionQueueClient.enqueue(any(), any(), any()) }
+    }
+
+    @Test
+    fun `persists complete form context and deduplicates Slack retries`() {
+        val body = formBody()
+        val gateway = SlackInboundGateway(signingSecret = SECRET)
+
+        val accepted = gateway.accept(signedHeaders(SECRET, body), body, SlackInboundRequestType.INTERACTION)
+        val duplicate = gateway.accept(signedHeaders(SECRET, body), body, SlackInboundRequestType.INTERACTION)
+        val deliveryId = accepted.deliveryId
+
+        assertNotNull(deliveryId)
+        assertFalse(accepted.duplicate)
+        assertTrue(duplicate.duplicate)
+        val row = transaction {
+            SlackInboundDeliveries.selectAll().single()
+        }
+        assertEquals("QUEUED", row[SlackInboundDeliveries.status])
+        assertEquals("T1", row[SlackInboundDeliveries.teamId])
+        assertEquals("E1", row[SlackInboundDeliveries.enterpriseId])
+        assertEquals("C1", row[SlackInboundDeliveries.channelId])
+        assertEquals("U1", row[SlackInboundDeliveries.userId])
+        assertEquals("1710000000.000001", row[SlackInboundDeliveries.messageTs])
+        assertEquals("1710000000.000000", row[SlackInboundDeliveries.threadTs])
+        assertEquals("V1", row[SlackInboundDeliveries.viewId])
+        verify(exactly = 1) {
+            IngestionQueueClient.enqueue(IngestionPipeline.SLACK_INBOUND, "slack-inbound", deliveryId)
+        }
+    }
+
+    @Test
+    fun `requeues retry state and marks durable delivery processed`() {
+        val body = formBody()
+        val gateway = SlackInboundGateway(signingSecret = SECRET)
+        val acceptance = gateway.accept(signedHeaders(SECRET, body), body, SlackInboundRequestType.COMMAND)
+        val deliveryId = requireNotNull(acceptance.deliveryId)
+        transaction {
+            SlackInboundDeliveries.update({ SlackInboundDeliveries.resourceId eq kotlin.uuid.Uuid.parse(deliveryId) }) {
+                it[status] = SlackInboundDeliveryStatus.RETRY.wire
+            }
+        }
+
+        val retried = gateway.accept(signedHeaders(SECRET, body), body, SlackInboundRequestType.COMMAND)
+        gateway.process(deliveryId)
+
+        assertFalse(retried.duplicate)
+        val row = transaction { SlackInboundDeliveries.selectAll().single() }
+        assertEquals(SlackInboundDeliveryStatus.PROCESSED.wire, row[SlackInboundDeliveries.status])
+        assertEquals(1, row[SlackInboundDeliveries.attemptCount])
+        verify(exactly = 2) { IngestionQueueClient.enqueue(any(), any(), any()) }
+        gateway.process(deliveryId)
+    }
+
+    @Test
+    fun `records queue failure for retry`() {
+        every { IngestionQueueClient.enqueue(any(), any(), any()) } throws IllegalStateException("redis down")
+        val body = formBody()
+        val gateway = SlackInboundGateway(signingSecret = SECRET)
+
+        assertFailsWith<SlackInboundRequestException> {
+            gateway.accept(signedHeaders(SECRET, body), body, SlackInboundRequestType.COMMAND)
+        }.also { assertEquals(SlackInboundRequestRejection.QUEUE_UNAVAILABLE, it.reason) }
+        val row = transaction { SlackInboundDeliveries.selectAll().single() }
+        assertEquals(SlackInboundDeliveryStatus.RETRY.wire, row[SlackInboundDeliveries.status])
+        assertEquals("redis down", row[SlackInboundDeliveries.lastError])
+    }
+
+    @Test
+    fun `retains nested event and interaction context from JSON payload`() {
+        val payload = """
+            {"type":"block_actions","event_id":"Ev1","team":{"id":"T2"},
+             "enterprise":{"id":"E2"},"channel":{"id":"C2"},"user":{"id":"U2"},
+             "container":{"message_ts":"2.1","thread_ts":"2.0"},
+             "view":{"id":"V2"},"trigger_id":"TR2"}
+        """.trimIndent()
+        val body = "payload=" + URLEncoder.encode(payload, Charsets.UTF_8)
+        val gateway = SlackInboundGateway(signingSecret = SECRET)
+
+        val acceptance = gateway.accept(signedHeaders(SECRET, body), body, SlackInboundRequestType.INTERACTION)
+        assertNotNull(acceptance.deliveryId)
+        val row = transaction { SlackInboundDeliveries.selectAll().single() }
+        assertEquals("T2", row[SlackInboundDeliveries.teamId])
+        assertEquals("E2", row[SlackInboundDeliveries.enterpriseId])
+        assertEquals("C2", row[SlackInboundDeliveries.channelId])
+        assertEquals("U2", row[SlackInboundDeliveries.userId])
+        assertEquals("2.1", row[SlackInboundDeliveries.messageTs])
+        assertEquals("2.0", row[SlackInboundDeliveries.threadTs])
+        assertEquals("V2", row[SlackInboundDeliveries.viewId])
+    }
+
+    private fun formBody(): String =
+        "team_id=T1&enterprise_id=E1&channel_id=C1&user_id=U1" +
+            "&message_ts=1710000000.000001&thread_ts=1710000000.000000&view_id=V1&trigger_id=TR1"
+
+    private fun signedHeaders(secret: String, body: String): io.ktor.http.Headers {
+        val timestamp = (System.currentTimeMillis() / 1_000L).toString()
+        return headersOf(
+            "X-Slack-Request-Timestamp" to listOf(timestamp),
+            "X-Slack-Signature" to listOf(signature(secret, timestamp, body)),
+        )
+    }
+
+    private fun signature(secret: String, timestamp: String, body: String): String {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(secret.toByteArray(), "HmacSHA256"))
+        val digest = mac.doFinal("v0:$timestamp:$body".toByteArray())
+        return "v0=" + digest.joinToString("") { "%02x".format(it) }
+    }
+}

--- a/docs/security/incident-response-threat-model.md
+++ b/docs/security/incident-response-threat-model.md
@@ -39,7 +39,7 @@ The Backlog is authoritative for task boundaries. The security-relevant owners a
 |------|-------|--------|
 | TASK-1.2 | Incident command policy, authorization, concurrency, and idempotency | In progress |
 | TASK-1.7 | Slack installation, scopes, workspace bindings, token health, and privileged installation access | In progress |
-| TASK-1.8 | Durable authenticated inbound Slack gateway, including replay protection | Planned |
+| TASK-1.8 | Durable authenticated inbound Slack gateway, including replay protection | Implemented |
 | TASK-1.9 | Slack identity, responder permissions, and private-incident access | Planned |
 | TASK-1.10 | Durable outbound Slack delivery and reconciliation | Planned |
 | TASK-1.11–1.22 | Incident-channel provisioning and Slack responder feature surfaces; each task owns authorization and safe rendering for its own actions/messages | Planned |
@@ -83,7 +83,7 @@ The Backlog is authoritative for task boundaries. The security-relevant owners a
 | Entitlement gating of native incidents | **Implemented** (`IncidentCommandPolicy`) | Keep; add per-command authorization beyond "member of org" | TASK-1.2 / 1.50 |
 | Command authorization granularity | **Coarse**: authorizer allows any `org>0 && user>0` actor (`IncidentCommandPolicy.kt:21-23`) | Role/visibility-aware authorization per command type | TASK-1.2 / 1.9 |
 | Private incident visibility (`PRIVATE`) | **Stored, not enforced on read**: incident reads filter by org only (`OnCallIncidentService.kt:148-256`); timeline list/export/revisions resolve the incident in-org but do not apply caller or event visibility, and export includes deleted events (`IncidentTimelineRoutes.kt`, `IncidentTimelineService.export`) | Enforce membership-gated read/list/timeline/revision/export/metadata for `PRIVATE`, `PARTICIPANTS`, and deleted entries | TASK-1.9 |
-| Slack signature/timestamp/replay verification (inbound) | **Implemented** for `/slack/interactions` (`verifySlackRequestSignature`, 300s window, constant-time compare — `IntegrationRoutes.kt:152-175`) | Keep; extend to all inbound routes; add nonce replay cache | TASK-1.8 |
+| Slack signature/timestamp/replay verification (inbound) | **Implemented** for commands, events, shortcuts, mentions, and interactions through `SlackInboundGateway` (300s window, constant-time compare, durable delivery-key deduplication) | Keep; bind every delivery to the verified workspace identity and downstream command idempotency | TASK-1.7 / 1.9 |
 | Slack workspace install model | **Single bot token per org** in `organization_integrations.access_token`, plaintext (`IntegrationRoutes.kt:732`) | Workspace = explicit principal; **distinct bot vs user grants**; explicit workspace↔org bindings; encrypted at rest | TASK-1.7 |
 | Slack identity mapping | **Self-asserted, not workspace-verified, not org-scoped** (`SlackUserMappings`, `/slack/link-user` — `IntegrationRoutes.kt:1017-1084`) | Resolve `team_id` to a workspace binding, then key verified mappings and every lookup/write by `(workspace_binding_id, slack_user_id)`; handle guests/Connect/stale users | TASK-1.9 |
 | Token storage | **Plaintext** Slack token + OSS provider `api_key` (`incident_provider_configs.api_key`) | Encrypt integration secrets with dedicated per-purpose keys; never return plaintext from management APIs | TASK-1.7 / 1.48 |
@@ -149,7 +149,7 @@ The Backlog is authoritative for task boundaries. The security-relevant owners a
 |---|---|---|
 | REST incident commands | `ee/.../oncall/routes/IncidentRoutes.kt` (JWT) | Authenticated member |
 | Slack OAuth start/callback | `/slack/oauth/start`, `/slack/oauth/callback` (`IntegrationRoutes.kt:298,655`) | Signed-state CSRF-bound |
-| Slack interactivity | `POST /slack/interactions` (`IntegrationRoutes.kt:885`) | Slack-signed body |
+| Slack inbound gateway | `POST /slack/commands`, `/slack/events`, `/slack/shortcuts`, `/slack/mentions`, `/slack/interactions` (`IntegrationRoutes.kt`) | Slack-signed body; durable delivery record before asynchronous processing |
 | Slack user link | `POST /slack/link-user` (`IntegrationRoutes.kt:1017`) | Authenticated member (self-asserted mapping) |
 | Twilio webhooks | `/sms-status`, `/call-status`, `/gather` (`TwilioWebhookRoutes.kt`) | Twilio-signed (`X-Twilio-Signature`) |
 | AI chat / assistant | `ee/.../ai/routes/AiChatRoutes.kt`, `AiAssistantRoutes.kt` | Authenticated member |
@@ -188,7 +188,7 @@ flowchart TB
 
     subgraph edge["Moneat API edge (TLS)"]
         oauth["OAuth start/callback<br/>signed CSRF state<br/>IntegrationRoutes.kt:298,655"]
-        interact["POST /slack/interactions<br/>signature+timestamp verify<br/>IntegrationRoutes.kt:885"]
+        interact["Slack inbound gateway<br/>commands / events / shortcuts / mentions / interactions<br/>signature+timestamp verify"]
         linkuser["POST /slack/link-user<br/>(self-asserted today)"]
         rest["REST incident commands<br/>IncidentRoutes.kt"]
     end


### PR DESCRIPTION
## Summary
- verify signed Slack deliveries before organization lookup
- persist replay-safe delivery context and enqueue asynchronous work
- cover commands, events, shortcuts, mentions, and interactions
- add the durable delivery migration, worker, and threat-model updates

## Validation
- `./gradlew detekt --no-daemon --console=plain`
- `./gradlew :features:org:test --tests com.moneat.routes.IntegrationRoutesTest --no-daemon --console=plain`
- `./gradlew test --tests com.moneat.notifications.services.SlackInboundGatewayTest --no-daemon --console=plain`
- `python3 scripts/check-migration-versions.py --base-ref origin/develop`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unified Slack inbound handling for commands, events, shortcuts, mentions, and interactions.
  * Added durable delivery tracking with deduplication, retries, and asynchronous processing.
  * Added URL-verification challenge support and improved request validation.
* **Bug Fixes**
  * Prevented stale, malformed, oversized, unsigned, or tampered Slack requests from being accepted.
* **Documentation**
  * Updated security documentation to reflect coverage across all Slack inbound routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->