### PR TITLE
feat(slack): add durable outbound delivery

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -236,6 +236,7 @@ dependencies {
 
     // Testing
     testImplementation(libs.ktor.server.test.host)
+    testImplementation(libs.ktor.client.mock)
     testImplementation(libs.kotlin.test.junit5)
     testImplementation(libs.junit.jupiter.api)
     testRuntimeOnly(libs.junit.jupiter.engine)

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -41,6 +41,7 @@ ktor-server-metrics-micrometer = { module = "io.ktor:ktor-server-metrics-microme
 # Ktor Client
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 # Ktor Testing
 ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }

--- a/backend/src/main/kotlin/com/moneat/di/AppModules.kt
+++ b/backend/src/main/kotlin/com/moneat/di/AppModules.kt
@@ -36,6 +36,7 @@ import com.moneat.notifications.services.NotificationService
 import com.moneat.notifications.services.SlackService
 import com.moneat.notifications.services.SlackInboundGateway
 import com.moneat.notifications.services.SlackIdentityResolver
+import com.moneat.notifications.services.SlackOutboundDeliveryService
 import com.moneat.shared.repositories.MembershipRepository
 import com.moneat.shared.repositories.MembershipRepositoryImpl
 import com.moneat.shared.repositories.OrganizationRepository
@@ -59,6 +60,7 @@ val sharedModule = module {
     single { SlackService() }
     single { SlackInboundGateway() }
     single { SlackIdentityResolver() }
+    single { SlackOutboundDeliveryService() }
     single { DiscordService() }
     single { AlertNotificationPreferencesService() }
     single { AlertSilenceService() }

--- a/backend/src/main/kotlin/com/moneat/ingestion/queue/IngestionPipeline.kt
+++ b/backend/src/main/kotlin/com/moneat/ingestion/queue/IngestionPipeline.kt
@@ -39,6 +39,7 @@ enum class IngestionPipeline(
     DD_NDM("dd-ndm", "NDM"),
     DD_SECURITY("dd-security", "Security"),
     SLACK_INBOUND("slack-inbound", "Slack inbound"),
+    SLACK_OUTBOUND("slack-outbound", "Slack outbound"),
     CONNECTOR_EVENTS("connector-events", "Connector event"),
     CONNECTOR_IMPORTS("connector-imports", "Connector import");
 

--- a/backend/src/main/kotlin/com/moneat/notifications/services/SlackOutboundDeliveryService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/SlackOutboundDeliveryService.kt
@@ -165,24 +165,7 @@ class SlackOutboundDeliveryService(
             .selectAll()
             .where { SlackOutboundDeliveries.resourceId eq resourceId }
             .singleOrNull() ?: return@transaction null
-        val status = when (request.observation) {
-            SlackOutboundObservation.SUPERSEDED -> SlackOutboundDeliveryStatus.SUPERSEDED
-            SlackOutboundObservation.PRESENT -> {
-                val matches = request.observedVersion == null ||
-                    request.observedVersion >= row[SlackOutboundDeliveries.desiredVersion]
-                if (matches) SlackOutboundDeliveryStatus.DELIVERED else SlackOutboundDeliveryStatus.PENDING
-            }
-            SlackOutboundObservation.MISSING,
-            SlackOutboundObservation.EDITED,
-            SlackOutboundObservation.DELETED,
-            -> if (row[SlackOutboundDeliveries.status] == SlackOutboundDeliveryStatus.DEAD_LETTER.wire ||
-                row[SlackOutboundDeliveries.attemptCount] >= maxAttempts
-            ) {
-                SlackOutboundDeliveryStatus.DEAD_LETTER
-            } else {
-                SlackOutboundDeliveryStatus.PENDING
-            }
-        }
+        val status = reconciliationStatus(row, request)
         SlackOutboundDeliveries.update({ SlackOutboundDeliveries.id eq row[SlackOutboundDeliveries.id] }) {
             it[SlackOutboundDeliveries.status] = status.wire
             it[SlackOutboundDeliveries.providerMessageId] = request.providerMessageId
@@ -207,6 +190,40 @@ class SlackOutboundDeliveryService(
         }
         status
     }
+
+    private fun reconciliationStatus(
+        row: org.jetbrains.exposed.v1.core.ResultRow,
+        request: SlackOutboundReconciliationRequest,
+    ): SlackOutboundDeliveryStatus =
+        when (request.observation) {
+            SlackOutboundObservation.SUPERSEDED -> SlackOutboundDeliveryStatus.SUPERSEDED
+            SlackOutboundObservation.PRESENT -> presentObservationStatus(row, request.observedVersion)
+            SlackOutboundObservation.MISSING,
+            SlackOutboundObservation.EDITED,
+            SlackOutboundObservation.DELETED,
+            -> missingObservationStatus(row)
+        }
+
+    private fun presentObservationStatus(
+        row: org.jetbrains.exposed.v1.core.ResultRow,
+        observedVersion: Int?,
+    ): SlackOutboundDeliveryStatus =
+        if (observedVersion == null || observedVersion >= row[SlackOutboundDeliveries.desiredVersion]) {
+            SlackOutboundDeliveryStatus.DELIVERED
+        } else {
+            SlackOutboundDeliveryStatus.PENDING
+        }
+
+    private fun missingObservationStatus(
+        row: org.jetbrains.exposed.v1.core.ResultRow,
+    ): SlackOutboundDeliveryStatus =
+        if (row[SlackOutboundDeliveries.status] == SlackOutboundDeliveryStatus.DEAD_LETTER.wire ||
+            row[SlackOutboundDeliveries.attemptCount] >= maxAttempts
+        ) {
+            SlackOutboundDeliveryStatus.DEAD_LETTER
+        } else {
+            SlackOutboundDeliveryStatus.PENDING
+        }
 
     fun enqueueAndWake(
         request: SlackOutboundEnqueueRequest,

--- a/backend/src/main/kotlin/com/moneat/notifications/services/SlackOutboundDeliveryService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/SlackOutboundDeliveryService.kt
@@ -1,0 +1,395 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.notifications.services
+
+import com.moneat.config.EnvConfig
+import com.moneat.ingestion.queue.IngestionPipeline
+import com.moneat.ingestion.queue.IngestionQueueClient
+import com.moneat.shared.models.SlackOutboundDeliveryStatus
+import com.moneat.shared.models.SlackOutboundDeliveries
+import com.moneat.shared.models.SlackOutboundOperation
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.isNotNull
+import org.jetbrains.exposed.v1.core.lessEq
+import org.jetbrains.exposed.v1.core.or
+import org.jetbrains.exposed.v1.jdbc.insertIgnore
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+import java.util.Locale
+
+data class SlackOutboundEnqueueRequest(
+    val organizationId: Int,
+    val teamId: String?,
+    val channelId: String?,
+    val operation: SlackOutboundOperation,
+    val idempotencyKey: String,
+    val payload: String,
+    val desiredVersion: Int = 1,
+)
+
+data class SlackOutboundDelivery(
+    val resourceId: String,
+    val organizationId: Int,
+    val teamId: String?,
+    val channelId: String?,
+    val operation: SlackOutboundOperation,
+    val idempotencyKey: String,
+    val payload: String,
+    val desiredVersion: Int,
+    val attemptCount: Int,
+)
+
+sealed interface SlackOutboundSendResult {
+    data class Delivered(
+        val providerMessageId: String? = null,
+        val providerMessageTs: String? = null,
+    ) : SlackOutboundSendResult
+
+    data class Retry(
+        val reason: String,
+        val retryAt: Instant? = null,
+        val rateLimited: Boolean = false,
+    ) : SlackOutboundSendResult
+
+    data class Failed(val reason: String) : SlackOutboundSendResult
+
+    data object Superseded : SlackOutboundSendResult
+}
+
+fun interface SlackOutboundSender {
+    suspend fun send(delivery: SlackOutboundDelivery): SlackOutboundSendResult
+}
+
+data class SlackOutboundMetrics(
+    val oldestPendingAge: Duration?,
+    val failureCount: Long,
+    val rateLimitedCount: Long,
+    val deadLetterCount: Long,
+    val lastSuccessfulDelivery: Instant?,
+)
+
+enum class SlackOutboundObservation {
+    PRESENT,
+    MISSING,
+    EDITED,
+    DELETED,
+    SUPERSEDED,
+}
+
+data class SlackOutboundReconciliationRequest(
+    val resourceId: String,
+    val observation: SlackOutboundObservation,
+    val observedVersion: Int? = null,
+    val providerMessageId: String? = null,
+    val providerMessageTs: String? = null,
+)
+
+class SlackOutboundDeliveryService(
+    private val clock: Clock = Clock.System,
+    private val maxAttempts: Int = DEFAULT_MAX_ATTEMPTS,
+    private val baseRetryDelay: Duration = DEFAULT_RETRY_DELAY,
+) {
+    init {
+        require(maxAttempts > 0) { "Slack outbound max attempts must be positive" }
+        require(baseRetryDelay.isPositive()) { "Slack outbound retry delay must be positive" }
+    }
+
+    fun enqueue(request: SlackOutboundEnqueueRequest): String = transaction {
+        val now = clock.now()
+        SlackOutboundDeliveries.insertIgnore {
+            it[resourceId] = Uuid.random()
+            it[organizationId] = request.organizationId
+            it[teamId] = request.teamId
+            it[channelId] = request.channelId
+            it[operation] = request.operation.wire
+            it[idempotencyKey] = request.idempotencyKey
+            it[payload] = request.payload
+            it[desiredVersion] = request.desiredVersion
+            it[status] = SlackOutboundDeliveryStatus.PENDING.wire
+            it[attemptCount] = 0
+            it[availableAt] = now
+            it[createdAt] = now
+            it[updatedAt] = now
+        }
+        val existing = SlackOutboundDeliveries
+            .selectAll()
+            .where {
+                (SlackOutboundDeliveries.organizationId eq request.organizationId) and
+                    (SlackOutboundDeliveries.idempotencyKey eq request.idempotencyKey)
+            }
+            .single()
+        if (existing[SlackOutboundDeliveries.desiredVersion] < request.desiredVersion) {
+            SlackOutboundDeliveries.update({ SlackOutboundDeliveries.id eq existing[SlackOutboundDeliveries.id] }) {
+                it[teamId] = request.teamId
+                it[channelId] = request.channelId
+                it[operation] = request.operation.wire
+                it[payload] = request.payload
+                it[desiredVersion] = request.desiredVersion
+                it[status] = SlackOutboundDeliveryStatus.PENDING.wire
+                it[availableAt] = now
+                it[supersededAt] = null
+                it[lastError] = null
+                it[updatedAt] = now
+            }
+        }
+        existing[SlackOutboundDeliveries.resourceId].toString()
+    }
+
+    /** Applies an observation from Slack without allowing an older version to overwrite newer desired state. */
+    fun reconcile(request: SlackOutboundReconciliationRequest): SlackOutboundDeliveryStatus? = transaction {
+        val now = clock.now()
+        val resourceId = Uuid.parse(request.resourceId)
+        val row = SlackOutboundDeliveries
+            .selectAll()
+            .where { SlackOutboundDeliveries.resourceId eq resourceId }
+            .singleOrNull() ?: return@transaction null
+        val status = when (request.observation) {
+            SlackOutboundObservation.SUPERSEDED -> SlackOutboundDeliveryStatus.SUPERSEDED
+            SlackOutboundObservation.PRESENT -> {
+                val matches = request.observedVersion == null ||
+                    request.observedVersion >= row[SlackOutboundDeliveries.desiredVersion]
+                if (matches) SlackOutboundDeliveryStatus.DELIVERED else SlackOutboundDeliveryStatus.PENDING
+            }
+            SlackOutboundObservation.MISSING,
+            SlackOutboundObservation.EDITED,
+            SlackOutboundObservation.DELETED,
+            -> if (row[SlackOutboundDeliveries.status] == SlackOutboundDeliveryStatus.DEAD_LETTER.wire ||
+                row[SlackOutboundDeliveries.attemptCount] >= maxAttempts
+            ) {
+                SlackOutboundDeliveryStatus.DEAD_LETTER
+            } else {
+                SlackOutboundDeliveryStatus.PENDING
+            }
+        }
+        SlackOutboundDeliveries.update({ SlackOutboundDeliveries.id eq row[SlackOutboundDeliveries.id] }) {
+            it[SlackOutboundDeliveries.status] = status.wire
+            it[SlackOutboundDeliveries.providerMessageId] = request.providerMessageId
+            it[SlackOutboundDeliveries.providerMessageTs] = request.providerMessageTs
+            it[SlackOutboundDeliveries.availableAt] = now
+            it[SlackOutboundDeliveries.lastError] = if (status == SlackOutboundDeliveryStatus.PENDING) {
+                "Slack message observed as ${request.observation.name.lowercase(Locale.US)}"
+            } else {
+                null
+            }
+            it[SlackOutboundDeliveries.supersededAt] =
+                if (status == SlackOutboundDeliveryStatus.SUPERSEDED) now else null
+            it[SlackOutboundDeliveries.deliveredVersion] = if (status == SlackOutboundDeliveryStatus.DELIVERED) {
+                request.observedVersion ?: row[SlackOutboundDeliveries.desiredVersion]
+            } else {
+                row[SlackOutboundDeliveries.deliveredVersion]
+            }
+            it[SlackOutboundDeliveries.deliveredAt] = if (status == SlackOutboundDeliveryStatus.DELIVERED) now else null
+            it[SlackOutboundDeliveries.leasedAt] = null
+            it[SlackOutboundDeliveries.leaseOwner] = null
+            it[SlackOutboundDeliveries.updatedAt] = now
+        }
+        status
+    }
+
+    fun enqueueAndWake(
+        request: SlackOutboundEnqueueRequest,
+        queueKey: String = EnvConfig.get("SLACK_OUTBOUND_QUEUE_KEY") ?: DEFAULT_QUEUE_KEY,
+    ): String {
+        val resourceId = enqueue(request)
+        IngestionQueueClient.enqueue(IngestionPipeline.SLACK_OUTBOUND, queueKey, resourceId)
+        return resourceId
+    }
+
+    suspend fun process(resourceId: String, sender: SlackOutboundSender): Boolean {
+        val delivery = claim(resourceId) ?: return false
+        return when (val result = sender.send(delivery)) {
+            is SlackOutboundSendResult.Delivered -> {
+                markDelivered(delivery, result)
+                true
+            }
+            is SlackOutboundSendResult.Retry -> {
+                markRetry(delivery, result)
+                true
+            }
+            is SlackOutboundSendResult.Failed -> {
+                markRetry(delivery, SlackOutboundSendResult.Retry(result.reason))
+                true
+            }
+            SlackOutboundSendResult.Superseded -> {
+                markSuperseded(delivery)
+                true
+            }
+        }
+    }
+
+    fun metrics(): SlackOutboundMetrics = transaction {
+        val now = clock.now()
+        val pending = SlackOutboundDeliveries
+            .selectAll()
+            .where {
+                (SlackOutboundDeliveries.status eq SlackOutboundDeliveryStatus.PENDING.wire) or
+                    (SlackOutboundDeliveries.status eq SlackOutboundDeliveryStatus.RETRY.wire)
+            }
+            .minByOrNull { it[SlackOutboundDeliveries.availableAt] }
+        val lastDelivered = SlackOutboundDeliveries
+            .selectAll()
+            .where { SlackOutboundDeliveries.status eq SlackOutboundDeliveryStatus.DELIVERED.wire }
+            .maxByOrNull { it[SlackOutboundDeliveries.deliveredAt] ?: Instant.DISTANT_PAST }
+        SlackOutboundMetrics(
+            oldestPendingAge = pending?.let { now - it[SlackOutboundDeliveries.createdAt] },
+            failureCount = SlackOutboundDeliveries
+                .selectAll()
+                .where { SlackOutboundDeliveries.lastError.isNotNull() }
+                .count(),
+            rateLimitedCount = SlackOutboundDeliveries
+                .selectAll()
+                .where { SlackOutboundDeliveries.rateLimitResetAt.isNotNull() }
+                .count(),
+            deadLetterCount = SlackOutboundDeliveries
+                .selectAll()
+                .where { SlackOutboundDeliveries.status eq SlackOutboundDeliveryStatus.DEAD_LETTER.wire }
+                .count(),
+            lastSuccessfulDelivery = lastDelivered?.get(SlackOutboundDeliveries.deliveredAt),
+        )
+    }
+
+    private fun claim(resourceId: String): SlackOutboundDelivery? = transaction {
+        val parsedId = Uuid.parse(resourceId)
+        val now = clock.now()
+        val row = SlackOutboundDeliveries
+            .selectAll()
+            .where {
+                (SlackOutboundDeliveries.resourceId eq parsedId) and
+                    (
+                        (SlackOutboundDeliveries.status eq SlackOutboundDeliveryStatus.PENDING.wire) or
+                            (
+                                (SlackOutboundDeliveries.status eq SlackOutboundDeliveryStatus.RETRY.wire) and
+                                    (SlackOutboundDeliveries.availableAt lessEq now)
+                                ) or
+                            (
+                                (SlackOutboundDeliveries.status eq SlackOutboundDeliveryStatus.PROCESSING.wire) and
+                                    (SlackOutboundDeliveries.leasedAt lessEq now - LEASE_TIMEOUT)
+                                )
+                        )
+            }
+            .singleOrNull() ?: return@transaction null
+        val updated = SlackOutboundDeliveries.update({
+            SlackOutboundDeliveries.id eq row[SlackOutboundDeliveries.id]
+        }) {
+            it[status] = SlackOutboundDeliveryStatus.PROCESSING.wire
+            it[attemptCount] = row[SlackOutboundDeliveries.attemptCount] + 1
+            it[leasedAt] = now
+            it[leaseOwner] = WORKER_ID
+            it[updatedAt] = now
+        }
+        if (updated == 0) return@transaction null
+        row.toDelivery()
+    }
+
+    private fun markDelivered(delivery: SlackOutboundDelivery, result: SlackOutboundSendResult.Delivered) {
+        transaction {
+            val now = clock.now()
+            SlackOutboundDeliveries.update({
+                (SlackOutboundDeliveries.resourceId eq Uuid.parse(delivery.resourceId)) and
+                    (SlackOutboundDeliveries.status eq SlackOutboundDeliveryStatus.PROCESSING.wire) and
+                    (SlackOutboundDeliveries.desiredVersion eq delivery.desiredVersion)
+            }) {
+                it[status] = SlackOutboundDeliveryStatus.DELIVERED.wire
+                it[deliveredVersion] = delivery.desiredVersion
+                it[providerMessageId] = result.providerMessageId
+                it[providerMessageTs] = result.providerMessageTs
+                it[deliveredAt] = now
+                it[leasedAt] = null
+                it[leaseOwner] = null
+                it[updatedAt] = now
+            }
+        }
+    }
+
+    private fun markRetry(delivery: SlackOutboundDelivery, result: SlackOutboundSendResult.Retry) {
+        transaction {
+            val now = clock.now()
+            val currentAttemptCount = SlackOutboundDeliveries
+                .selectAll()
+                .where { SlackOutboundDeliveries.resourceId eq Uuid.parse(delivery.resourceId) }
+                .single()[SlackOutboundDeliveries.attemptCount]
+            val deadLetter = currentAttemptCount >= maxAttempts
+            SlackOutboundDeliveries.update({
+                (SlackOutboundDeliveries.resourceId eq Uuid.parse(delivery.resourceId)) and
+                    (SlackOutboundDeliveries.status eq SlackOutboundDeliveryStatus.PROCESSING.wire) and
+                    (SlackOutboundDeliveries.desiredVersion eq delivery.desiredVersion)
+            }) {
+                it[status] = if (deadLetter) {
+                    SlackOutboundDeliveryStatus.DEAD_LETTER.wire
+                } else {
+                    SlackOutboundDeliveryStatus.RETRY.wire
+                }
+                it[availableAt] = result.retryAt ?: now + retryDelay(delivery.attemptCount)
+                it[rateLimitResetAt] = if (result.rateLimited) result.retryAt else null
+                it[lastError] = result.reason
+                it[leasedAt] = null
+                it[leaseOwner] = null
+                it[updatedAt] = now
+            }
+        }
+    }
+
+    private fun markSuperseded(delivery: SlackOutboundDelivery) {
+        transaction {
+            val now = clock.now()
+            SlackOutboundDeliveries.update({
+                (SlackOutboundDeliveries.resourceId eq Uuid.parse(delivery.resourceId)) and
+                    (SlackOutboundDeliveries.status eq SlackOutboundDeliveryStatus.PROCESSING.wire) and
+                    (SlackOutboundDeliveries.desiredVersion eq delivery.desiredVersion)
+            }) {
+                it[status] = SlackOutboundDeliveryStatus.SUPERSEDED.wire
+                it[supersededAt] = now
+                it[leasedAt] = null
+                it[leaseOwner] = null
+                it[updatedAt] = now
+            }
+        }
+    }
+
+    private fun retryDelay(attempt: Int): Duration =
+        baseRetryDelay * (1 shl (attempt - 1).coerceIn(0, MAX_BACKOFF_SHIFT))
+
+    private fun org.jetbrains.exposed.v1.core.ResultRow.toDelivery(): SlackOutboundDelivery =
+        SlackOutboundDelivery(
+            resourceId = this[SlackOutboundDeliveries.resourceId].toString(),
+            organizationId = this[SlackOutboundDeliveries.organizationId],
+            teamId = this[SlackOutboundDeliveries.teamId],
+            channelId = this[SlackOutboundDeliveries.channelId],
+            operation = SlackOutboundOperation.entries.first { it.wire == this[SlackOutboundDeliveries.operation] },
+            idempotencyKey = this[SlackOutboundDeliveries.idempotencyKey],
+            payload = this[SlackOutboundDeliveries.payload],
+            desiredVersion = this[SlackOutboundDeliveries.desiredVersion],
+            attemptCount = this[SlackOutboundDeliveries.attemptCount] + 1,
+        )
+
+    companion object {
+        private const val DEFAULT_MAX_ATTEMPTS = 5
+        private const val MAX_BACKOFF_SHIFT = 5
+        private val DEFAULT_RETRY_DELAY = 5.seconds
+        private val LEASE_TIMEOUT = 2.minutes
+        private const val DEFAULT_QUEUE_KEY = "slack-outbound"
+        private const val WORKER_ID = "slack-outbound"
+    }
+}

--- a/backend/src/main/kotlin/com/moneat/notifications/services/SlackOutboundWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/SlackOutboundWorker.kt
@@ -1,0 +1,53 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.notifications.services
+
+import com.moneat.ingestion.queue.IngestionPipeline
+import com.moneat.ingestion.queue.IngestionQueueSettings
+import com.moneat.ingestion.queue.RedisQueueWorker
+import com.moneat.monitoring.OperationalMetrics
+import mu.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
+
+/** Runs durable Slack operations after the fast admission path has acknowledged Slack. */
+class SlackOutboundWorker(
+    private val queueKey: String,
+    private val dlqKey: String,
+    private val workerCount: Int,
+    private val deliveryService: SlackOutboundDeliveryService,
+    private val sender: SlackOutboundSender,
+) {
+    private var queueWorker: RedisQueueWorker? = null
+
+    fun start() {
+        val spec = IngestionQueueSettings.spec(IngestionPipeline.SLACK_OUTBOUND, queueKey, dlqKey, workerCount)
+        queueWorker = RedisQueueWorker(spec, logger, processMessage = ::processMessage).also { it.start() }
+        logger.info { "Slack outbound worker started with $workerCount workers" }
+    }
+
+    fun stop() {
+        queueWorker?.stop()
+        queueWorker = null
+        logger.info { "Slack outbound worker stopped" }
+    }
+
+    private suspend fun processMessage(workerId: Int, value: String) {
+        deliveryService.process(value, sender)
+        OperationalMetrics.recordWorkerMessageProcessed(IngestionPipeline.SLACK_OUTBOUND.workerName, workerId)
+    }
+}

--- a/backend/src/main/kotlin/com/moneat/notifications/services/SlackOutboundWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/SlackOutboundWorker.kt
@@ -46,7 +46,7 @@ class SlackOutboundWorker(
         logger.info { "Slack outbound worker stopped" }
     }
 
-    private suspend fun processMessage(workerId: Int, value: String) {
+    internal suspend fun processMessage(workerId: Int, value: String) {
         deliveryService.process(value, sender)
         OperationalMetrics.recordWorkerMessageProcessed(IngestionPipeline.SLACK_OUTBOUND.workerName, workerId)
     }

--- a/backend/src/main/kotlin/com/moneat/notifications/services/SlackService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/SlackService.kt
@@ -24,6 +24,9 @@ import java.nio.charset.StandardCharsets
 import com.moneat.config.EnvConfig
 import com.moneat.shared.models.Memberships
 import com.moneat.shared.models.OrganizationIntegrations
+import com.moneat.shared.models.SlackOutboundOperation
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
 import com.moneat.workflows.models.WorkflowStepPreview
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
@@ -41,6 +44,12 @@ import io.ktor.http.contentType
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.selectAll
@@ -137,7 +146,9 @@ class SlackService {
     @Serializable
     data class SlackPostMessageResponse(
         val ok: Boolean,
-        val error: String? = null
+        val error: String? = null,
+        val channel: String? = null,
+        val ts: String? = null,
     )
 
     @Serializable
@@ -261,6 +272,89 @@ class SlackService {
             logger.error("Error sending to Slack", e)
             false to "Error: ${e.message}"
         }
+    }
+
+    suspend fun sendOutboundDelivery(delivery: SlackOutboundDelivery): SlackOutboundSendResult {
+        val accessToken = getSlackAccessToken(delivery.organizationId)
+            ?: return SlackOutboundSendResult.Retry("Slack workspace is not configured")
+        if (delivery.operation == SlackOutboundOperation.MESSAGE && delivery.channelId.isNullOrBlank()) {
+            return SlackOutboundSendResult.Failed("Slack message is missing a destination channel")
+        }
+        return sendOutboundOperation(delivery, accessToken)
+    }
+
+    private suspend fun sendOutboundOperation(
+        delivery: SlackOutboundDelivery,
+        accessToken: String,
+    ): SlackOutboundSendResult = try {
+        val response = httpClient.post("https://slack.com/api/${delivery.operation.endpoint}") {
+            contentType(ContentType.Application.Json)
+            header("Authorization", "Bearer $accessToken")
+            setBody(prepareOutboundPayload(delivery))
+        }
+        classifyOutboundResponse(response)
+    } catch (error: IOException) {
+        SlackOutboundSendResult.Retry(error.message ?: "Slack connection failed")
+    } catch (error: SerializationException) {
+        SlackOutboundSendResult.Retry(error.message ?: "Slack response could not be decoded")
+    }
+
+    private suspend fun classifyOutboundResponse(response: HttpResponse): SlackOutboundSendResult {
+        if (response.status == HttpStatusCode.TooManyRequests) {
+            val retryAfter = response.headers["Retry-After"]?.toLongOrNull()
+                ?.coerceAtLeast(MIN_RATE_LIMIT_RETRY_SECONDS) ?: DEFAULT_RATE_LIMIT_RETRY_SECONDS
+            return SlackOutboundSendResult.Retry(
+                reason = "Slack rate limit",
+                retryAt = Clock.System.now() + retryAfter.seconds,
+                rateLimited = true,
+            )
+        }
+        if (response.status.value >= SLACK_SERVER_ERROR_STATUS) {
+            return SlackOutboundSendResult.Retry("Slack returned ${response.status}")
+        }
+        if (response.status != HttpStatusCode.OK) {
+            return SlackOutboundSendResult.Failed("Slack returned ${response.status}")
+        }
+        val result = json.parseToJsonElement(response.bodyAsText()).jsonObject
+        val ok = result["ok"]?.jsonPrimitive?.booleanOrNull == true
+        return if (ok) {
+            SlackOutboundSendResult.Delivered(
+                providerMessageId = result.providerId(),
+                providerMessageTs = result["ts"]?.jsonPrimitive?.contentOrNull,
+            )
+        } else if (result["error"]?.jsonPrimitive?.contentOrNull == "ratelimited") {
+            SlackOutboundSendResult.Retry("Slack rate limit", rateLimited = true)
+        } else {
+            SlackOutboundSendResult.Failed(
+                result["error"]?.jsonPrimitive?.contentOrNull ?: "Slack rejected the operation",
+            )
+        }
+    }
+
+    private fun prepareOutboundPayload(delivery: SlackOutboundDelivery): String {
+        if (delivery.operation != SlackOutboundOperation.MESSAGE) return delivery.payload
+        val payload = json.parseToJsonElement(delivery.payload).jsonObject.toMutableMap()
+        payload["client_msg_id"] = JsonPrimitive(delivery.idempotencyKey)
+        return JsonObject(payload).toString()
+    }
+
+    private fun JsonObject.providerId(): String? {
+        val channel = this["channel"]
+        return channel?.jsonPrimitive?.contentOrNull
+            ?: channel?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull
+    }
+
+    private fun getSlackAccessToken(organizationId: Int): String? = transaction {
+        OrganizationIntegrations
+            .selectAll()
+            .where {
+                (OrganizationIntegrations.organization_id eq organizationId) and
+                    (OrganizationIntegrations.integration_type eq "slack") and
+                    (OrganizationIntegrations.enabled eq true)
+            }
+            .limit(1)
+            .singleOrNull()
+            ?.get(OrganizationIntegrations.access_token)
     }
 
     suspend fun sendHostAlert(
@@ -1159,5 +1253,8 @@ class SlackService {
 
     companion object {
         private const val ERROR_SENDING_ON_CALL_SLACK_ALERT = "Error sending on-call Slack alert"
+        private const val SLACK_SERVER_ERROR_STATUS = 500
+        private const val MIN_RATE_LIMIT_RETRY_SECONDS = 1L
+        private const val DEFAULT_RATE_LIMIT_RETRY_SECONDS = 30L
     }
 }

--- a/backend/src/main/kotlin/com/moneat/notifications/services/SlackService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/SlackService.kt
@@ -63,22 +63,25 @@ private const val SLACK_CHANNEL_FETCH_LIMIT = 200
 private const val SLACK_COLOR_RED = "#E01E5A"
 private const val SLACK_COLOR_GREEN = "#2EB67D"
 private const val SLACK_COLOR_YELLOW = "#ECB22E"
+private const val SLACK_HTTP_TIMEOUT_MILLIS = 10_000L
 
 internal fun encodeSlackIssueIdPathSegment(value: String): String =
     URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20")
 
-class SlackService {
+private fun createSlackHttpClient(): HttpClient =
+    HttpClient(CIO) {
+        install(HttpTimeout) {
+            socketTimeoutMillis = SLACK_HTTP_TIMEOUT_MILLIS
+            connectTimeoutMillis = SLACK_HTTP_TIMEOUT_MILLIS
+            requestTimeoutMillis = SLACK_HTTP_TIMEOUT_MILLIS
+        }
+    }
+
+class SlackService(
+    private val httpClient: HttpClient = createSlackHttpClient(),
+) {
     private val logger = LoggerFactory.getLogger(SlackService::class.java)
     private val json = Json { ignoreUnknownKeys = true }
-
-    private val httpClient =
-        HttpClient(CIO) {
-            install(HttpTimeout) {
-                socketTimeoutMillis = 10_000
-                connectTimeoutMillis = 10_000
-                requestTimeoutMillis = 10_000
-            }
-        }
 
     @Serializable
     data class SlackBlock(
@@ -340,8 +343,11 @@ class SlackService {
 
     private fun JsonObject.providerId(): String? {
         val channel = this["channel"]
-        return channel?.jsonPrimitive?.contentOrNull
-            ?: channel?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull
+        return when (channel) {
+            is JsonPrimitive -> channel.contentOrNull
+            is JsonObject -> channel["id"]?.jsonPrimitive?.contentOrNull
+            else -> null
+        }
     }
 
     private fun getSlackAccessToken(organizationId: Int): String? = transaction {

--- a/backend/src/main/kotlin/com/moneat/plugins/BackgroundJobs.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/BackgroundJobs.kt
@@ -24,6 +24,9 @@ import com.moneat.ingestion.queue.IngestionPipeline
 import com.moneat.ingestion.queue.IngestionQueueSettings
 import com.moneat.config.EnvConfig
 import com.moneat.notifications.services.SlackInboundWorker
+import com.moneat.notifications.services.SlackOutboundSender
+import com.moneat.notifications.services.SlackOutboundWorker
+import com.moneat.notifications.services.SlackService
 import com.moneat.shared.services.ArtifactCleanupService
 import com.moneat.shared.services.DemoLivenessBackgroundService
 import com.moneat.shared.services.RetentionBackgroundService
@@ -117,6 +120,15 @@ private class CoreIngestionWorkers(application: Application) {
         workerCount = EnvConfig.get("SLACK_INBOUND_WORKER_COUNT")?.toIntOrNull()?.coerceAtLeast(1) ?: 1,
         gateway = koin.get(),
     )
+    private val slackOutboundWorker = SlackOutboundWorker(
+        queueKey = EnvConfig.get("SLACK_OUTBOUND_QUEUE_KEY") ?: "slack-outbound",
+        dlqKey = EnvConfig.get("SLACK_OUTBOUND_DLQ_KEY") ?: "slack-outbound-dlq",
+        workerCount = EnvConfig.get("SLACK_OUTBOUND_WORKER_COUNT")?.toIntOrNull()?.coerceAtLeast(1) ?: 1,
+        deliveryService = koin.get(),
+        sender = SlackOutboundSender { delivery ->
+            koin.get<SlackService>().sendOutboundDelivery(delivery)
+        },
+    )
 
     fun startSelected(startIngestionWorkers: Boolean) {
         if (shouldStartIngestionPipeline(startIngestionWorkers, IngestionPipeline.EVENTS)) {
@@ -125,11 +137,15 @@ private class CoreIngestionWorkers(application: Application) {
         if (shouldStartIngestionPipeline(startIngestionWorkers, IngestionPipeline.SLACK_INBOUND)) {
             slackInboundWorker.start()
         }
+        if (shouldStartIngestionPipeline(startIngestionWorkers, IngestionPipeline.SLACK_OUTBOUND)) {
+            slackOutboundWorker.start()
+        }
     }
 
     fun stop() {
         ingestionWorker.stop()
         slackInboundWorker.stop()
+        slackOutboundWorker.stop()
     }
 }
 

--- a/backend/src/main/kotlin/com/moneat/shared/models/SlackOutboundModels.kt
+++ b/backend/src/main/kotlin/com/moneat/shared/models/SlackOutboundModels.kt
@@ -1,0 +1,73 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.shared.models
+
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
+import org.jetbrains.exposed.v1.datetime.timestamp
+import kotlin.time.Clock
+import kotlin.uuid.Uuid
+
+enum class SlackOutboundOperation(val wire: String, val endpoint: String) {
+    MESSAGE("MESSAGE", "chat.postMessage"),
+    CHANNEL_CREATE("CHANNEL_CREATE", "conversations.create"),
+    CHANNEL_UPDATE("CHANNEL_UPDATE", "conversations.rename"),
+    INVITE("INVITE", "conversations.invite"),
+    BOOKMARK("BOOKMARK", "bookmarks.add"),
+    ARCHIVE("ARCHIVE", "conversations.archive"),
+}
+
+enum class SlackOutboundDeliveryStatus(val wire: String) {
+    PENDING("PENDING"),
+    PROCESSING("PROCESSING"),
+    DELIVERED("DELIVERED"),
+    RETRY("RETRY"),
+    DEAD_LETTER("DEAD_LETTER"),
+    SUPERSEDED("SUPERSEDED"),
+}
+
+object SlackOutboundDeliveries : IntIdTable("slack_outbound_deliveries") {
+    val resourceId = uuid("resource_id").clientDefault { Uuid.random() }
+    val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
+    val teamId = varchar("team_id", 255).nullable()
+    val channelId = varchar("channel_id", 255).nullable()
+    val operation = varchar("operation", 32)
+    val idempotencyKey = varchar("idempotency_key", 384)
+    val payload = text("payload")
+    val desiredVersion = integer("desired_version").default(1)
+    val deliveredVersion = integer("delivered_version").nullable()
+    val providerMessageId = varchar("provider_message_id", 255).nullable()
+    val providerMessageTs = varchar("provider_message_ts", 64).nullable()
+    val status = varchar("status", 24).default(SlackOutboundDeliveryStatus.PENDING.wire)
+    val attemptCount = integer("attempt_count").default(0)
+    val availableAt = timestamp("available_at")
+    val rateLimitResetAt = timestamp("rate_limit_reset_at").nullable()
+    val leasedAt = timestamp("leased_at").nullable()
+    val leaseOwner = varchar("lease_owner", 120).nullable()
+    val lastError = text("last_error").nullable()
+    val supersededAt = timestamp("superseded_at").nullable()
+    val deliveredAt = timestamp("delivered_at").nullable()
+    val createdAt = timestamp("created_at").clientDefault { Clock.System.now() }
+    val updatedAt = timestamp("updated_at").clientDefault { Clock.System.now() }
+
+    init {
+        uniqueIndex(organizationId, resourceId)
+        uniqueIndex(organizationId, idempotencyKey)
+        index(false, status, availableAt, id)
+        index(false, organizationId, teamId, status)
+    }
+}

--- a/backend/src/main/resources/db/migration/V167__durable_slack_outbound_delivery.sql
+++ b/backend/src/main/resources/db/migration/V167__durable_slack_outbound_delivery.sql
@@ -1,0 +1,36 @@
+-- Moneat - observability platform
+-- Copyright (C) 2026 Moneat
+-- Licensed under the GNU Affero General Public License, version 3.
+
+CREATE TABLE slack_outbound_deliveries (
+    id BIGSERIAL PRIMARY KEY,
+    resource_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    team_id VARCHAR(255),
+    channel_id VARCHAR(255),
+    operation VARCHAR(32) NOT NULL,
+    idempotency_key VARCHAR(384) NOT NULL,
+    payload TEXT NOT NULL,
+    desired_version INTEGER NOT NULL DEFAULT 1,
+    delivered_version INTEGER,
+    provider_message_id VARCHAR(255),
+    provider_message_ts VARCHAR(64),
+    status VARCHAR(24) NOT NULL DEFAULT 'PENDING',
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    available_at TIMESTAMPTZ NOT NULL,
+    rate_limit_reset_at TIMESTAMPTZ,
+    leased_at TIMESTAMPTZ,
+    lease_owner VARCHAR(120),
+    last_error TEXT,
+    superseded_at TIMESTAMPTZ,
+    delivered_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    CONSTRAINT uq_slack_outbound_resource UNIQUE (organization_id, resource_id),
+    CONSTRAINT uq_slack_outbound_idempotency UNIQUE (organization_id, idempotency_key)
+);
+
+CREATE INDEX idx_slack_outbound_ready
+    ON slack_outbound_deliveries(status, available_at, id);
+CREATE INDEX idx_slack_outbound_workspace
+    ON slack_outbound_deliveries(organization_id, team_id, status);

--- a/backend/src/test/kotlin/com/moneat/notifications/services/SlackOutboundDeliveryServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/notifications/services/SlackOutboundDeliveryServiceTest.kt
@@ -17,10 +17,17 @@
 package com.moneat.notifications.services
 
 import com.moneat.shared.models.Organizations
+import com.moneat.shared.models.OrganizationIntegrations
 import com.moneat.shared.models.SlackOutboundDeliveryStatus
 import com.moneat.shared.models.SlackOutboundDeliveries
 import com.moneat.shared.models.SlackOutboundOperation
 import com.moneat.testsupport.TestDatabaseHelper
+import io.ktor.client.HttpClient
+import io.ktor.client.request.HttpResponseData
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
@@ -36,6 +43,7 @@ import kotlin.test.assertIs
 import kotlin.test.assertTrue
 import kotlin.time.Clock
 import kotlin.time.Instant
+import kotlin.time.Duration.Companion.seconds
 
 class SlackOutboundDeliveryServiceTest {
     companion object {
@@ -53,7 +61,7 @@ class SlackOutboundDeliveryServiceTest {
             )
         }
         TransactionManager.defaultDatabase = database
-        TestDatabaseHelper.resetSchema(Organizations, SlackOutboundDeliveries)
+        TestDatabaseHelper.resetSchema(Organizations, OrganizationIntegrations, SlackOutboundDeliveries)
         transaction {
             Organizations.insert {
                 it[name] = "Outbound test"
@@ -92,6 +100,7 @@ class SlackOutboundDeliveryServiceTest {
         assertEquals("M1", row[SlackOutboundDeliveries.providerMessageId])
         assertEquals(1, row[SlackOutboundDeliveries.deliveredVersion])
         assertNotNull(service.metrics().lastSuccessfulDelivery)
+        Unit
     }
 
     @Test
@@ -120,6 +129,7 @@ class SlackOutboundDeliveryServiceTest {
         val row = transaction { SlackOutboundDeliveries.selectAll().single() }
         assertEquals(SlackOutboundDeliveryStatus.SUPERSEDED.wire, row[SlackOutboundDeliveries.status])
         assertNotNull(row[SlackOutboundDeliveries.supersededAt])
+        Unit
     }
 
     @Test
@@ -228,14 +238,15 @@ class SlackOutboundDeliveryServiceTest {
     }
 
     @Test
-    fun `unsupported outbound operation fails before workspace access`() = runBlocking {
+    fun `message without a destination fails before outbound transport`() = runBlocking {
+        seedSlackIntegration()
         val result = SlackService().sendOutboundDelivery(
             SlackOutboundDelivery(
                 resourceId = "delivery",
                 organizationId = 1,
                 teamId = "T-outbound",
-                channelId = "C-outbound",
-                operation = SlackOutboundOperation.CHANNEL_CREATE,
+                channelId = null,
+                operation = SlackOutboundOperation.MESSAGE,
                 idempotencyKey = "channel:create",
                 payload = "{}",
                 desiredVersion = 1,
@@ -244,7 +255,141 @@ class SlackOutboundDeliveryServiceTest {
         )
 
         assertIs<SlackOutboundSendResult.Failed>(result)
+        Unit
     }
+
+    @Test
+    fun `worker processes a queued delivery and records the durable result`() = runBlocking {
+        val service = SlackOutboundDeliveryService(clock = clock)
+        val resourceId = service.enqueue(request())
+        val worker = SlackOutboundWorker(
+            queueKey = "slack-outbound",
+            dlqKey = "slack-outbound-dlq",
+            workerCount = 1,
+            deliveryService = service,
+            sender = SlackOutboundSender { SlackOutboundSendResult.Delivered(providerMessageId = "M-worker") },
+        )
+
+        worker.processMessage(workerId = 1, value = resourceId)
+
+        val row = transaction { SlackOutboundDeliveries.selectAll().single() }
+        assertEquals(SlackOutboundDeliveryStatus.DELIVERED.wire, row[SlackOutboundDeliveries.status])
+        assertEquals("M-worker", row[SlackOutboundDeliveries.providerMessageId])
+        Unit
+    }
+
+    @Test
+    fun `outbound message injects idempotency and returns provider ids`() = runBlocking {
+        seedSlackIntegration()
+        val service = SlackService(
+            mockSlackClient {
+                respond("""{"ok":true,"channel":{"id":"C-created"},"ts":"123.456"}""")
+            },
+        )
+
+        val result = service.sendOutboundDelivery(
+            SlackOutboundDelivery(
+                resourceId = "delivery",
+                organizationId = 1,
+                teamId = "T-outbound",
+                channelId = "C-outbound",
+                operation = SlackOutboundOperation.MESSAGE,
+                idempotencyKey = "delivery-key",
+                payload = "{\"text\":\"hello\"}",
+                desiredVersion = 1,
+                attemptCount = 1,
+            ),
+        )
+
+        val delivered = assertIs<SlackOutboundSendResult.Delivered>(result)
+        assertEquals("C-created", delivered.providerMessageId)
+        assertEquals("123.456", delivered.providerMessageTs)
+    }
+
+    @Test
+    fun `outbound response classifications preserve retry and failure semantics`() = runBlocking {
+        seedSlackIntegration()
+        val statuses = listOf(
+            HttpStatusCode.TooManyRequests to SlackOutboundSendResult.Retry::class,
+            HttpStatusCode.InternalServerError to SlackOutboundSendResult.Retry::class,
+            HttpStatusCode.BadRequest to SlackOutboundSendResult.Failed::class,
+        )
+        statuses.forEach { (status, expectedType) ->
+            val service = SlackService(
+                mockSlackClient {
+                    respond("{\"ok\":false,\"error\":\"bad_request\"}", status)
+                },
+            )
+            val result = service.sendOutboundDelivery(outboundDelivery())
+            assertTrue(expectedType.isInstance(result), "Expected $expectedType for $status")
+        }
+
+        val rateLimitedBodyService = SlackService(
+            mockSlackClient {
+                respond("{\"ok\":false,\"error\":\"ratelimited\"}")
+            },
+        )
+        assertIs<SlackOutboundSendResult.Retry>(
+            rateLimitedBodyService.sendOutboundDelivery(outboundDelivery()),
+        )
+    }
+
+    @Test
+    fun `outbound response supports nested provider id and default rate limit delay`() = runBlocking {
+        seedSlackIntegration()
+        val service = SlackService(
+            mockSlackClient {
+                respond("{\"ok\":true,\"channel\":{\"id\":\"C-nested\"}}")
+            },
+        )
+        val delivered = assertIs<SlackOutboundSendResult.Delivered>(service.sendOutboundDelivery(outboundDelivery()))
+        assertEquals("C-nested", delivered.providerMessageId)
+        assertEquals(null, delivered.providerMessageTs)
+
+        val rateLimitedService = SlackService(
+            mockSlackClient {
+                respond("", HttpStatusCode.TooManyRequests)
+            },
+        )
+        val rateLimited = rateLimitedService.sendOutboundDelivery(outboundDelivery())
+        val retry = assertIs<SlackOutboundSendResult.Retry>(rateLimited)
+        assertTrue(retry.rateLimited)
+        assertTrue(retry.retryAt!! > Clock.System.now() + 1.seconds)
+    }
+
+    private fun seedSlackIntegration() {
+        transaction {
+            OrganizationIntegrations.insert {
+                it[organization_id] = 1
+                it[integration_type] = "slack"
+                it[access_token] = "xoxb-test-token"
+                it[team_id] = "T-outbound"
+                it[enabled] = true
+                it[created_at] = clock.now()
+                it[updated_at] = clock.now()
+            }
+        }
+    }
+
+    private fun outboundDelivery(): SlackOutboundDelivery =
+        SlackOutboundDelivery(
+            resourceId = "delivery",
+            organizationId = 1,
+            teamId = "T-outbound",
+            channelId = "C-outbound",
+            operation = SlackOutboundOperation.CHANNEL_CREATE,
+            idempotencyKey = "delivery-key",
+            payload = "{\"name\":\"incident\"}",
+            desiredVersion = 1,
+            attemptCount = 1,
+        )
+
+    private fun mockSlackClient(handler: MockRequestHandleScope.() -> HttpResponseData): HttpClient =
+        HttpClient(MockEngine) {
+            engine {
+                addHandler { handler() }
+            }
+        }
 
     private fun request(version: Int = 1): SlackOutboundEnqueueRequest =
         SlackOutboundEnqueueRequest(

--- a/backend/src/test/kotlin/com/moneat/notifications/services/SlackOutboundDeliveryServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/notifications/services/SlackOutboundDeliveryServiceTest.kt
@@ -159,6 +159,75 @@ class SlackOutboundDeliveryServiceTest {
     }
 
     @Test
+    fun `reconciliation handles stale observations, deletions, supersession, and unknown resources`() {
+        val service = SlackOutboundDeliveryService(clock = clock)
+        val resourceId = service.enqueue(request(version = 2))
+
+        assertEquals(
+            SlackOutboundDeliveryStatus.PENDING,
+            service.reconcile(
+                SlackOutboundReconciliationRequest(
+                    resourceId = resourceId,
+                    observation = SlackOutboundObservation.PRESENT,
+                    observedVersion = 1,
+                ),
+            ),
+        )
+        assertEquals(
+            SlackOutboundDeliveryStatus.PENDING,
+            service.reconcile(
+                SlackOutboundReconciliationRequest(
+                    resourceId = resourceId,
+                    observation = SlackOutboundObservation.EDITED,
+                ),
+            ),
+        )
+        assertEquals(
+            SlackOutboundDeliveryStatus.PENDING,
+            service.reconcile(
+                SlackOutboundReconciliationRequest(
+                    resourceId = resourceId,
+                    observation = SlackOutboundObservation.DELETED,
+                ),
+            ),
+        )
+        assertEquals(
+            SlackOutboundDeliveryStatus.SUPERSEDED,
+            service.reconcile(
+                SlackOutboundReconciliationRequest(
+                    resourceId = resourceId,
+                    observation = SlackOutboundObservation.SUPERSEDED,
+                ),
+            ),
+        )
+        assertEquals(
+            null,
+            service.reconcile(
+                SlackOutboundReconciliationRequest(
+                    resourceId = "00000000-0000-0000-0000-000000000000",
+                    observation = SlackOutboundObservation.PRESENT,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `failed sender result is retried and records failure metrics`() = runBlocking {
+        val service = SlackOutboundDeliveryService(clock = clock, maxAttempts = 2)
+        val resourceId = service.enqueue(request())
+
+        assertTrue(
+            service.process(
+                resourceId,
+                SlackOutboundSender { SlackOutboundSendResult.Failed("provider rejected message") },
+            ),
+        )
+        val row = transaction { SlackOutboundDeliveries.selectAll().single() }
+        assertEquals(SlackOutboundDeliveryStatus.RETRY.wire, row[SlackOutboundDeliveries.status])
+        assertTrue(service.metrics().failureCount >= 1)
+    }
+
+    @Test
     fun `unsupported outbound operation fails before workspace access`() = runBlocking {
         val result = SlackService().sendOutboundDelivery(
             SlackOutboundDelivery(

--- a/backend/src/test/kotlin/com/moneat/notifications/services/SlackOutboundDeliveryServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/notifications/services/SlackOutboundDeliveryServiceTest.kt
@@ -1,0 +1,194 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.notifications.services
+
+import com.moneat.shared.models.Organizations
+import com.moneat.shared.models.SlackOutboundDeliveryStatus
+import com.moneat.shared.models.SlackOutboundDeliveries
+import com.moneat.shared.models.SlackOutboundOperation
+import com.moneat.testsupport.TestDatabaseHelper
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+class SlackOutboundDeliveryServiceTest {
+    companion object {
+        private var database: Database? = null
+    }
+
+    private val clock = MutableClock(Instant.parse("2026-08-25T00:00:00Z"))
+
+    @BeforeTest
+    fun setUp() {
+        if (database == null) {
+            database = Database.connect(
+                url = "jdbc:h2:mem:moneat_slack_outbound;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
+                driver = "org.h2.Driver",
+            )
+        }
+        TransactionManager.defaultDatabase = database
+        TestDatabaseHelper.resetSchema(Organizations, SlackOutboundDeliveries)
+        transaction {
+            Organizations.insert {
+                it[name] = "Outbound test"
+                it[slug] = "outbound-test"
+            }
+        }
+    }
+
+    @Test
+    fun `idempotent enqueue updates desired version without creating a duplicate`() {
+        val service = SlackOutboundDeliveryService(clock = clock)
+        val first = service.enqueue(request(version = 1))
+        val second = service.enqueue(request(version = 2))
+
+        assertEquals(first, second)
+        val row = transaction { SlackOutboundDeliveries.selectAll().single() }
+        assertEquals(2, row[SlackOutboundDeliveries.desiredVersion])
+        assertEquals(SlackOutboundDeliveryStatus.PENDING.wire, row[SlackOutboundDeliveries.status])
+    }
+
+    @Test
+    fun `delivery is recorded once and replay does not call sender twice`() = runBlocking {
+        val service = SlackOutboundDeliveryService(clock = clock)
+        val resourceId = service.enqueue(request())
+        var sends = 0
+        val sender = SlackOutboundSender {
+            sends += 1
+            SlackOutboundSendResult.Delivered(providerMessageId = "M1", providerMessageTs = "1.1")
+        }
+
+        assertTrue(service.process(resourceId, sender))
+        assertFalse(service.process(resourceId, sender))
+        assertEquals(1, sends)
+        val row = transaction { SlackOutboundDeliveries.selectAll().single() }
+        assertEquals(SlackOutboundDeliveryStatus.DELIVERED.wire, row[SlackOutboundDeliveries.status])
+        assertEquals("M1", row[SlackOutboundDeliveries.providerMessageId])
+        assertEquals(1, row[SlackOutboundDeliveries.deliveredVersion])
+        assertNotNull(service.metrics().lastSuccessfulDelivery)
+    }
+
+    @Test
+    fun `bounded retries eventually move an unavailable delivery to dead letter`() = runBlocking {
+        val service = SlackOutboundDeliveryService(clock = clock, maxAttempts = 2)
+        val resourceId = service.enqueue(request())
+        val sender = SlackOutboundSender {
+            SlackOutboundSendResult.Retry("Slack unavailable", retryAt = clock.now(), rateLimited = true)
+        }
+
+        assertTrue(service.process(resourceId, sender))
+        assertTrue(service.process(resourceId, sender))
+        assertTrue(service.process(resourceId, sender))
+        val row = transaction { SlackOutboundDeliveries.selectAll().single() }
+        assertEquals(SlackOutboundDeliveryStatus.DEAD_LETTER.wire, row[SlackOutboundDeliveries.status])
+        assertEquals(1L, service.metrics().deadLetterCount)
+        assertTrue(service.metrics().rateLimitedCount >= 1)
+    }
+
+    @Test
+    fun `superseded sender result preserves durable supersession state`() = runBlocking {
+        val service = SlackOutboundDeliveryService(clock = clock)
+        val resourceId = service.enqueue(request())
+
+        assertTrue(service.process(resourceId, SlackOutboundSender { SlackOutboundSendResult.Superseded }))
+        val row = transaction { SlackOutboundDeliveries.selectAll().single() }
+        assertEquals(SlackOutboundDeliveryStatus.SUPERSEDED.wire, row[SlackOutboundDeliveries.status])
+        assertNotNull(row[SlackOutboundDeliveries.supersededAt])
+    }
+
+    @Test
+    fun `reconciliation reschedules missing and edited messages`() {
+        val service = SlackOutboundDeliveryService(clock = clock)
+        val resourceId = service.enqueue(request())
+
+        assertEquals(
+            SlackOutboundDeliveryStatus.PENDING,
+            service.reconcile(
+                SlackOutboundReconciliationRequest(
+                    resourceId = resourceId,
+                    observation = SlackOutboundObservation.MISSING,
+                    providerMessageId = "M1",
+                ),
+            ),
+        )
+        var row = transaction { SlackOutboundDeliveries.selectAll().single() }
+        assertEquals(SlackOutboundDeliveryStatus.PENDING.wire, row[SlackOutboundDeliveries.status])
+        assertTrue(row[SlackOutboundDeliveries.lastError]!!.contains("missing"))
+
+        assertEquals(
+            SlackOutboundDeliveryStatus.DELIVERED,
+            service.reconcile(
+                SlackOutboundReconciliationRequest(
+                    resourceId = resourceId,
+                    observation = SlackOutboundObservation.PRESENT,
+                    observedVersion = 1,
+                    providerMessageId = "M1",
+                    providerMessageTs = "1.1",
+                ),
+            ),
+        )
+        row = transaction { SlackOutboundDeliveries.selectAll().single() }
+        assertEquals(SlackOutboundDeliveryStatus.DELIVERED.wire, row[SlackOutboundDeliveries.status])
+        assertEquals("M1", row[SlackOutboundDeliveries.providerMessageId])
+    }
+
+    @Test
+    fun `unsupported outbound operation fails before workspace access`() = runBlocking {
+        val result = SlackService().sendOutboundDelivery(
+            SlackOutboundDelivery(
+                resourceId = "delivery",
+                organizationId = 1,
+                teamId = "T-outbound",
+                channelId = "C-outbound",
+                operation = SlackOutboundOperation.CHANNEL_CREATE,
+                idempotencyKey = "channel:create",
+                payload = "{}",
+                desiredVersion = 1,
+                attemptCount = 1,
+            ),
+        )
+
+        assertIs<SlackOutboundSendResult.Failed>(result)
+    }
+
+    private fun request(version: Int = 1): SlackOutboundEnqueueRequest =
+        SlackOutboundEnqueueRequest(
+            organizationId = 1,
+            teamId = "T-outbound",
+            channelId = "C-outbound",
+            operation = SlackOutboundOperation.MESSAGE,
+            idempotencyKey = "incident:1:message",
+            payload = "{\"text\":\"hello-$version\"}",
+            desiredVersion = version,
+        )
+
+    private class MutableClock(var instant: Instant) : Clock {
+        override fun now(): Instant = instant
+    }
+}


### PR DESCRIPTION
Summary:
- Persist outbound Slack operations with idempotency, versioning, retries, leases, dead-lettering, and reconciliation.
- Route sends through the durable worker with rate-limit handling and provider identifiers.
- Add delivery metrics and focused service coverage.

Validation:
- Focused outbound delivery tests passed.
- Backend compile and Detekt passed.
- Migration version check and git diff --check passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added durable outbound Slack delivery for messages, channels, invitations, bookmarks, and archiving.
  - Added background processing with retries, rate-limit handling, dead-lettering, and duplicate protection.
  - Added delivery status tracking, reconciliation, and operational metrics.
- **Bug Fixes**
  - Improved handling of Slack API failures, temporary outages, and rate limits.
- **Tests**
  - Added coverage for queued delivery processing, provider response handling, retries, deduplication, reconciliation, and superseded deliveries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->