### PR TITLE
feat(slack): enforce identity and incident authorization

### DIFF
--- a/backend/src/main/kotlin/com/moneat/di/AppModules.kt
+++ b/backend/src/main/kotlin/com/moneat/di/AppModules.kt
@@ -35,6 +35,7 @@ import com.moneat.notifications.services.EmailService
 import com.moneat.notifications.services.NotificationService
 import com.moneat.notifications.services.SlackService
 import com.moneat.notifications.services.SlackInboundGateway
+import com.moneat.notifications.services.SlackIdentityResolver
 import com.moneat.shared.repositories.MembershipRepository
 import com.moneat.shared.repositories.MembershipRepositoryImpl
 import com.moneat.shared.repositories.OrganizationRepository
@@ -57,6 +58,7 @@ val sharedModule = module {
     single { EmailService() }
     single { SlackService() }
     single { SlackInboundGateway() }
+    single { SlackIdentityResolver() }
     single { DiscordService() }
     single { AlertNotificationPreferencesService() }
     single { AlertSilenceService() }

--- a/backend/src/main/kotlin/com/moneat/notifications/services/SlackIdentityResolver.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/SlackIdentityResolver.kt
@@ -97,85 +97,87 @@ class SlackIdentityResolver {
         }
 
         return transaction {
-            val mapping = SlackUserMappings
-                .selectAll()
-                .where {
-                    (SlackUserMappings.slackTeamId eq teamId) and
-                        (SlackUserMappings.slackUserId eq userId)
-                }
-                .firstOrNull()
-            if (mapping == null) {
-                return@transaction resolution(
-                    SlackIdentityStatus.UNMAPPED,
-                    teamId,
-                    enterpriseId,
-                    LINK_USER_MESSAGE,
-                )
-            }
-            val mappedUserId = mapping[SlackUserMappings.userId]
-            val user = Users
-                .selectAll()
-                .where { Users.id eq mappedUserId }
-                .firstOrNull()
-            if (user == null || user[Users.deletedAt] != null) {
-                return@transaction resolution(
-                    SlackIdentityStatus.REVOKED,
-                    teamId,
-                    enterpriseId,
-                    "This Slack identity is no longer active in Moneat. Relink it from the organization settings.",
-                )
-            }
+            resolveMappedIdentity(teamId, userId, enterpriseId, request.organizationId)
+        }
+    }
 
