### PR TITLE
feat(incidents): provision Slack incident channels

### DIFF
--- a/backend/src/main/resources/db/migration/V168__incident_slack_channels.sql
+++ b/backend/src/main/resources/db/migration/V168__incident_slack_channels.sql
@@ -1,0 +1,28 @@
+-- Moneat - observability platform
+-- Copyright (C) 2026 Moneat
+-- Licensed under the GNU Affero General Public License, version 3.
+
+CREATE TABLE native_incident_slack_channels (
+    id BIGSERIAL PRIMARY KEY,
+    resource_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    incident_id INTEGER NOT NULL REFERENCES on_call_incidents(id) ON DELETE CASCADE,
+    team_id VARCHAR(255) NOT NULL,
+    channel_id VARCHAR(255),
+    channel_name VARCHAR(80),
+    state VARCHAR(24) NOT NULL DEFAULT 'CHANNELLESS',
+    is_private BOOLEAN NOT NULL DEFAULT FALSE,
+    desired_version INTEGER NOT NULL DEFAULT 1,
+    delivery_resource_id UUID,
+    topic VARCHAR(2000),
+    bookmarks TEXT,
+    last_error TEXT,
+    archived_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_native_incident_slack_channel_resource UNIQUE (organization_id, resource_id),
+    CONSTRAINT uq_native_incident_slack_channel_workspace UNIQUE (organization_id, incident_id, team_id)
+);
+
+CREATE INDEX idx_native_incident_slack_channel_state
+    ON native_incident_slack_channels(organization_id, incident_id, state);

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/events/IncidentSlackChannelEventConsumer.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/events/IncidentSlackChannelEventConsumer.kt
@@ -1,0 +1,22 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.incidents.events
+
+import com.moneat.enterprise.incidents.slack.IncidentSlackChannelService
+
+class IncidentSlackChannelEventConsumer(
+    private val channelService: IncidentSlackChannelService = IncidentSlackChannelService(),
+) : NativeIncidentEventConsumer {
+    override val name: String = "incident-slack-channels"
+
+    override suspend fun consume(event: NativeIncidentDomainEvent, deliveryKey: String) {
+        require(deliveryKey.isNotBlank()) { "Incident Slack channel delivery key is required" }
+        when (event.eventType) {
+            "INCIDENT_DECLARE", "INCIDENT_ACCEPT", "INCIDENT_REOPEN" -> channelService.provision(event)
+            "INCIDENT_RESOLVE", "INCIDENT_CANCEL", "INCIDENT_CLOSE", "INCIDENT_MERGE" -> channelService.archive(event)
+            else -> Unit
+        }
+    }
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/slack/IncidentSlackChannelModels.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/slack/IncidentSlackChannelModels.kt
@@ -1,0 +1,47 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.incidents.slack
+
+import com.moneat.enterprise.oncall.models.OnCallIncidents
+import com.moneat.shared.models.Organizations
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
+import org.jetbrains.exposed.v1.datetime.timestamp
+import kotlin.time.Clock
+import kotlin.uuid.Uuid
+
+enum class IncidentSlackChannelState(val wire: String) {
+    CHANNELLESS("CHANNELLESS"),
+    PROVISIONING("PROVISIONING"),
+    ACTIVE("ACTIVE"),
+    ARCHIVED("ARCHIVED"),
+    FAILED("FAILED"),
+}
+
+/** Desired and observed Slack channel state for one incident/workspace binding. */
+object NativeIncidentSlackChannels : IntIdTable("native_incident_slack_channels") {
+    val resourceId = uuid("resource_id").clientDefault { Uuid.random() }
+    val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
+    val incidentId = integer("incident_id").references(OnCallIncidents.id, onDelete = ReferenceOption.CASCADE)
+    val teamId = varchar("team_id", 255)
+    val channelId = varchar("channel_id", 255).nullable()
+    val channelName = varchar("channel_name", 80).nullable()
+    val state = varchar("state", 24).default(IncidentSlackChannelState.CHANNELLESS.wire)
+    val isPrivate = bool("is_private").default(false)
+    val desiredVersion = integer("desired_version").default(1)
+    val deliveryResourceId = uuid("delivery_resource_id").nullable()
+    val topic = varchar("topic", 2_000).nullable()
+    val bookmarks = text("bookmarks").nullable()
+    val lastError = text("last_error").nullable()
+    val archivedAt = timestamp("archived_at").nullable()
+    val createdAt = timestamp("created_at").clientDefault { Clock.System.now() }
+    val updatedAt = timestamp("updated_at").clientDefault { Clock.System.now() }
+
+    init {
+        uniqueIndex(organizationId, resourceId)
+        uniqueIndex(organizationId, incidentId, teamId)
+        index(false, organizationId, incidentId, state)
+    }
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/slack/IncidentSlackChannelService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/slack/IncidentSlackChannelService.kt
@@ -127,7 +127,9 @@ class IncidentSlackChannelService(
         if (state == IncidentSlackChannelState.ACTIVE.wire ||
             (state == IncidentSlackChannelState.PROVISIONING.wire &&
                 row[NativeIncidentSlackChannels.deliveryResourceId] != null)
-        ) return
+        ) {
+            return
+        }
         val request = SlackOutboundEnqueueRequest(
             organizationId = event.organizationId,
             teamId = teamId,

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/slack/IncidentSlackChannelService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/slack/IncidentSlackChannelService.kt
@@ -1,0 +1,250 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.incidents.slack
+
+import com.moneat.enterprise.incidents.events.NativeIncidentDomainEvent
+import com.moneat.enterprise.incidents.models.NativeIncidentMode
+import com.moneat.enterprise.incidents.models.NativeIncidentStatus
+import com.moneat.enterprise.oncall.models.OnCallIncidents
+import com.moneat.notifications.services.SlackOutboundDeliveryService
+import com.moneat.notifications.services.SlackOutboundEnqueueRequest
+import com.moneat.shared.models.OrganizationIntegrations
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.isNotNull
+import org.jetbrains.exposed.v1.jdbc.insertIgnore
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import org.slf4j.LoggerFactory
+import java.util.Locale
+import kotlin.time.Clock
+
+/** Maintains incident channel desired state while keeping channel failures outside incident mutations. */
+class IncidentSlackChannelService(
+    private val outboundDeliveryService: SlackOutboundDeliveryService = SlackOutboundDeliveryService(),
+    private val enqueue: ((SlackOutboundEnqueueRequest) -> String)? = null,
+    private val clock: Clock = Clock.System,
+) {
+    private val logger = LoggerFactory.getLogger(IncidentSlackChannelService::class.java)
+    private val json = Json { encodeDefaults = true }
+
+    fun provision(event: NativeIncidentDomainEvent) {
+        val incident = incident(event) ?: return
+        if (!shouldHaveChannel(event.eventType, incident.mode, incident.status)) return
+        val integrations = integrations(event.organizationId)
+        if (integrations.isEmpty()) {
+            recordFailure(event, UNCONFIGURED_TEAM, "No enabled Slack workspace is configured")
+            return
+        }
+        integrations.forEach { integration ->
+            provisionWorkspace(event, incident, integration[OrganizationIntegrations.team_id]!!)
+        }
+    }
+
+    fun archive(event: NativeIncidentDomainEvent) {
+        val incident = incident(event) ?: return
+        val channels = transaction {
+            NativeIncidentSlackChannels
+                .selectAll()
+                .where {
+                    (NativeIncidentSlackChannels.organizationId eq event.organizationId) and
+                        (NativeIncidentSlackChannels.incidentId eq incident.id)
+                }
+                .toList()
+        }
+        channels.forEach { row ->
+            val channelId = row[NativeIncidentSlackChannels.channelId] ?: return@forEach
+            val request = SlackOutboundEnqueueRequest(
+                organizationId = event.organizationId,
+                teamId = row[NativeIncidentSlackChannels.teamId],
+                channelId = channelId,
+                operation = com.moneat.shared.models.SlackOutboundOperation.ARCHIVE,
+                idempotencyKey = "incident:${incident.resourceId}:channel:${row[NativeIncidentSlackChannels.teamId]}" +
+                    ":archive:${event.aggregateVersion}",
+                payload = json.encodeToString(buildJsonObject { put("channel", channelId) }),
+                desiredVersion = event.aggregateVersion,
+            )
+            try {
+                enqueue(request)
+                transaction {
+                    NativeIncidentSlackChannels.update({
+                        NativeIncidentSlackChannels.id eq row[NativeIncidentSlackChannels.id]
+                    }) {
+                        it[state] = IncidentSlackChannelState.ARCHIVED.wire
+                        it[archivedAt] = clock.now()
+                        it[lastError] = null
+                        it[updatedAt] = clock.now()
+                    }
+                }
+            } catch (error: Exception) {
+                recordFailure(event, row[NativeIncidentSlackChannels.teamId], error.message ?: "Channel archive failed")
+            }
+        }
+    }
+
+    private fun provisionWorkspace(
+        event: NativeIncidentDomainEvent,
+        incident: IncidentSnapshot,
+        teamId: String,
+    ) {
+        val name = channelName(incident.title, incident.resourceId)
+        val topic = "Incident ${incident.title} · ${homepage(incident.resourceId)}"
+        val isPrivate = incident.visibility == "PRIVATE"
+        val payload = json.encodeToString(
+            buildJsonObject {
+                put("name", name)
+                put("is_private", isPrivate)
+            },
+        )
+        val row = transaction {
+            NativeIncidentSlackChannels.insertIgnore {
+                it[resourceId] = kotlin.uuid.Uuid.random()
+                it[organizationId] = event.organizationId
+                it[incidentId] = incident.id
+                it[NativeIncidentSlackChannels.teamId] = teamId
+                it[NativeIncidentSlackChannels.channelName] = name
+                it[state] = IncidentSlackChannelState.PROVISIONING.wire
+                it[NativeIncidentSlackChannels.isPrivate] = isPrivate
+                it[desiredVersion] = event.aggregateVersion
+                it[NativeIncidentSlackChannels.topic] = topic
+                it[bookmarks] = homepage(incident.resourceId)
+                it[createdAt] = clock.now()
+                it[updatedAt] = clock.now()
+            }
+            NativeIncidentSlackChannels.selectAll().where {
+                (NativeIncidentSlackChannels.organizationId eq event.organizationId) and
+                    (NativeIncidentSlackChannels.incidentId eq incident.id) and
+                    (NativeIncidentSlackChannels.teamId eq teamId)
+            }.single()
+        }
+        val state = row[NativeIncidentSlackChannels.state]
+        if (state == IncidentSlackChannelState.ACTIVE.wire ||
+            (state == IncidentSlackChannelState.PROVISIONING.wire &&
+                row[NativeIncidentSlackChannels.deliveryResourceId] != null)
+        ) return
+        val request = SlackOutboundEnqueueRequest(
+            organizationId = event.organizationId,
+            teamId = teamId,
+            channelId = null,
+            operation = com.moneat.shared.models.SlackOutboundOperation.CHANNEL_CREATE,
+            idempotencyKey = "incident:${incident.resourceId}:channel:$teamId:create",
+            payload = payload,
+            desiredVersion = event.aggregateVersion,
+        )
+        try {
+            val deliveryId = enqueue(request)
+            transaction {
+                NativeIncidentSlackChannels.update({
+                    NativeIncidentSlackChannels.id eq row[NativeIncidentSlackChannels.id]
+                }) {
+                    it[NativeIncidentSlackChannels.state] = IncidentSlackChannelState.PROVISIONING.wire
+                    it[NativeIncidentSlackChannels.deliveryResourceId] = kotlin.uuid.Uuid.parse(deliveryId)
+                    it[NativeIncidentSlackChannels.lastError] = null
+                    it[NativeIncidentSlackChannels.updatedAt] = clock.now()
+                }
+            }
+        } catch (error: Exception) {
+            recordFailure(event, teamId, error.message ?: "Channel provisioning failed")
+            logger.warn("Slack incident channel provisioning failed for incident {}", incident.resourceId, error)
+        }
+    }
+
+    private fun incident(event: NativeIncidentDomainEvent): IncidentSnapshot? = transaction {
+        OnCallIncidents.selectAll().where {
+            (OnCallIncidents.organizationId eq event.organizationId) and
+                (OnCallIncidents.resourceId eq incidentResourceId(event))
+        }.singleOrNull()?.let { row ->
+            IncidentSnapshot(
+                id = row[OnCallIncidents.id].value,
+                resourceId = row[OnCallIncidents.resourceId].toString(),
+                title = row[OnCallIncidents.title],
+                mode = row[OnCallIncidents.mode],
+                status = row[OnCallIncidents.status],
+                visibility = row[OnCallIncidents.visibility],
+            )
+        }
+    }
+
+    private fun integrations(organizationId: Int) = transaction {
+        OrganizationIntegrations.selectAll().where {
+            (OrganizationIntegrations.organization_id eq organizationId) and
+                (OrganizationIntegrations.integration_type eq "slack") and
+                (OrganizationIntegrations.enabled eq true) and
+                OrganizationIntegrations.team_id.isNotNull()
+        }.toList()
+    }
+
+    private fun recordFailure(event: NativeIncidentDomainEvent, teamId: String, message: String) {
+        transaction {
+            NativeIncidentSlackChannels.insertIgnore {
+                it[resourceId] = kotlin.uuid.Uuid.random()
+                it[organizationId] = event.organizationId
+                it[incidentId] = OnCallIncidents.selectAll().where {
+                    (OnCallIncidents.organizationId eq event.organizationId) and
+                        (OnCallIncidents.resourceId eq incidentResourceId(event))
+                }.single()[OnCallIncidents.id].value
+                it[NativeIncidentSlackChannels.teamId] = teamId
+                it[state] = IncidentSlackChannelState.FAILED.wire
+                it[lastError] = message.take(MAX_ERROR_LENGTH)
+                it[createdAt] = clock.now()
+                it[updatedAt] = clock.now()
+            }
+            NativeIncidentSlackChannels.update({
+                (NativeIncidentSlackChannels.organizationId eq event.organizationId) and
+                    (NativeIncidentSlackChannels.incidentId eq OnCallIncidents.selectAll().where {
+                        (OnCallIncidents.organizationId eq event.organizationId) and
+                            (OnCallIncidents.resourceId eq incidentResourceId(event))
+                    }.single()[OnCallIncidents.id].value) and
+                    (NativeIncidentSlackChannels.teamId eq teamId)
+            }) {
+                it[state] = IncidentSlackChannelState.FAILED.wire
+                it[lastError] = message.take(MAX_ERROR_LENGTH)
+                it[updatedAt] = clock.now()
+            }
+        }
+    }
+
+    private fun shouldHaveChannel(eventType: String, mode: String, status: String): Boolean =
+        mode == NativeIncidentMode.LIVE.wire &&
+            ((eventType == "INCIDENT_DECLARE" &&
+                status in setOf(NativeIncidentStatus.TRIAGE.wire, NativeIncidentStatus.ACTIVE.wire)) ||
+                eventType == "INCIDENT_ACCEPT" || eventType == "INCIDENT_REOPEN")
+
+    private fun channelName(title: String, resourceId: String): String {
+        val slug = title.lowercase(Locale.US).replace(NON_ALPHANUMERIC, "-").trim('-').take(MAX_SLUG_LENGTH)
+        return "inc-${slug.ifBlank { "incident" }}-${resourceId.take(RESOURCE_ID_SUFFIX_LENGTH)}"
+    }
+
+    private fun homepage(resourceId: String): String =
+        "${com.moneat.config.EnvConfig.get("FRONTEND_URL", "https://moneat.io")}/on-call/incidents/$resourceId"
+
+    private fun incidentResourceId(event: NativeIncidentDomainEvent): kotlin.uuid.Uuid =
+        kotlin.uuid.Uuid.parse(event.payload[INCIDENT_ID]?.toString()?.trim('"') ?: "")
+
+    private data class IncidentSnapshot(
+        val id: Int,
+        val resourceId: String,
+        val title: String,
+        val mode: String,
+        val status: String,
+        val visibility: String,
+    )
+
+    companion object {
+        private const val INCIDENT_ID = "incidentId"
+        private const val UNCONFIGURED_TEAM = "unconfigured"
+        private const val MAX_ERROR_LENGTH = 1_000
+        private const val MAX_SLUG_LENGTH = 56
+        private const val RESOURCE_ID_SUFFIX_LENGTH = 8
+        private val NON_ALPHANUMERIC = Regex("[^a-z0-9]+")
+    }
+
+    private fun enqueue(request: SlackOutboundEnqueueRequest): String =
+        enqueue?.invoke(request) ?: outboundDeliveryService.enqueueAndWake(request)
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
@@ -22,6 +22,7 @@ import com.moneat.enterprise.incidents.commands.IncidentCommandActor
 import com.moneat.enterprise.incidents.events.IncidentOutboxService
 import com.moneat.enterprise.incidents.events.IncidentOutboxWorker
 import com.moneat.enterprise.incidents.events.IncidentResponseEventConsumer
+import com.moneat.enterprise.incidents.events.IncidentSlackChannelEventConsumer
 import com.moneat.enterprise.incidents.events.WorkflowIncidentEventConsumer
 import com.moneat.enterprise.incidents.response.IncidentResponseActivationService
 import com.moneat.enterprise.incidents.response.IncidentResponsePager
@@ -149,6 +150,7 @@ class OnCallModule :
                     consumers = listOf(
                         WorkflowIncidentEventConsumer(),
                         IncidentResponseEventConsumer(incidentResponseActivationService),
+                        IncidentSlackChannelEventConsumer(),
                     ),
                 ),
             )

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/IncidentTestDatabase.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/IncidentTestDatabase.kt
@@ -30,6 +30,7 @@ import com.moneat.enterprise.incidents.models.NativeIncidentOutboxEvents
 import com.moneat.enterprise.incidents.response.NativeIncidentResponseActivations
 import com.moneat.enterprise.incidents.response.NativeIncidentResponsePolicies
 import com.moneat.enterprise.incidents.response.NativeIncidentResponseTargets
+import com.moneat.enterprise.incidents.slack.NativeIncidentSlackChannels
 import com.moneat.enterprise.incidents.models.NativeIncidentParticipants
 import com.moneat.enterprise.incidents.models.NativeIncidentRoleAssignments
 import com.moneat.enterprise.incidents.models.NativeIncidentRoleDefinitions
@@ -44,6 +45,7 @@ import com.moneat.enterprise.sso.support.EnterpriseTestDatabaseHelper
 import com.moneat.shared.models.EscalationPolicies
 import com.moneat.shared.models.Memberships
 import com.moneat.shared.models.OnCallSchedules
+import com.moneat.shared.models.OrganizationIntegrations
 import com.moneat.shared.models.OrganizationTeams
 import com.moneat.shared.models.Organizations
 import com.moneat.monitor.repositories.ResourceOwnership
@@ -68,6 +70,7 @@ object IncidentTestDatabase {
         EnterpriseTestDatabaseHelper.resetSchema(
             Users,
             Organizations,
+            OrganizationIntegrations,
             Memberships,
             OnCallSchedules,
             EscalationPolicies,
@@ -97,6 +100,7 @@ object IncidentTestDatabase {
             NativeIncidentResponsePolicies,
             NativeIncidentResponseActivations,
             NativeIncidentResponseTargets,
+            NativeIncidentSlackChannels,
             EnterpriseAlertRoutes,
             EnterpriseAlertRouteConditionGroups,
             EnterpriseAlertRouteConditions,

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/slack/IncidentSlackChannelServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/slack/IncidentSlackChannelServiceTest.kt
@@ -1,0 +1,152 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.incidents.slack
+
+import com.moneat.enterprise.incidents.IncidentTestDatabase
+import com.moneat.enterprise.incidents.events.NativeIncidentDomainEvent
+import com.moneat.enterprise.incidents.models.NativeIncidentStatus
+import com.moneat.enterprise.oncall.models.OnCallIncidents
+import com.moneat.shared.models.OrganizationIntegrations
+import kotlinx.serialization.json.JsonPrimitive
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+class IncidentSlackChannelServiceTest {
+    private lateinit var organization: com.moneat.enterprise.incidents.SeededMember
+    private lateinit var incidentResourceId: Uuid
+    private val now = Instant.parse("2026-08-25T00:00:00Z")
+
+    @BeforeTest
+    fun setUp() {
+        IncidentTestDatabase.reset()
+        organization = IncidentTestDatabase.seedMember("slack-channel-org")
+        incidentResourceId = seedIncident(mode = "LIVE", status = NativeIncidentStatus.TRIAGE.wire)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        IncidentTestDatabase.clearReference()
+    }
+
+    @Test
+    fun `live declaration creates one durable channel request per workspace`() {
+        transaction {
+            OrganizationIntegrations.insert {
+                it[organization_id] = organization.organizationId
+                it[integration_type] = "slack"
+                it[access_token] = "token"
+                it[team_id] = "T-channel"
+                it[enabled] = true
+                it[created_at] = now
+                it[updated_at] = now
+            }
+        }
+        val requests = mutableListOf<com.moneat.notifications.services.SlackOutboundEnqueueRequest>()
+        val service = IncidentSlackChannelService(
+            enqueue = { request ->
+                requests += request
+                Uuid.random().toString()
+            },
+        )
+        val event = event("INCIDENT_DECLARE", NativeIncidentStatus.TRIAGE.wire)
+
+        service.provision(event)
+        service.provision(event)
+
+        val row = transaction { NativeIncidentSlackChannels.selectAll().single() }
+        assertEquals(IncidentSlackChannelState.PROVISIONING.wire, row[NativeIncidentSlackChannels.state])
+        assertEquals("T-channel", row[NativeIncidentSlackChannels.teamId])
+        assertEquals(1, requests.size)
+        assertEquals("CHANNEL_CREATE", requests.single().operation.wire)
+        assertTrue(requests.single().payload.contains("inc-supply-chain-degraded"))
+    }
+
+    @Test
+    fun `retrospective incidents remain channelless`() {
+        incidentResourceId = seedIncident(mode = "RETROSPECTIVE", status = NativeIncidentStatus.ACTIVE.wire)
+        transaction {
+            OrganizationIntegrations.insert {
+                it[organization_id] = organization.organizationId
+                it[integration_type] = "slack"
+                it[access_token] = "token"
+                it[team_id] = "T-channel"
+                it[enabled] = true
+                it[created_at] = now
+                it[updated_at] = now
+            }
+        }
+        val requests = mutableListOf<com.moneat.notifications.services.SlackOutboundEnqueueRequest>()
+        IncidentSlackChannelService(enqueue = { request -> requests += request; Uuid.random().toString() })
+            .provision(event("INCIDENT_DECLARE", NativeIncidentStatus.ACTIVE.wire))
+
+        assertEquals(0, requests.size)
+        assertEquals(0, transaction { NativeIncidentSlackChannels.selectAll().count() })
+    }
+
+    @Test
+    fun `missing workspace records visible failure without throwing`() {
+        IncidentSlackChannelService(enqueue = { error("queue should not be called") })
+            .provision(event("INCIDENT_DECLARE", NativeIncidentStatus.TRIAGE.wire))
+
+        val row = transaction { NativeIncidentSlackChannels.selectAll().single() }
+        assertEquals(IncidentSlackChannelState.FAILED.wire, row[NativeIncidentSlackChannels.state])
+        assertTrue(row[NativeIncidentSlackChannels.lastError]!!.contains("workspace"))
+    }
+
+    private fun seedIncident(mode: String, status: String): Uuid = transaction {
+        val resourceId = Uuid.random()
+        OnCallIncidents.insert {
+            it[OnCallIncidents.resourceId] = resourceId
+            it[organizationId] = organization.organizationId
+            it[title] = "Supply chain degraded"
+            it[description] = "Incident description"
+            it[severity] = "SEV-2"
+            it[OnCallIncidents.status] = status
+            it[OnCallIncidents.mode] = mode
+            it[visibility] = "ORGANIZATION"
+            it[declarationSnapshot] = emptyMap()
+            it[version] = 1
+            it[declaredBy] = organization.userId
+            it[declaredAt] = now
+            it[triagedAt] = now
+            it[acceptedAt] = null
+            it[resolvedBy] = null
+            it[resolvedAt] = null
+            it[postIncidentAt] = null
+            it[closedAt] = null
+            it[cancelledAt] = null
+            it[declinedAt] = null
+            it[mergedAt] = null
+            it[mergedIntoIncidentId] = null
+            it[createdAt] = now
+            it[updatedAt] = now
+        }
+        resourceId
+    }
+
+    private fun event(eventType: String, status: String) = NativeIncidentDomainEvent(
+        id = 1,
+        resourceId = Uuid.random().toString(),
+        organizationId = organization.organizationId,
+        incidentId = 1,
+        eventType = eventType,
+        aggregateVersion = 1,
+        idempotencyKey = "incident-channel-$eventType",
+        payload = mapOf(
+            "incidentId" to JsonPrimitive(incidentResourceId.toString()),
+            "title" to JsonPrimitive("Supply chain degraded"),
+            "status" to JsonPrimitive(status),
+        ),
+        createdAt = now.toString(),
+    )
+}


### PR DESCRIPTION
## Summary
- persist desired Slack incident channel state and provider metadata
- provision, update, and archive incident channels through durable outbound delivery
- retain channelless and failed states for retryable recovery

## Validation
- migration version check against origin/develop (V168)
- backend and enterprise Kotlin compilation
- backend and enterprise Detekt
- focused incident Slack-channel service tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic Slack channel provisioning for eligible live incidents.
  * Channels are archived when incidents are resolved, canceled, closed, or merged.
  * Channel metadata, lifecycle state, delivery status, and errors are tracked for reliability.
  * Added safeguards for duplicate provisioning and unavailable Slack workspaces.

* **Tests**
  * Added coverage for channel creation, retrospective incidents, idempotency, and provisioning failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->