-            val installedOrganizations = OrganizationIntegrations
-                .selectAll()
-                .where {
-                    (OrganizationIntegrations.integration_type eq "slack") and
-                        (OrganizationIntegrations.team_id eq teamId) and
-                        (OrganizationIntegrations.enabled eq true)
-                }
-                .map { it[OrganizationIntegrations.organization_id] }
-                .distinct()
-            val memberships = Memberships
-                .selectAll()
-                .where { Memberships.user_id eq mappedUserId }
-                .toList()
-            val membership = memberships.firstOrNull { row ->
-                val organizationId = row[Memberships.organization_id]
-                (request.organizationId == null && organizationId in installedOrganizations) ||
-                    organizationId == request.organizationId
+    private fun resolveMappedIdentity(
+        teamId: String,
+        slackUserId: String,
+        enterpriseId: String?,
+        requestedOrganizationId: Int?,
+    ): SlackIdentityResolution {
+        val mapping = SlackUserMappings
+            .selectAll()
+            .where {
+                (SlackUserMappings.slackTeamId eq teamId) and
+                    (SlackUserMappings.slackUserId eq slackUserId)
             }
-            if (membership == null) {
-                val status = if (memberships.isEmpty()) {
-                    SlackIdentityStatus.REVOKED
-                } else {
-                    SlackIdentityStatus.CROSS_ORGANIZATION
-                }
-                return@transaction resolution(
-                    status,
-                    teamId,
-                    enterpriseId,
-                    "This Slack identity is not a member of the connected Moneat organization.",
-                )
-            }
-            val role = runCatching { OrgRole.fromString(membership[Memberships.role]) }.getOrNull()
-            if (role == null) {
-                return@transaction resolution(
-                    SlackIdentityStatus.REVOKED,
-                    teamId,
-                    enterpriseId,
-                    "This Moneat membership has an invalid or revoked role.",
-                )
-            }
-            SlackIdentityResolution(
-                status = SlackIdentityStatus.MAPPED,
-                organizationId = membership[Memberships.organization_id],
-                userId = mappedUserId,
-                role = role,
-                teamId = teamId,
-                enterpriseId = enterpriseId,
-                message = "Slack identity mapped to an active Moneat member.",
+            .firstOrNull()
+            ?: return resolution(SlackIdentityStatus.UNMAPPED, teamId, enterpriseId, LINK_USER_MESSAGE)
+        val mappedUserId = mapping[SlackUserMappings.userId]
+        val user = Users.selectAll().where { Users.id eq mappedUserId }.firstOrNull()
+        if (user == null || user[Users.deletedAt] != null) {
+            return resolution(
+                SlackIdentityStatus.REVOKED,
+                teamId,
+                enterpriseId,
+                "This Slack identity is no longer active in Moneat. Relink it from the organization settings.",
             )
         }
+        return resolveMembership(teamId, enterpriseId, mappedUserId, requestedOrganizationId)
+    }
+
+    private fun resolveMembership(
+        teamId: String,
+        enterpriseId: String?,
+        mappedUserId: Int,
+        requestedOrganizationId: Int?,
+    ): SlackIdentityResolution {
+        val installedOrganizations = OrganizationIntegrations
+            .selectAll()
+            .where {
+                (OrganizationIntegrations.integration_type eq "slack") and
+                    (OrganizationIntegrations.team_id eq teamId) and
+                    (OrganizationIntegrations.enabled eq true)
+            }
+            .map { it[OrganizationIntegrations.organization_id] }
+            .distinct()
+        val memberships = Memberships.selectAll().where { Memberships.user_id eq mappedUserId }.toList()
+        val membership = memberships.firstOrNull { row ->
+            val organizationId = row[Memberships.organization_id]
+            (requestedOrganizationId == null && organizationId in installedOrganizations) ||
+                organizationId == requestedOrganizationId
+        }
+        if (membership == null) {
+            val status = if (memberships.isEmpty()) {
+                SlackIdentityStatus.REVOKED
+            } else {
+                SlackIdentityStatus.CROSS_ORGANIZATION
+            }
+            return resolution(
+                status,
+                teamId,
+                enterpriseId,
+                "This Slack identity is not a member of the connected Moneat organization.",
+            )
+        }
+        val role = runCatching { OrgRole.fromString(membership[Memberships.role]) }.getOrNull()
+            ?: return resolution(
+                SlackIdentityStatus.REVOKED,
+                teamId,
+                enterpriseId,
+                "This Moneat membership has an invalid or revoked role.",
+            )
+        return SlackIdentityResolution(
+            status = SlackIdentityStatus.MAPPED,
+            organizationId = membership[Memberships.organization_id],
+            userId = mappedUserId,
+            role = role,
+            teamId = teamId,
+            enterpriseId = enterpriseId,
+            message = "Slack identity mapped to an active Moneat member.",
+        )
     }
 
     private fun resolution(

--- a/backend/src/main/kotlin/com/moneat/notifications/services/SlackIdentityResolver.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/SlackIdentityResolver.kt
@@ -1,0 +1,199 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.notifications.services
+
+import com.moneat.org.services.OrgRole
+import com.moneat.shared.models.Memberships
+import com.moneat.shared.models.OrganizationIntegrations
+import com.moneat.shared.models.SlackUserMappings
+import com.moneat.shared.models.Users
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+
+enum class SlackIdentityStatus {
+    MAPPED,
+    UNMAPPED,
+    GUEST,
+    EXTERNAL,
+    REVOKED,
+    CROSS_ORGANIZATION,
+}
+
+data class SlackIdentityRequest(
+    val teamId: String?,
+    val enterpriseId: String? = null,
+    val userId: String?,
+    val organizationId: Int? = null,
+    val isGuest: Boolean = false,
+    val isExternal: Boolean = false,
+)
+
+data class SlackIdentityResolution(
+    val status: SlackIdentityStatus,
+    val organizationId: Int? = null,
+    val userId: Int? = null,
+    val role: OrgRole? = null,
+    val teamId: String? = null,
+    val enterpriseId: String? = null,
+    val message: String,
+) {
+    val isMapped: Boolean
+        get() = status == SlackIdentityStatus.MAPPED
+
+    val canRespond: Boolean
+        get() = isMapped && role != null
+}
+
+/**
+ * Resolves a Slack principal against the workspace binding and current Moneat membership.
+ * The resolver intentionally returns a safe decision instead of throwing: inbound workers
+ * must be able to acknowledge Slack requests without exposing organization data or retrying
+ * permanently unauthorized deliveries.
+ */
+class SlackIdentityResolver {
+    fun resolve(request: SlackIdentityRequest): SlackIdentityResolution {
+        val teamId = request.teamId?.trim()?.takeIf(String::isNotEmpty)
+        val userId = request.userId?.trim()?.takeIf(String::isNotEmpty)
+        val enterpriseId = request.enterpriseId?.trim()?.takeIf(String::isNotEmpty)
+        if (request.isExternal) {
+            return resolution(
+                SlackIdentityStatus.EXTERNAL,
+                teamId,
+                enterpriseId,
+                "External Slack users must be linked to an organization member before they can respond.",
+            )
+        }
+        if (request.isGuest) {
+            return resolution(
+                SlackIdentityStatus.GUEST,
+                teamId,
+                enterpriseId,
+                "Slack guests need an explicit Moneat membership before they can respond.",
+            )
+        }
+        if (teamId == null || userId == null) {
+            return resolution(
+                SlackIdentityStatus.UNMAPPED,
+                teamId,
+                enterpriseId,
+                LINK_USER_MESSAGE,
+            )
+        }
+
+        return transaction {
+            val mapping = SlackUserMappings
+                .selectAll()
+                .where {
+                    (SlackUserMappings.slackTeamId eq teamId) and
+                        (SlackUserMappings.slackUserId eq userId)
+                }
+                .firstOrNull()
+            if (mapping == null) {
+                return@transaction resolution(
+                    SlackIdentityStatus.UNMAPPED,
+                    teamId,
+                    enterpriseId,
+                    LINK_USER_MESSAGE,
+                )
+            }
+            val mappedUserId = mapping[SlackUserMappings.userId]
+            val user = Users
+                .selectAll()
+                .where { Users.id eq mappedUserId }
+                .firstOrNull()
+            if (user == null || user[Users.deletedAt] != null) {
+                return@transaction resolution(
+                    SlackIdentityStatus.REVOKED,
+                    teamId,
+                    enterpriseId,
+                    "This Slack identity is no longer active in Moneat. Relink it from the organization settings.",
+                )
+            }
+
+            val installedOrganizations = OrganizationIntegrations
+                .selectAll()
+                .where {
+                    (OrganizationIntegrations.integration_type eq "slack") and
+                        (OrganizationIntegrations.team_id eq teamId) and
+                        (OrganizationIntegrations.enabled eq true)
+                }
+                .map { it[OrganizationIntegrations.organization_id] }
+                .distinct()
+            val memberships = Memberships
+                .selectAll()
+                .where { Memberships.user_id eq mappedUserId }
+                .toList()
+            val membership = memberships.firstOrNull { row ->
+                val organizationId = row[Memberships.organization_id]
+                (request.organizationId == null && organizationId in installedOrganizations) ||
+                    organizationId == request.organizationId
+            }
+            if (membership == null) {
+                val status = if (memberships.isEmpty()) {
+                    SlackIdentityStatus.REVOKED
+                } else {
+                    SlackIdentityStatus.CROSS_ORGANIZATION
+                }
+                return@transaction resolution(
+                    status,
+                    teamId,
+                    enterpriseId,
+                    "This Slack identity is not a member of the connected Moneat organization.",
+                )
+            }
+            val role = runCatching { OrgRole.fromString(membership[Memberships.role]) }.getOrNull()
+            if (role == null) {
+                return@transaction resolution(
+                    SlackIdentityStatus.REVOKED,
+                    teamId,
+                    enterpriseId,
+                    "This Moneat membership has an invalid or revoked role.",
+                )
+            }
+            SlackIdentityResolution(
+                status = SlackIdentityStatus.MAPPED,
+                organizationId = membership[Memberships.organization_id],
+                userId = mappedUserId,
+                role = role,
+                teamId = teamId,
+                enterpriseId = enterpriseId,
+                message = "Slack identity mapped to an active Moneat member.",
+            )
+        }
+    }
+
+    private fun resolution(
+        status: SlackIdentityStatus,
+        teamId: String?,
+        enterpriseId: String?,
+        message: String,
+    ): SlackIdentityResolution =
+        SlackIdentityResolution(
+            status = status,
+            teamId = teamId,
+            enterpriseId = enterpriseId,
+            message = message,
+        )
+
+    companion object {
+        const val LINK_USER_MESSAGE =
+            "Your Slack identity is not linked to Moneat. " +
+                "Ask an organization admin to link your Slack user before responding."
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/notifications/services/SlackIdentityResolverTest.kt
+++ b/backend/src/test/kotlin/com/moneat/notifications/services/SlackIdentityResolverTest.kt
@@ -1,0 +1,186 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.notifications.services
+
+import com.moneat.shared.models.Memberships
+import com.moneat.shared.models.OrganizationIntegrations
+import com.moneat.shared.models.Organizations
+import com.moneat.shared.models.SlackUserMappings
+import com.moneat.shared.models.Users
+import com.moneat.testsupport.TestDatabaseHelper
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+
+class SlackIdentityResolverTest {
+    companion object {
+        private var database: Database? = null
+    }
+
+    @BeforeTest
+    fun setUp() {
+        if (database == null) {
+            database = Database.connect(
+                url = "jdbc:h2:mem:moneat_slack_identity;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
+                driver = "org.h2.Driver",
+            )
+        }
+        TransactionManager.defaultDatabase = database
+        TestDatabaseHelper.resetSchema(
+            Organizations,
+            Users,
+            Memberships,
+            OrganizationIntegrations,
+            SlackUserMappings,
+        )
+    }
+
+    @Test
+    fun `maps active Slack user only through an enabled workspace integration`() {
+        val (organizationId, userId) = seedMember("member@moneat.io", "T-active", "U-active")
+
+        val result = SlackIdentityResolver().resolve(
+            SlackIdentityRequest(teamId = "T-active", userId = "U-active"),
+        )
+
+        assertEquals(SlackIdentityStatus.MAPPED, result.status)
+        assertEquals(organizationId, result.organizationId)
+        assertEquals(userId, result.userId)
+        assertTrue(result.isMapped)
+        assertTrue(result.canRespond)
+    }
+
+    @Test
+    fun `unmapped identity receives only the linking path`() {
+        val result = SlackIdentityResolver().resolve(
+            SlackIdentityRequest(teamId = "T-unknown", userId = "U-unknown"),
+        )
+
+        assertEquals(SlackIdentityStatus.UNMAPPED, result.status)
+        assertFalse(result.isMapped)
+        assertFalse(result.canRespond)
+        assertTrue(result.message.contains("link", ignoreCase = true))
+    }
+
+    @Test
+    fun `guest and external identities fail closed before database lookup`() {
+        val guest = SlackIdentityResolver().resolve(
+            SlackIdentityRequest(teamId = "T-guest", userId = "U-guest", isGuest = true),
+        )
+        val external = SlackIdentityResolver().resolve(
+            SlackIdentityRequest(teamId = "T-external", userId = "U-external", isExternal = true),
+        )
+
+        assertEquals(SlackIdentityStatus.GUEST, guest.status)
+        assertEquals(SlackIdentityStatus.EXTERNAL, external.status)
+        assertFalse(guest.canRespond)
+        assertFalse(external.canRespond)
+    }
+
+    @Test
+    fun `cross organization and deleted members cannot be resolved`() {
+        val (organizationId, userId) = seedMember("deleted@moneat.io", "T-cross", "U-cross")
+        val otherOrganizationId = seedOrganization("other")
+        transaction {
+            Users.update({ Users.id eq userId }) {
+                it[deletedAt] = Clock.System.now()
+            }
+        }
+
+        val deleted = SlackIdentityResolver().resolve(
+            SlackIdentityRequest(teamId = "T-cross", userId = "U-cross", organizationId = organizationId),
+        )
+        assertEquals(SlackIdentityStatus.REVOKED, deleted.status)
+
+        val activeUser = transaction {
+            Users.insert {
+                it[Users.email] = "cross@moneat.io"
+                it[password_hash] = "test"
+                it[name] = "cross"
+            } get Users.id
+        }
+        transaction {
+            Memberships.insert {
+                it[user_id] = activeUser
+                it[Memberships.organization_id] = otherOrganizationId
+                it[role] = "MEMBER"
+            }
+            SlackUserMappings.insert {
+                it[SlackUserMappings.userId] = activeUser
+                it[SlackUserMappings.slackUserId] = "U-cross-active"
+                it[SlackUserMappings.slackTeamId] = "T-cross"
+                it[createdAt] = Clock.System.now()
+                it[updatedAt] = Clock.System.now()
+            }
+        }
+        val crossOrganization = SlackIdentityResolver().resolve(
+            SlackIdentityRequest(teamId = "T-cross", userId = "U-cross-active", organizationId = organizationId),
+        )
+        assertEquals(SlackIdentityStatus.CROSS_ORGANIZATION, crossOrganization.status)
+    }
+
+    private fun seedMember(email: String, teamId: String, slackUserId: String): Pair<Int, Int> {
+        val organizationId = seedOrganization(teamId)
+        val userId = transaction {
+            Users.insert {
+                it[Users.email] = email
+                it[password_hash] = "test"
+                it[name] = email.substringBefore('@')
+            } get Users.id
+        }
+        transaction {
+            Memberships.insert {
+                it[user_id] = userId
+                it[Memberships.organization_id] = organizationId
+                it[role] = "MEMBER"
+            }
+            SlackUserMappings.insert {
+                it[SlackUserMappings.userId] = userId
+                it[SlackUserMappings.slackUserId] = slackUserId
+                it[SlackUserMappings.slackTeamId] = teamId
+                it[createdAt] = Clock.System.now()
+                it[updatedAt] = Clock.System.now()
+            }
+        }
+        return organizationId to userId
+    }
+
+    private fun seedOrganization(teamId: String): Int = transaction {
+        val organizationId = Organizations.insert {
+            it[name] = teamId
+            it[slug] = teamId.lowercase()
+        } get Organizations.id
+        OrganizationIntegrations.insert {
+            it[organization_id] = organizationId
+            it[integration_type] = "slack"
+            it[OrganizationIntegrations.team_id] = teamId
+            it[enabled] = true
+            it[created_at] = Clock.System.now()
+            it[updated_at] = Clock.System.now()
+        }
+        organizationId
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/notifications/services/SlackIdentityResolverTest.kt
+++ b/backend/src/test/kotlin/com/moneat/notifications/services/SlackIdentityResolverTest.kt
@@ -86,6 +86,21 @@ class SlackIdentityResolverTest {
     }
 
     @Test
+    fun `missing or blank Slack identifiers fail closed without a database lookup`() {
+        val missingTeam = SlackIdentityResolver().resolve(
+            SlackIdentityRequest(teamId = " ", userId = "U-user"),
+        )
+        val missingUser = SlackIdentityResolver().resolve(
+            SlackIdentityRequest(teamId = "T-team", userId = null),
+        )
+
+        assertEquals(SlackIdentityStatus.UNMAPPED, missingTeam.status)
+        assertEquals(SlackIdentityStatus.UNMAPPED, missingUser.status)
+        assertFalse(missingTeam.canRespond)
+        assertFalse(missingUser.canRespond)
+    }
+
+    @Test
     fun `guest and external identities fail closed before database lookup`() {
         val guest = SlackIdentityResolver().resolve(
             SlackIdentityRequest(teamId = "T-guest", userId = "U-guest", isGuest = true),

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/authorization/SlackIncidentAuthorizationService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/authorization/SlackIncidentAuthorizationService.kt
@@ -1,0 +1,112 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.incidents.authorization
+
+import com.moneat.enterprise.incidents.models.IncidentParticipationType
+import com.moneat.enterprise.incidents.models.NativeIncidentParticipants
+import com.moneat.enterprise.incidents.models.NativeIncidentRoleAssignments
+import com.moneat.enterprise.incidents.models.NativeIncidentVisibility
+import com.moneat.notifications.services.SlackIdentityResolution
+import com.moneat.notifications.services.SlackIdentityStatus
+import com.moneat.org.services.OrgRole
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.isNull
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+
+enum class SlackIncidentAction {
+    READ,
+    RESPOND,
+}
+
+enum class SlackIncidentAccessStatus {
+    ALLOWED,
+    LINK_REQUIRED,
+    FORBIDDEN,
+}
+
+data class SlackIncidentAccessRequest(
+    val identity: SlackIdentityResolution,
+    val organizationId: Int,
+    val incidentId: Int,
+    val visibility: NativeIncidentVisibility,
+    val action: SlackIncidentAction,
+)
+
+data class SlackIncidentAccessDecision(
+    val status: SlackIncidentAccessStatus,
+    val message: String,
+) {
+    val allowed: Boolean
+        get() = status == SlackIncidentAccessStatus.ALLOWED
+}
+
+/**
+ * Centralizes Slack incident visibility and responder checks. Slack adapters should call this
+ * before rendering incident data or executing a mutation; the returned messages are safe for
+ * ephemeral Slack responses and never disclose whether a private incident exists.
+ */
+class SlackIncidentAuthorizationService {
+    fun authorize(request: SlackIncidentAccessRequest): SlackIncidentAccessDecision {
+        val identity = request.identity
+        if (identity.status == SlackIdentityStatus.UNMAPPED) {
+            return SlackIncidentAccessDecision(
+                SlackIncidentAccessStatus.LINK_REQUIRED,
+                "Link your Slack identity to Moneat before accessing incident response actions.",
+            )
+        }
+        if (!identity.isMapped || identity.organizationId != request.organizationId) {
+            return denied()
+        }
+        val userId = identity.userId ?: return denied()
+        val role = identity.role ?: return denied()
+        if (request.visibility != NativeIncidentVisibility.PRIVATE && request.action == SlackIncidentAction.READ) {
+            return allowed()
+        }
+        if (role.level >= OrgRole.ADMIN.level) {
+            return allowed()
+        }
+
+        val hasIncidentAccess = transaction {
+            val assignedRole = NativeIncidentRoleAssignments
+                .selectAll()
+                .where {
+                    (NativeIncidentRoleAssignments.organizationId eq request.organizationId) and
+                        (NativeIncidentRoleAssignments.incidentId eq request.incidentId) and
+                        (NativeIncidentRoleAssignments.assigneeUserId eq userId) and
+                        NativeIncidentRoleAssignments.endedAt.isNull()
+                }
+                .limit(1)
+                .firstOrNull() != null
+            val participant = NativeIncidentParticipants
+                .selectAll()
+                .where {
+                    (NativeIncidentParticipants.organizationId eq request.organizationId) and
+                        (NativeIncidentParticipants.incidentId eq request.incidentId) and
+                        (NativeIncidentParticipants.userId eq userId) and
+                        (NativeIncidentParticipants.participationType eq IncidentParticipationType.PARTICIPANT.wire) and
+                        NativeIncidentParticipants.leftAt.isNull()
+                }
+                .limit(1)
+                .firstOrNull() != null
+            assignedRole || participant
+        }
+        if (hasIncidentAccess) return allowed()
+        return denied()
+    }
+
+    private fun allowed() =
+        SlackIncidentAccessDecision(
+            SlackIncidentAccessStatus.ALLOWED,
+            "Slack incident access granted.",
+        )
+
+    private fun denied() =
+        SlackIncidentAccessDecision(
+            SlackIncidentAccessStatus.FORBIDDEN,
+            "You are not authorized to access or respond to this incident in Slack.",
+        )
+}

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/authorization/SlackIncidentAuthorizationServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/authorization/SlackIncidentAuthorizationServiceTest.kt
@@ -1,0 +1,105 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.incidents.authorization
+
+import com.moneat.enterprise.incidents.models.NativeIncidentVisibility
+import com.moneat.notifications.services.SlackIdentityResolution
+import com.moneat.notifications.services.SlackIdentityStatus
+import com.moneat.org.services.OrgRole
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SlackIncidentAuthorizationServiceTest {
+    private val service = SlackIncidentAuthorizationService()
+
+    @Test
+    fun `mapped organization member can read organization incident`() {
+        val decision = service.authorize(
+            request(
+                status = SlackIdentityStatus.MAPPED,
+                role = OrgRole.MEMBER,
+                organizationId = 42,
+                visibility = NativeIncidentVisibility.ORGANIZATION,
+                action = SlackIncidentAction.READ,
+            ),
+        )
+
+        assertTrue(decision.allowed)
+        assertEquals(SlackIncidentAccessStatus.ALLOWED, decision.status)
+    }
+
+    @Test
+    fun `unmapped member receives linking response without incident access`() {
+        val decision = service.authorize(
+            request(
+                status = SlackIdentityStatus.UNMAPPED,
+                role = null,
+                organizationId = null,
+                visibility = NativeIncidentVisibility.PRIVATE,
+                action = SlackIncidentAction.READ,
+            ),
+        )
+
+        assertFalse(decision.allowed)
+        assertEquals(SlackIncidentAccessStatus.LINK_REQUIRED, decision.status)
+        assertTrue(decision.message.contains("link", ignoreCase = true))
+    }
+
+    @Test
+    fun `cross organization identity fails closed without revealing incident state`() {
+        val decision = service.authorize(
+            request(
+                status = SlackIdentityStatus.CROSS_ORGANIZATION,
+                role = OrgRole.ADMIN,
+                organizationId = 42,
+                visibility = NativeIncidentVisibility.PUBLIC,
+                action = SlackIncidentAction.READ,
+            ),
+        )
+
+        assertFalse(decision.allowed)
+        assertEquals(SlackIncidentAccessStatus.FORBIDDEN, decision.status)
+        assertTrue(decision.message.contains("not authorized", ignoreCase = true))
+    }
+
+    @Test
+    fun `organization admin can respond to private incident`() {
+        val decision = service.authorize(
+            request(
+                status = SlackIdentityStatus.MAPPED,
+                role = OrgRole.ADMIN,
+                organizationId = 42,
+                visibility = NativeIncidentVisibility.PRIVATE,
+                action = SlackIncidentAction.RESPOND,
+            ),
+        )
+
+        assertTrue(decision.allowed)
+    }
+
+    private fun request(
+        status: SlackIdentityStatus,
+        role: OrgRole?,
+        organizationId: Int?,
+        visibility: NativeIncidentVisibility,
+        action: SlackIncidentAction,
+    ): SlackIncidentAccessRequest =
+        SlackIncidentAccessRequest(
+            identity = SlackIdentityResolution(
+                status = status,
+                organizationId = organizationId,
+                userId = organizationId,
+                role = role,
+                teamId = "T-test",
+                message = "test",
+            ),
+            organizationId = 42,
+            incidentId = 7,
+            visibility = visibility,
+            action = action,
+        )
+}


### PR DESCRIPTION
## Summary
- resolve Slack identities through enabled workspace bindings and active Moneat memberships
- fail closed for unmapped, guest, external, deleted, cross-organization, and invalid-role identities
- centralize incident visibility and responder authorization with safe linking and denial responses

## Validation
- `./gradlew :compileKotlin :ee:compileKotlin :compileTestKotlin :ee:compileTestKotlin --no-daemon --console=plain`
- `./gradlew :test --tests com.moneat.notifications.services.SlackIdentityResolverTest :ee:test --tests com.moneat.enterprise.incidents.authorization.SlackIncidentAuthorizationServiceTest --no-daemon --console=plain`
- `./gradlew detekt --no-daemon --console=plain`
- `python3 scripts/check-migration-versions.py --base-ref origin/develop`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure Slack identity resolution for mapped, guest, external, revoked, and cross-organization accounts.
  * Added centralized authorization for viewing and responding to incidents from Slack.
  * Unmapped identities are prompted to link their account, while unauthorized access is safely denied.
* **Bug Fixes**
  * Prevented inactive, deleted, mismatched, or improperly assigned members from accessing incidents.
* **Tests**
  * Added coverage for identity mapping, organization boundaries, guest access, private incidents, and administrator permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->