### PR TITLE
feat(ai): persist assistant executions durably

### DIFF
--- a/backend/features/ai/src/main/kotlin/com/moneat/ai/AiTables.kt
+++ b/backend/features/ai/src/main/kotlin/com/moneat/ai/AiTables.kt
@@ -18,6 +18,7 @@ package com.moneat.ai
 
 import com.moneat.shared.models.Organizations
 import com.moneat.shared.models.Users
+import com.moneat.shared.models.jsonb
 import org.jetbrains.exposed.v1.core.ReferenceOption
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.datetime.timestamp
@@ -29,6 +30,9 @@ object AiConversations : Table("ai_conversations") {
     val organization_id = integer("organization_id").references(Organizations.id)
     val user_id = integer("user_id").references(Users.id)
     val title = varchar("title", 255).nullable()
+    val project_id = long("project_id").nullable()
+    val channel = varchar("channel", 32).default("chat")
+    val state_version = long("state_version").default(0)
     val created_at = timestamp("created_at")
     val updated_at = timestamp("updated_at")
     override val primaryKey = PrimaryKey(id)
@@ -50,6 +54,10 @@ object AiMessages : Table("ai_messages") {
     val output_tokens = integer("output_tokens").nullable()
     val cost_usd = decimal("cost_usd", 10, 6).nullable()
     val provider = varchar("provider", 20).nullable()
+    val run_id = long("run_id").nullable()
+    val tool_call_id = varchar("tool_call_id", 255).nullable()
+    val tool_calls = jsonb("tool_calls").nullable()
+    val sequence_number = long("sequence_number").nullable()
     val created_at = timestamp("created_at")
     override val primaryKey = PrimaryKey(id)
 }

--- a/backend/src/main/resources/db/migration/V170__durable_ai_runs_and_approvals.sql
+++ b/backend/src/main/resources/db/migration/V170__durable_ai_runs_and_approvals.sql
@@ -1,0 +1,125 @@
+-- Durable execution state for enterprise AI conversations and tool approvals.
+
+ALTER TABLE ai_conversations
+    ADD COLUMN IF NOT EXISTS project_id BIGINT REFERENCES projects(id) ON DELETE SET NULL,
+    ADD COLUMN IF NOT EXISTS channel VARCHAR(32) NOT NULL DEFAULT 'chat',
+    ADD COLUMN IF NOT EXISTS state_version BIGINT NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS ai_runs (
+    id BIGSERIAL PRIMARY KEY,
+    resource_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    conversation_id INTEGER NOT NULL REFERENCES ai_conversations(id) ON DELETE CASCADE,
+    project_id BIGINT REFERENCES projects(id) ON DELETE SET NULL,
+    idempotency_key VARCHAR(128) NOT NULL,
+    request_fingerprint CHAR(64) NOT NULL,
+    status VARCHAR(32) NOT NULL DEFAULT 'pending',
+    current_round INTEGER NOT NULL DEFAULT 0,
+    provider VARCHAR(64),
+    model VARCHAR(255),
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    cost_usd NUMERIC(18, 8) NOT NULL DEFAULT 0,
+    cost_metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    output_content TEXT,
+    error_code VARCHAR(64),
+    error_message TEXT,
+    cancellation_requested_at TIMESTAMPTZ,
+    cancellation_requested_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    started_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    version BIGINT NOT NULL DEFAULT 0,
+    CONSTRAINT chk_ai_runs_status CHECK (
+        status IN ('pending', 'running', 'waiting_for_approval', 'completed', 'failed', 'cancelled')
+    ),
+    CONSTRAINT uq_ai_runs_actor_idempotency UNIQUE (organization_id, user_id, idempotency_key),
+    CONSTRAINT uq_ai_runs_org_resource UNIQUE (organization_id, resource_id)
+);
+
+ALTER TABLE ai_messages
+    ADD COLUMN IF NOT EXISTS run_id BIGINT REFERENCES ai_runs(id) ON DELETE SET NULL,
+    ADD COLUMN IF NOT EXISTS tool_call_id VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS tool_calls JSONB,
+    ADD COLUMN IF NOT EXISTS sequence_number BIGINT;
+
+CREATE TABLE IF NOT EXISTS ai_tool_calls (
+    id BIGSERIAL PRIMARY KEY,
+    resource_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    run_id BIGINT NOT NULL REFERENCES ai_runs(id) ON DELETE CASCADE,
+    round INTEGER NOT NULL,
+    provider_call_id VARCHAR(255) NOT NULL,
+    tool_name VARCHAR(255) NOT NULL,
+    arguments JSONB,
+    arguments_valid BOOLEAN NOT NULL DEFAULT TRUE,
+    read_only BOOLEAN NOT NULL,
+    status VARCHAR(32) NOT NULL DEFAULT 'proposed',
+    effect_idempotency_key VARCHAR(255) NOT NULL,
+    result JSONB,
+    result_summary TEXT,
+    is_error BOOLEAN,
+    result_audit_event_id UUID,
+    started_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT chk_ai_tool_calls_status CHECK (
+        status IN ('proposed', 'awaiting_approval', 'executing', 'succeeded', 'failed', 'denied', 'expired')
+    ),
+    CONSTRAINT uq_ai_tool_calls_run_provider_call UNIQUE (run_id, round, provider_call_id),
+    CONSTRAINT uq_ai_tool_calls_effect_key UNIQUE (organization_id, effect_idempotency_key),
+    CONSTRAINT uq_ai_tool_calls_org_resource UNIQUE (organization_id, resource_id)
+);
+
+CREATE TABLE IF NOT EXISTS ai_run_evidence (
+    id BIGSERIAL PRIMARY KEY,
+    resource_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    run_id BIGINT NOT NULL REFERENCES ai_runs(id) ON DELETE CASCADE,
+    evidence_type VARCHAR(64) NOT NULL,
+    source VARCHAR(128) NOT NULL,
+    source_resource_id VARCHAR(255),
+    content JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_ai_run_evidence_org_resource UNIQUE (organization_id, resource_id)
+);
+
+CREATE TABLE IF NOT EXISTS ai_approvals (
+    id BIGSERIAL PRIMARY KEY,
+    resource_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    run_id BIGINT NOT NULL REFERENCES ai_runs(id) ON DELETE CASCADE,
+    tool_call_id BIGINT NOT NULL UNIQUE REFERENCES ai_tool_calls(id) ON DELETE CASCADE,
+    requested_by INTEGER NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+    decided_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    incident_resource_id UUID,
+    incident_version BIGINT,
+    proposed_command JSONB NOT NULL,
+    proposal_sha256 CHAR(64) NOT NULL,
+    status VARCHAR(32) NOT NULL DEFAULT 'pending',
+    decision_reason TEXT,
+    expires_at TIMESTAMPTZ NOT NULL,
+    decided_at TIMESTAMPTZ,
+    result_audit_event_id UUID,
+    response JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT chk_ai_approvals_status CHECK (status IN ('pending', 'approved', 'denied', 'expired')),
+    CONSTRAINT uq_ai_approvals_org_resource UNIQUE (organization_id, resource_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_runs_conversation_created
+    ON ai_runs (conversation_id, created_at, id);
+CREATE INDEX IF NOT EXISTS idx_ai_runs_org_status
+    ON ai_runs (organization_id, status, updated_at);
+CREATE INDEX IF NOT EXISTS idx_ai_messages_run_sequence
+    ON ai_messages (run_id, sequence_number, id);
+CREATE INDEX IF NOT EXISTS idx_ai_tool_calls_run_status
+    ON ai_tool_calls (run_id, status, created_at);
+CREATE INDEX IF NOT EXISTS idx_ai_run_evidence_run
+    ON ai_run_evidence (run_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_ai_approvals_org_pending
+    ON ai_approvals (organization_id, status, expires_at);

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/models/AiAssistantModels.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/models/AiAssistantModels.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.json.JsonObject
 data class AiAssistantStreamRequest(
     val message: String,
     val conversationId: String? = null,
+    val runId: String? = null,
     val projectId: String? = null,
 )
 
@@ -23,6 +24,7 @@ data class AiAssistantConfirmRequest(
 @Serializable
 data class AiAssistantConfirmResponse(
     val conversationId: String,
+    val runId: String,
     val requestId: String,
     val approved: Boolean,
     val tool: String,
@@ -51,6 +53,7 @@ data class AssistantConfirmationNeededEvent(
     val type: String = "confirmation_needed",
     val requestId: String,
     val conversationId: String,
+    val runId: String? = null,
     val tool: String,
     val args: JsonObject,
 )
@@ -71,4 +74,5 @@ data class AssistantErrorEvent(
 data class AssistantDoneEvent(
     val type: String = "done",
     val conversationId: String,
+    val runId: String? = null,
 )

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/models/AiModels.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/models/AiModels.kt
@@ -8,14 +8,22 @@ import kotlinx.serialization.Serializable
 import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.ColumnType
 import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.stringLiteral
 import org.jetbrains.exposed.v1.datetime.timestamp
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.postgresql.util.PGobject
 import kotlin.uuid.Uuid
 
-// ── Custom JSONB column type for raw JSON strings ───────────────────────
+// Custom JSONB column type for raw JSON strings.
 
 private class StringJsonbColumnType : ColumnType<String>() {
-    override fun sqlType() = "JSONB"
+    private fun isH2(): Boolean = TransactionManager
+        .currentOrNull()
+        ?.db
+        ?.url
+        ?.contains("h2", ignoreCase = true) == true
+
+    override fun sqlType() = if (isH2()) "TEXT" else "JSONB"
 
     override fun valueFromDB(value: Any): String = when (value) {
         is PGobject -> value.value ?: "{}"
@@ -23,16 +31,19 @@ private class StringJsonbColumnType : ColumnType<String>() {
         else -> value.toString()
     }
 
-    override fun notNullValueToDB(value: String): Any = PGobject().apply {
-        type = "jsonb"
-        this.value = value
+    override fun notNullValueToDB(value: String): Any {
+        if (isH2()) return value
+        return PGobject().apply {
+            type = "jsonb"
+            this.value = value
+        }
     }
 }
 
 private fun Table.stringJsonb(name: String): Column<String> =
     registerColumn(name, StringJsonbColumnType())
 
-// ── Exposed Table for context snapshots ─────────────────────────────────
+// Exposed table for context snapshots.
 
 object AiContextSnapshots : Table("ai_context_snapshots") {
     val id = integer("id").autoIncrement()
@@ -49,7 +60,97 @@ object AiContextSnapshots : Table("ai_context_snapshots") {
     override val primaryKey = PrimaryKey(id)
 }
 
-// ── SSE Event Types ─────────────────────────────────────────────────────
+object AiRuns : Table("ai_runs") {
+    val id = long("id").autoIncrement()
+    val resource_id = uuid("resource_id").clientDefault { Uuid.random() }
+    val organization_id = integer("organization_id")
+    val user_id = integer("user_id")
+    val conversation_id = integer("conversation_id")
+    val project_id = long("project_id").nullable()
+    val idempotency_key = varchar("idempotency_key", 128)
+    val request_fingerprint = char("request_fingerprint", 64)
+    val status = varchar("status", 32)
+    val current_round = integer("current_round").default(0)
+    val provider = varchar("provider", 64).nullable()
+    val model = varchar("model", 255).nullable()
+    val input_tokens = integer("input_tokens").default(0)
+    val output_tokens = integer("output_tokens").default(0)
+    val cost_usd = decimal("cost_usd", 18, 8).default(java.math.BigDecimal.ZERO)
+    val cost_metadata = stringJsonb("cost_metadata").defaultExpression(stringLiteral("{}"))
+    val output_content = text("output_content").nullable()
+    val error_code = varchar("error_code", 64).nullable()
+    val error_message = text("error_message").nullable()
+    val cancellation_requested_at = timestamp("cancellation_requested_at").nullable()
+    val cancellation_requested_by = integer("cancellation_requested_by").nullable()
+    val started_at = timestamp("started_at").nullable()
+    val completed_at = timestamp("completed_at").nullable()
+    val created_at = timestamp("created_at")
+    val updated_at = timestamp("updated_at")
+    val version = long("version").default(0)
+    override val primaryKey = PrimaryKey(id)
+}
+
+object AiToolCalls : Table("ai_tool_calls") {
+    val id = long("id").autoIncrement()
+    val resource_id = uuid("resource_id").clientDefault { Uuid.random() }
+    val organization_id = integer("organization_id")
+    val run_id = long("run_id")
+    val round = integer("round")
+    val provider_call_id = varchar("provider_call_id", 255)
+    val tool_name = varchar("tool_name", 255)
+    val arguments = stringJsonb("arguments").nullable()
+    val arguments_valid = bool("arguments_valid").default(true)
+    val read_only = bool("read_only")
+    val status = varchar("status", 32)
+    val effect_idempotency_key = varchar("effect_idempotency_key", 255)
+    val result = stringJsonb("result").nullable()
+    val result_summary = text("result_summary").nullable()
+    val is_error = bool("is_error").nullable()
+    val result_audit_event_id = uuid("result_audit_event_id").nullable()
+    val started_at = timestamp("started_at").nullable()
+    val completed_at = timestamp("completed_at").nullable()
+    val created_at = timestamp("created_at")
+    val updated_at = timestamp("updated_at")
+    override val primaryKey = PrimaryKey(id)
+}
+
+object AiRunEvidence : Table("ai_run_evidence") {
+    val id = long("id").autoIncrement()
+    val resource_id = uuid("resource_id").clientDefault { Uuid.random() }
+    val organization_id = integer("organization_id")
+    val run_id = long("run_id")
+    val evidence_type = varchar("evidence_type", 64)
+    val source_name = varchar("source", 128)
+    val source_resource_id = varchar("source_resource_id", 255).nullable()
+    val content = stringJsonb("content")
+    val created_at = timestamp("created_at")
+    override val primaryKey = PrimaryKey(id)
+}
+
+object AiApprovals : Table("ai_approvals") {
+    val id = long("id").autoIncrement()
+    val resource_id = uuid("resource_id").clientDefault { Uuid.random() }
+    val organization_id = integer("organization_id")
+    val run_id = long("run_id")
+    val tool_call_id = long("tool_call_id")
+    val requested_by = integer("requested_by")
+    val decided_by = integer("decided_by").nullable()
+    val incident_resource_id = uuid("incident_resource_id").nullable()
+    val incident_version = long("incident_version").nullable()
+    val proposed_command = stringJsonb("proposed_command")
+    val proposal_sha256 = char("proposal_sha256", 64)
+    val status = varchar("status", 32)
+    val decision_reason = text("decision_reason").nullable()
+    val expires_at = timestamp("expires_at")
+    val decided_at = timestamp("decided_at").nullable()
+    val result_audit_event_id = uuid("result_audit_event_id").nullable()
+    val response = stringJsonb("response").nullable()
+    val created_at = timestamp("created_at")
+    val updated_at = timestamp("updated_at")
+    override val primaryKey = PrimaryKey(id)
+}
+
+// SSE event types.
 
 @Serializable
 data class SseSearchProgress(
@@ -80,7 +181,7 @@ data class SseError(
     val error: String,
 )
 
-// ── API Request DTOs ────────────────────────────────────────────────────
+// API request DTOs.
 
 @Serializable
 data class AiChatStreamRequest(
@@ -95,7 +196,7 @@ data class AiConfirmRequest(
     val snapshotId: String,
 )
 
-// ── Aggregated Context Types ────────────────────────────────────────────
+// Aggregated context types.
 
 @Serializable
 data class AggregatedContext(

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/routes/AiAssistantRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/routes/AiAssistantRoutes.kt
@@ -10,6 +10,7 @@ import com.moneat.enterprise.ai.models.AiAssistantStreamRequest
 import com.moneat.enterprise.ai.models.AssistantDoneEvent
 import com.moneat.enterprise.ai.models.AssistantErrorEvent
 import com.moneat.enterprise.ai.services.AiAssistantService
+import com.moneat.enterprise.ai.services.AiAssistantStreamCommand
 import com.moneat.shared.models.Projects
 import com.moneat.shared.models.Users
 import com.moneat.shared.services.toUuidOrNull
@@ -37,112 +38,142 @@ private val json = Json {
     ignoreUnknownKeys = true
     encodeDefaults = true
 }
+private const val ADMIN_ONLY_ERROR = "AI assistant is only available for admins"
 
 fun Route.aiAssistantRoutes(service: AiAssistantService) {
     authenticate("auth-jwt") {
         route("/v1/ai/assistant") {
-            post("/stream") {
-                val context = call.requireCurrentOrg() ?: return@post
-                val userId = context.userId
+            registerAssistantStreamRoute(service)
+            registerAssistantConfirmationRoute(service)
+            registerAssistantCancellationRoute(service)
+        }
+    }
+}
 
-                val userDetails = getUserDetails(userId)
-                if (!userDetails.isAdmin) {
-                    call.respond(
-                        HttpStatusCode.Forbidden,
-                        mapOf("error" to "AI assistant is only available for admins")
-                    )
-                    return@post
-                }
+private fun Route.registerAssistantStreamRoute(service: AiAssistantService) {
+    post("/stream") {
+        val context = call.requireCurrentOrg() ?: return@post
+        val userDetails = getUserDetails(context.userId)
+        if (!userDetails.isAdmin) {
+            call.respond(HttpStatusCode.Forbidden, mapOf("error" to ADMIN_ONLY_ERROR))
+            return@post
+        }
 
-                val orgId = context.orgId
+        val request = call.receive<AiAssistantStreamRequest>()
+        val requestError = validateStreamRequest(request)
+        if (requestError != null) {
+            call.respond(HttpStatusCode.BadRequest, mapOf("error" to requestError))
+            return@post
+        }
+        val projectResolution = resolveAssistantProjectId(context.orgId, request.projectId)
+        if (projectResolution.errorStatus != null) {
+            call.respond(projectResolution.errorStatus, mapOf("error" to projectResolution.errorMessage))
+            return@post
+        }
 
-                val request = call.receive<AiAssistantStreamRequest>()
-                if (request.message.isBlank()) {
-                    call.respond(HttpStatusCode.BadRequest, mapOf("error" to "Message cannot be empty"))
-                    return@post
-                }
-                val projectResolution = resolveAssistantProjectId(orgId, request.projectId)
-                if (projectResolution.errorStatus != null) {
-                    call.respond(projectResolution.errorStatus, mapOf("error" to projectResolution.errorMessage))
-                    return@post
-                }
-                val projectId = projectResolution.projectId
-
-                call.response.headers.append(HttpHeaders.CacheControl, "no-cache")
-                call.response.headers.append(HttpHeaders.Connection, "keep-alive")
-
-                call.respondTextWriter(contentType = ContentType.Text.EventStream) {
-                    try {
-                        service.streamAssistant(
-                            writer = this,
-                            userId = userId,
-                            orgId = orgId,
-                            message = request.message,
-                            conversationId = request.conversationId,
-                            projectId = projectId,
-                            userTimezone = userDetails.timezone,
-                        )
-                    } catch (e: Exception) {
-                        logger.error(e) { "Assistant stream failed for user $userId" }
-                        AiAssistantService.sendSse(
-                            this,
-                            json.encodeToString(
-                                AssistantErrorEvent.serializer(),
-                                AssistantErrorEvent(error = "Assistant stream failed: ${e.message}"),
-                            ),
-                        )
-                        AiAssistantService.sendSse(
-                            this,
-                            json.encodeToString(
-                                AssistantDoneEvent.serializer(),
-                                AssistantDoneEvent(conversationId = request.conversationId.orEmpty()),
-                            ),
-                        )
-                    }
-                }
-            }
-
-            post("/confirm") {
-                val context = call.requireCurrentOrg() ?: return@post
-                val userId = context.userId
-
-                if (!getUserDetails(userId).isAdmin) {
-                    call.respond(
-                        HttpStatusCode.Forbidden,
-                        mapOf("error" to "AI assistant is only available for admins")
-                    )
-                    return@post
-                }
-
-                val orgId = context.orgId
-
-                val request = call.receive<AiAssistantConfirmRequest>()
-                if (request.requestId.isBlank()) {
-                    call.respond(HttpStatusCode.BadRequest, mapOf("error" to "requestId is required"))
-                    return@post
-                }
-
-                try {
-                    val response = service.confirmPendingAction(
-                        userId = userId,
-                        orgId = orgId,
-                        request = request,
-                    )
-                    call.respond(response)
-                } catch (e: IllegalArgumentException) {
-                    call.respond(HttpStatusCode.NotFound, mapOf("error" to e.message))
-                } catch (e: IllegalAccessException) {
-                    call.respond(HttpStatusCode.Forbidden, mapOf("error" to e.message))
-                } catch (e: Exception) {
-                    logger.error(e) { "Assistant confirmation failed for user $userId" }
-                    call.respond(
-                        HttpStatusCode.InternalServerError,
-                        mapOf("error" to "Failed to confirm assistant action"),
-                    )
-                }
+        call.response.headers.append(HttpHeaders.CacheControl, "no-cache")
+        call.response.headers.append(HttpHeaders.Connection, "keep-alive")
+        call.respondTextWriter(contentType = ContentType.Text.EventStream) {
+            try {
+                service.streamAssistant(
+                    writer = this,
+                    command = AiAssistantStreamCommand(
+                        userId = context.userId,
+                        organizationId = context.orgId,
+                        message = request.message,
+                        conversationId = request.conversationId,
+                        runId = request.runId,
+                        projectId = projectResolution.projectId,
+                        userTimezone = userDetails.timezone,
+                    ),
+                )
+            } catch (e: Exception) {
+                logger.error(e) { "Assistant stream failed for user ${context.userId}" }
+                sendAssistantStreamError(this, request, e)
             }
         }
     }
+}
+
+private fun Route.registerAssistantConfirmationRoute(service: AiAssistantService) {
+    post("/confirm") {
+        val context = call.requireCurrentOrg() ?: return@post
+        if (!getUserDetails(context.userId).isAdmin) {
+            call.respond(HttpStatusCode.Forbidden, mapOf("error" to ADMIN_ONLY_ERROR))
+            return@post
+        }
+
+        val request = call.receive<AiAssistantConfirmRequest>()
+        if (request.requestId.isBlank()) {
+            call.respond(HttpStatusCode.BadRequest, mapOf("error" to "requestId is required"))
+            return@post
+        }
+
+        try {
+            call.respond(service.confirmPendingAction(context.userId, context.orgId, request))
+        } catch (e: IllegalArgumentException) {
+            call.respond(HttpStatusCode.NotFound, mapOf("error" to e.message))
+        } catch (e: IllegalAccessException) {
+            call.respond(HttpStatusCode.Forbidden, mapOf("error" to e.message))
+        } catch (e: IllegalStateException) {
+            call.respond(HttpStatusCode.Conflict, mapOf("error" to e.message))
+        } catch (e: Exception) {
+            logger.error(e) { "Assistant confirmation failed for user ${context.userId}" }
+            call.respond(HttpStatusCode.InternalServerError, mapOf("error" to "Failed to confirm assistant action"))
+        }
+    }
+}
+
+private fun Route.registerAssistantCancellationRoute(service: AiAssistantService) {
+    post("/runs/{runId}/cancel") {
+        val context = call.requireCurrentOrg() ?: return@post
+        if (!getUserDetails(context.userId).isAdmin) {
+            call.respond(HttpStatusCode.Forbidden, mapOf("error" to ADMIN_ONLY_ERROR))
+            return@post
+        }
+        val runId = call.parameters["runId"]?.trim().orEmpty()
+        if (runId.toUuidOrNull() == null) {
+            call.respond(HttpStatusCode.BadRequest, mapOf("error" to "runId must be a UUID"))
+            return@post
+        }
+        if (service.cancelRun(context.userId, context.orgId, runId)) {
+            call.respond(HttpStatusCode.Accepted, mapOf("status" to "cancelled", "runId" to runId))
+        } else {
+            call.respond(
+                HttpStatusCode.NotFound,
+                mapOf("error" to "Assistant run not found or already finished"),
+            )
+        }
+    }
+}
+
+private fun validateStreamRequest(request: AiAssistantStreamRequest): String? = when {
+    request.message.isBlank() -> "Message cannot be empty"
+    request.conversationId != null && request.conversationId.toUuidOrNull() == null ->
+        "conversationId must be a UUID"
+    request.runId != null && request.runId.toUuidOrNull() == null -> "runId must be a UUID"
+    else -> null
+}
+
+private fun sendAssistantStreamError(
+    writer: java.io.Writer,
+    request: AiAssistantStreamRequest,
+    error: Exception,
+) {
+    AiAssistantService.sendSse(
+        writer,
+        json.encodeToString(
+            AssistantErrorEvent.serializer(),
+            AssistantErrorEvent(error = "Assistant stream failed: ${error.message}"),
+        ),
+    )
+    AiAssistantService.sendSse(
+        writer,
+        json.encodeToString(
+            AssistantDoneEvent.serializer(),
+            AssistantDoneEvent(conversationId = request.conversationId.orEmpty(), runId = request.runId),
+        ),
+    )
 }
 
 private fun resolveAssistantProjectId(orgId: Int, requestedProjectId: String?): AssistantProjectResolution {

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/services/AiAssistantService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/services/AiAssistantService.kt
@@ -12,6 +12,7 @@ import com.moneat.enterprise.ai.llm.LlmProvider
 import com.moneat.enterprise.ai.llm.LlmProviderFactory
 import com.moneat.enterprise.ai.llm.LlmResponse
 import com.moneat.enterprise.ai.llm.LlmTool
+import com.moneat.enterprise.ai.llm.LlmToolCall
 import com.moneat.enterprise.ai.models.AiAssistantConfirmRequest
 import com.moneat.enterprise.ai.models.AiAssistantConfirmResponse
 import com.moneat.enterprise.ai.models.AssistantConfirmationNeededEvent
@@ -51,70 +52,70 @@ private const val ASSISTANT_MAX_TOKENS = 2_048
 private const val ASSISTANT_TEMPERATURE = 0.2
 private const val NANOS_PER_MILLI = 1_000_000.0
 
+data class AiAssistantStreamCommand(
+    val userId: Int,
+    val organizationId: Int,
+    val message: String,
+    val conversationId: String?,
+    val runId: String?,
+    val projectId: Long?,
+    val userTimezone: String?,
+)
+
 class AiAssistantService(
     private val toolRegistry: McpToolRegistry,
     private val llmProvider: LlmProvider = LlmProviderFactory.create(),
+    private val executionStore: AiExecutionStore = ExposedAiExecutionStore(),
 ) {
     private val clickhouseDb: String get() = ClickHouseClient.getDatabase()
-    private val conversations = ConcurrentHashMap<String, ConversationState>()
-    private val pendingActions = ConcurrentHashMap<String, PendingAction>()
+    private val conversationLocks = ConcurrentHashMap<String, Mutex>()
 
     suspend fun streamAssistant(
         writer: Writer,
-        userId: Int,
-        orgId: Int,
-        message: String,
-        conversationId: String?,
-        projectId: Long? = null,
-        userTimezone: String? = null,
+        command: AiAssistantStreamCommand,
     ): String {
-        val normalizedMessage = message.trim()
+        val normalizedMessage = command.message.trim()
         if (normalizedMessage.isBlank()) {
             throw IllegalArgumentException("Message cannot be empty")
         }
 
-        val state = getOrCreateConversation(conversationId, projectId)
-        return state.mutex.withLock {
-            refreshTimeContext(state, userTimezone)
-            state.messages.add(LlmMessage(role = "user", content = normalizedMessage))
+        val session = executionStore.beginRun(
+            StartAiRun(
+                organizationId = command.organizationId,
+                userId = command.userId,
+                conversationId = command.conversationId,
+                runId = command.runId,
+                projectId = command.projectId,
+                message = normalizedMessage,
+            ),
+        )
+        val mutex = conversationLocks.computeIfAbsent(session.conversationId) { Mutex() }
+        return mutex.withLock {
+            if (session.status == AiRunStatus.COMPLETED) {
+                sendCompletedResponse(writer, session.outputContent.orEmpty(), session)
+                return@withLock session.conversationId
+            }
+            if (session.status == AiRunStatus.CANCELLED) {
+                sendCompletedResponse(writer, CANCELLED_RESPONSE, session)
+                return@withLock session.conversationId
+            }
 
-            val outcome = runAssistantLoop(
-                state = state,
-                userId = userId,
-                orgId = orgId,
-                onToolInvoking = { tool, args ->
-                    sendSse(
-                        writer,
-                        json.encodeToString(
-                            AssistantToolInvokingEvent.serializer(),
-                            AssistantToolInvokingEvent(tool = tool, args = args),
-                        ),
-                    )
-                },
-                onToolResult = { tool, summary, isError ->
-                    sendSse(
-                        writer,
-                        json.encodeToString(
-                            AssistantToolResultEvent.serializer(),
-                            AssistantToolResultEvent(tool = tool, summary = summary, isError = isError),
-                        ),
-                    )
-                },
-                onConfirmationNeeded = { requestId, tool, args ->
-                    sendSse(
-                        writer,
-                        json.encodeToString(
-                            AssistantConfirmationNeededEvent.serializer(),
-                            AssistantConfirmationNeededEvent(
-                                requestId = requestId,
-                                conversationId = state.id,
-                                tool = tool,
-                                args = args,
-                            ),
-                        ),
-                    )
-                },
+            val state = ConversationState(
+                id = session.conversationId,
+                run = session,
+                projectId = session.projectId,
+                messages = session.messages.toMutableList(),
             )
+            refreshTimeContext(state, command.userTimezone)
+            val callbacks = streamCallbacks(writer, state)
+
+            val outcome = try {
+                recoverPendingWork(state, command.userId, command.organizationId, callbacks)
+                    ?: runAssistantLoop(state, command.userId, command.organizationId, callbacks)
+            } catch (error: Exception) {
+                executionStore.failRun(session.internalRunId, "assistant_failed", error.message.orEmpty())
+                throw error
+            }
 
             when (outcome) {
                 is LoopOutcome.Completed -> {
@@ -140,7 +141,7 @@ class AiAssistantService(
                 writer,
                 json.encodeToString(
                     AssistantDoneEvent.serializer(),
-                    AssistantDoneEvent(conversationId = state.id),
+                    AssistantDoneEvent(conversationId = state.id, runId = session.runId),
                 ),
             )
 
@@ -153,78 +154,204 @@ class AiAssistantService(
         orgId: Int,
         request: AiAssistantConfirmRequest,
     ): AiAssistantConfirmResponse {
-        val pending = pendingActions.remove(request.requestId)
-            ?: throw IllegalArgumentException("Pending confirmation request not found")
-
-        if (pending.userId != userId || pending.orgId != orgId) {
-            throw IllegalAccessException("Confirmation request does not belong to this user")
+        val claim = executionStore.claimApproval(request.requestId, orgId, userId, request.approve)
+        if (claim is AiApprovalClaim.Completed) {
+            return json.decodeFromString(AiAssistantConfirmResponse.serializer(), claim.response)
+        }
+        require(claim != AiApprovalClaim.Missing) { "Pending confirmation request not found" }
+        require(claim != AiApprovalClaim.Expired) { "Pending confirmation request expired" }
+        check(claim != AiApprovalClaim.Cancelled) { "Assistant run was cancelled" }
+        check(claim !is AiApprovalClaim.InFlight) {
+            "Approved action is already executing; it will not be repeated"
         }
 
-        val state = conversations[pending.conversationId]
-            ?: throw IllegalStateException("Conversation not found for pending request")
-
-        return state.mutex.withLock {
-            val toolSummary = if (request.approve) {
+        val approval = when (claim) {
+            is AiApprovalClaim.Execute -> claim.approval
+            is AiApprovalClaim.Denied -> claim.approval
+        }
+        val mutex = conversationLocks.computeIfAbsent(approval.conversationResourceId) { Mutex() }
+        return mutex.withLock {
+            val toolSummary = if (claim is AiApprovalClaim.Execute) {
+                check(!executionStore.isCancellationRequested(approval.runId)) {
+                    "Assistant run was cancelled before the approved action could execute"
+                }
                 val result = executeTool(
-                    toolName = pending.tool,
-                    args = pending.args,
+                    toolName = approval.toolCall.name,
+                    args = checkNotNull(approval.toolCall.arguments),
                     userId = userId,
                     orgId = orgId,
-                    sessionId = pending.conversationId,
+                    sessionId = approval.conversationResourceId,
                 )
-                summarizeToolResult(result)
+                val summary = summarizeToolResult(result)
+                executionStore.recordToolResult(approval.toolCall, summary, result.isError)
+                summary
             } else {
-                "User denied execution of ${pending.tool}."
+                val summary = "User denied execution of ${approval.toolCall.name}."
+                executionStore.recordToolResult(approval.toolCall, summary, false)
+                summary
             }
 
-            state.messages.add(
-                LlmMessage(
-                    role = "tool",
-                    content = toolSummary,
-                    toolCallId = pending.toolCallId,
-                ),
+            val session = executionStore.resumeRun(approval.runId)
+            val state = ConversationState(
+                id = session.conversationId,
+                run = session,
+                projectId = session.projectId,
+                messages = session.messages.toMutableList(),
             )
+            refreshTimeContext(state, null)
 
             val outcome = runAssistantLoop(state = state, userId = userId, orgId = orgId)
-            return@withLock when (outcome) {
+            val response = when (outcome) {
                 is LoopOutcome.Completed -> {
                     AiAssistantConfirmResponse(
-                        conversationId = pending.conversationId,
-                        requestId = pending.requestId,
+                        conversationId = approval.conversationResourceId,
+                        runId = approval.runResourceId,
+                        requestId = approval.resourceId,
                         approved = request.approve,
-                        tool = pending.tool,
+                        tool = approval.toolCall.name,
                         toolSummary = toolSummary,
                         response = outcome.response,
                     )
                 }
                 is LoopOutcome.ConfirmationNeeded -> {
                     AiAssistantConfirmResponse(
-                        conversationId = pending.conversationId,
-                        requestId = pending.requestId,
+                        conversationId = approval.conversationResourceId,
+                        runId = approval.runResourceId,
+                        requestId = approval.resourceId,
                         approved = request.approve,
-                        tool = pending.tool,
+                        tool = approval.toolCall.name,
                         toolSummary = toolSummary,
                         response = "",
                         nextRequestId = outcome.requestId,
                     )
                 }
             }
+            executionStore.recordApprovalResponse(approval.internalId, json.encodeToString(response))
+            response
         }
+    }
+
+    private fun streamCallbacks(writer: Writer, state: ConversationState): AssistantCallbacks = AssistantCallbacks(
+        onToolInvoking = { tool, args ->
+            sendSse(
+                writer,
+                json.encodeToString(
+                    AssistantToolInvokingEvent.serializer(),
+                    AssistantToolInvokingEvent(tool = tool, args = args),
+                ),
+            )
+        },
+        onToolResult = { tool, summary, isError ->
+            sendSse(
+                writer,
+                json.encodeToString(
+                    AssistantToolResultEvent.serializer(),
+                    AssistantToolResultEvent(tool = tool, summary = summary, isError = isError),
+                ),
+            )
+        },
+        onConfirmationNeeded = { requestId, tool, args ->
+            sendSse(
+                writer,
+                json.encodeToString(
+                    AssistantConfirmationNeededEvent.serializer(),
+                    AssistantConfirmationNeededEvent(
+                        requestId = requestId,
+                        conversationId = state.id,
+                        runId = state.run.runId,
+                        tool = tool,
+                        args = args,
+                    ),
+                ),
+            )
+        },
+    )
+
+    private fun sendCompletedResponse(writer: Writer, response: String, session: AiRunSession) {
+        response.chunked(RESPONSE_CHUNK_SIZE).ifEmpty { listOf("") }.forEach { chunk ->
+            sendSse(
+                writer,
+                json.encodeToString(
+                    AssistantResponseEvent.serializer(),
+                    AssistantResponseEvent(content = chunk),
+                ),
+            )
+        }
+        sendSse(
+            writer,
+            json.encodeToString(
+                AssistantDoneEvent.serializer(),
+                AssistantDoneEvent(conversationId = session.conversationId, runId = session.runId),
+            ),
+        )
+    }
+
+    private suspend fun recoverPendingWork(
+        state: ConversationState,
+        userId: Int,
+        orgId: Int,
+        callbacks: AssistantCallbacks,
+    ): LoopOutcome? {
+        state.run.pendingApproval?.let { approval ->
+            val arguments = approval.toolCall.arguments ?: JsonObject(emptyMap())
+            callbacks.onConfirmationNeeded(approval.resourceId, approval.toolCall.name, arguments)
+            return LoopOutcome.ConfirmationNeeded(approval.resourceId, approval.toolCall.name, arguments)
+        }
+
+        val definitions = toolRegistry.listTools().associateBy(ToolDefinition::name)
+        for (toolCall in state.run.pendingToolCalls) {
+            val arguments = toolCall.arguments
+            if (arguments == null) {
+                val summary = "Invalid arguments for MCP tool: ${toolCall.name}"
+                executionStore.recordToolResult(toolCall, summary, true)
+                state.messages.add(LlmMessage("tool", summary, toolCall.providerCallId))
+                callbacks.onToolResult(toolCall.name, summary, true)
+                continue
+            }
+            val definition = definitions[toolCall.name]
+            if (definition == null) {
+                val summary = "Unknown MCP tool: ${toolCall.name}"
+                executionStore.recordToolResult(toolCall, summary, true)
+                state.messages.add(LlmMessage("tool", summary, toolCall.providerCallId))
+                callbacks.onToolResult(toolCall.name, summary, true)
+                continue
+            }
+            if (!definition.readOnly) {
+                if (toolCall.status == AiToolCallStatus.EXECUTING) {
+                    error("Approved tool outcome is unknown after interruption; refusing to repeat the mutation")
+                }
+                val approval = executionStore.createApproval(state.run, toolCall, userId)
+                callbacks.onConfirmationNeeded(approval.resourceId, toolCall.name, arguments)
+                return LoopOutcome.ConfirmationNeeded(approval.resourceId, toolCall.name, arguments)
+            }
+
+            check(executionStore.claimToolExecution(toolCall)) {
+                "Tool call ${toolCall.resourceId} is not recoverable"
+            }
+            callbacks.onToolInvoking(toolCall.name, arguments)
+            val result = executeTool(toolCall.name, arguments, userId, orgId, state.id)
+            val summary = summarizeToolResult(result)
+            executionStore.recordToolResult(toolCall, summary, result.isError)
+            state.messages.add(LlmMessage("tool", summary, toolCall.providerCallId))
+            callbacks.onToolResult(toolCall.name, summary, result.isError)
+        }
+        return null
     }
 
     private suspend fun runAssistantLoop(
         state: ConversationState,
         userId: Int,
         orgId: Int,
-        onToolInvoking: suspend (tool: String, args: JsonObject) -> Unit = { _, _ -> },
-        onToolResult: suspend (tool: String, summary: String, isError: Boolean) -> Unit = { _, _, _ -> },
-        onConfirmationNeeded: suspend (requestId: String, tool: String, args: JsonObject) -> Unit = { _, _, _ -> },
+        callbacks: AssistantCallbacks = AssistantCallbacks(),
     ): LoopOutcome {
         val toolDefinitions = toolRegistry.listTools()
         val toolMap = toolDefinitions.associateBy { it.name }
         val llmTools = toolDefinitions.map(::toLlmTool)
 
-        repeat(MAX_TOOL_ROUNDS) {
+        for (round in (state.run.currentRound + 1)..MAX_TOOL_ROUNDS) {
+            if (executionStore.isCancellationRequested(state.run.internalRunId)) {
+                return LoopOutcome.Completed(CANCELLED_RESPONSE)
+            }
             val startedAtMs = Clock.System.now().toEpochMilliseconds()
             val startedAtNs = System.nanoTime()
             val completion = llmProvider.chatCompletion(
@@ -237,6 +364,9 @@ class AiAssistantService(
                 tools = llmTools,
             )
             val durationMs = (System.nanoTime() - startedAtNs) / NANOS_PER_MILLI
+            if (executionStore.isCancellationRequested(state.run.internalRunId)) {
+                return LoopOutcome.Completed(CANCELLED_RESPONSE)
+            }
             persistLlmGeneration(
                 state = state,
                 completion = completion,
@@ -244,9 +374,29 @@ class AiAssistantService(
                 startedAtMs = startedAtMs,
                 durationMs = durationMs,
             )
+            val cost = CostRegistry.calculateCost(
+                model = completion.model,
+                inputTokens = completion.inputTokens,
+                outputTokens = completion.outputTokens,
+            )
+            val responseContent = completion.content.ifBlank { DEFAULT_EMPTY_RESPONSE }
+            val durableCompletion = if (completion.toolCalls.isEmpty()) {
+                completion.copy(content = responseContent)
+            } else {
+                completion
+            }
+            val readOnlyTools = toolDefinitions
+                .filter(ToolDefinition::readOnly)
+                .mapTo(mutableSetOf(), ToolDefinition::name)
+            val checkpoint = executionStore.checkpointCompletion(
+                session = state.run,
+                round = round,
+                response = durableCompletion,
+                readOnlyTools = readOnlyTools,
+                cost = cost,
+            )
 
             if (completion.toolCalls.isEmpty()) {
-                val responseContent = completion.content.ifBlank { DEFAULT_EMPTY_RESPONSE }
                 state.messages.add(
                     LlmMessage(
                         role = "assistant",
@@ -264,75 +414,19 @@ class AiAssistantService(
                 ),
             )
 
-            for (toolCall in completion.toolCalls) {
-                val args = toolCall.arguments
-                if (args == null) {
-                    val invalidArgumentsSummary = "Invalid arguments for MCP tool: ${toolCall.name}"
-                    state.messages.add(
-                        LlmMessage(
-                            role = "tool",
-                            content = invalidArgumentsSummary,
-                            toolCallId = toolCall.id,
-                        ),
-                    )
-                    onToolResult(toolCall.name, invalidArgumentsSummary, true)
-                    continue
-                }
-                val definition = toolMap[toolCall.name]
-
-                if (definition == null) {
-                    val unknownToolSummary = "Unknown MCP tool: ${toolCall.name}"
-                    state.messages.add(
-                        LlmMessage(
-                            role = "tool",
-                            content = unknownToolSummary,
-                            toolCallId = toolCall.id,
-                        ),
-                    )
-                    onToolResult(toolCall.name, unknownToolSummary, true)
-                    continue
-                }
-
-                if (!definition.readOnly) {
-                    val requestId = UUID.randomUUID().toString()
-                    pendingActions[requestId] = PendingAction(
-                        requestId = requestId,
-                        conversationId = state.id,
-                        userId = userId,
-                        orgId = orgId,
-                        tool = toolCall.name,
-                        args = args,
-                        toolCallId = toolCall.id,
-                    )
-                    onConfirmationNeeded(requestId, toolCall.name, args)
-                    return LoopOutcome.ConfirmationNeeded(
-                        requestId = requestId,
-                        tool = toolCall.name,
-                        args = args,
-                    )
-                }
-
-                onToolInvoking(toolCall.name, args)
-                val toolResult = executeTool(
-                    toolName = toolCall.name,
-                    args = args,
-                    userId = userId,
-                    orgId = orgId,
-                    sessionId = state.id,
-                )
-                val summary = summarizeToolResult(toolResult)
-                state.messages.add(
-                    LlmMessage(
-                        role = "tool",
-                        content = summary,
-                        toolCallId = toolCall.id,
-                    ),
-                )
-                onToolResult(toolCall.name, summary, toolResult.isError)
+            val toolOutcome = processToolCalls(
+                state = state,
+                completion = completion,
+                checkpoint = checkpoint,
+                context = ToolProcessingContext(toolMap, userId, orgId, callbacks),
+            )
+            if (toolOutcome != null) {
+                return toolOutcome
             }
         }
 
         val limitMessage = "I reached the MCP tool iteration limit. Please refine the question and try again."
+        executionStore.completeRun(state.run.internalRunId, limitMessage)
         state.messages.add(
             LlmMessage(
                 role = "assistant",
@@ -340,6 +434,71 @@ class AiAssistantService(
             ),
         )
         return LoopOutcome.Completed(limitMessage)
+    }
+
+    private suspend fun processToolCalls(
+        state: ConversationState,
+        completion: LlmResponse,
+        checkpoint: AiTurnCheckpoint,
+        context: ToolProcessingContext,
+    ): LoopOutcome? {
+        val storedCalls = checkpoint.toolCalls.associateBy(StoredAiToolCall::providerCallId)
+        for (toolCall in completion.toolCalls) {
+            val storedCall = checkNotNull(storedCalls[toolCall.id]) {
+                "Durable tool-call checkpoint missing for ${toolCall.id}"
+            }
+            val args = toolCall.arguments ?: run {
+                recordToolFailure(
+                    state = state,
+                    toolCall = toolCall,
+                    storedCall = storedCall,
+                    summary = "Invalid arguments for MCP tool: ${toolCall.name}",
+                    callbacks = context.callbacks,
+                )
+                continue
+            }
+            val definition = context.toolMap[toolCall.name] ?: run {
+                recordToolFailure(
+                    state = state,
+                    toolCall = toolCall,
+                    storedCall = storedCall,
+                    summary = "Unknown MCP tool: ${toolCall.name}",
+                    callbacks = context.callbacks,
+                )
+                continue
+            }
+            if (!definition.readOnly) {
+                val approval = executionStore.createApproval(state.run, storedCall, context.userId)
+                context.callbacks.onConfirmationNeeded(approval.resourceId, toolCall.name, args)
+                return LoopOutcome.ConfirmationNeeded(approval.resourceId, toolCall.name, args)
+            }
+
+            check(executionStore.claimToolExecution(storedCall)) {
+                "Tool call ${storedCall.resourceId} is not executable"
+            }
+            if (executionStore.isCancellationRequested(state.run.internalRunId)) {
+                return LoopOutcome.Completed(CANCELLED_RESPONSE)
+            }
+            context.callbacks.onToolInvoking(toolCall.name, args)
+            val toolResult = executeTool(toolCall.name, args, context.userId, context.orgId, state.id)
+            val summary = summarizeToolResult(toolResult)
+            executionStore.recordToolResult(storedCall, summary, toolResult.isError)
+            state.messages.add(LlmMessage("tool", summary, toolCall.id))
+            context.callbacks.onToolResult(toolCall.name, summary, toolResult.isError)
+        }
+        return null
+    }
+
+    private suspend fun recordToolFailure(
+        state: ConversationState,
+        toolCall: LlmToolCall,
+        storedCall: StoredAiToolCall,
+        summary: String,
+        callbacks: AssistantCallbacks,
+    ) {
+        executionStore.recordToolResult(storedCall, summary, true)
+        state.messages.add(LlmMessage("tool", summary, toolCall.id))
+        callbacks.onToolResult(toolCall.name, summary, true)
     }
 
     private suspend fun executeTool(
@@ -359,6 +518,9 @@ class AiAssistantService(
             sessionId = sessionId,
         ),
     )
+
+    fun cancelRun(userId: Int, orgId: Int, runId: String): Boolean =
+        executionStore.requestCancellation(runId, orgId, userId)
 
     private fun assistantScopesFor(toolName: String): Set<String> =
         toolRegistry
@@ -502,32 +664,6 @@ class AiAssistantService(
 
     private fun esc(value: String): String = ClickHouseSqlUtils.escapeSql(value)
 
-    private fun getOrCreateConversation(
-        conversationId: String?,
-        projectId: Long?,
-    ): ConversationState {
-        val normalizedConversationId = conversationId
-            ?.trim()
-            ?.takeIf { it.isNotBlank() }
-            ?: UUID.randomUUID().toString()
-
-        val state = conversations.computeIfAbsent(normalizedConversationId) {
-            ConversationState(
-                id = normalizedConversationId,
-                projectId = projectId,
-                messages = mutableListOf(
-                    LlmMessage(role = "system", content = loadSystemPrompt()),
-                ),
-            )
-        }
-
-        if (state.projectId == null && projectId != null) {
-            state.projectId = projectId
-        }
-
-        return state
-    }
-
     private fun buildTimeContext(userTimezone: String?): String {
         val utcNow = ZonedDateTime.now(ZoneId.of("UTC"))
         val utcFormatted = utcNow.format(
@@ -583,6 +719,7 @@ class AiAssistantService(
         private const val MAX_TOOL_SUMMARY_CHARS = 2_000
         private const val RESPONSE_CHUNK_SIZE = 1_200
         private const val DEFAULT_EMPTY_RESPONSE = "I could not generate a response."
+        private const val CANCELLED_RESPONSE = "This assistant run was cancelled."
 
         fun sendSse(writer: Writer, data: String) {
             writer.write("data: $data\n\n")
@@ -593,19 +730,22 @@ class AiAssistantService(
 
 private data class ConversationState(
     val id: String,
-    var projectId: Long?,
+    val run: AiRunSession,
+    val projectId: Long?,
     val messages: MutableList<LlmMessage>,
-    val mutex: Mutex = Mutex(),
 )
 
-private data class PendingAction(
-    val requestId: String,
-    val conversationId: String,
+private data class ToolProcessingContext(
+    val toolMap: Map<String, ToolDefinition>,
     val userId: Int,
     val orgId: Int,
-    val tool: String,
-    val args: JsonObject,
-    val toolCallId: String,
+    val callbacks: AssistantCallbacks,
+)
+
+private data class AssistantCallbacks(
+    val onToolInvoking: suspend (tool: String, args: JsonObject) -> Unit = { _, _ -> },
+    val onToolResult: suspend (tool: String, summary: String, isError: Boolean) -> Unit = { _, _, _ -> },
+    val onConfirmationNeeded: suspend (requestId: String, tool: String, args: JsonObject) -> Unit = { _, _, _ -> },
 )
 
 private sealed interface LoopOutcome {

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/services/AiExecutionStore.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/services/AiExecutionStore.kt
@@ -1,0 +1,825 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.ai.services
+
+import com.moneat.ai.AiConversations
+import com.moneat.ai.AiMessages
+import com.moneat.enterprise.ai.llm.LlmMessage
+import com.moneat.enterprise.ai.llm.LlmCost
+import com.moneat.enterprise.ai.llm.LlmResponse
+import com.moneat.enterprise.ai.llm.LlmToolCall
+import com.moneat.enterprise.ai.models.AiApprovals
+import com.moneat.enterprise.ai.models.AiRunEvidence
+import com.moneat.enterprise.ai.models.AiRuns
+import com.moneat.enterprise.ai.models.AiToolCalls
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+import kotlinx.serialization.json.put
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.or
+import org.jetbrains.exposed.v1.core.plus
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import java.security.MessageDigest
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
+import kotlin.uuid.Uuid
+
+enum class AiRunStatus(val value: String) {
+    PENDING("pending"),
+    RUNNING("running"),
+    WAITING_FOR_APPROVAL("waiting_for_approval"),
+    COMPLETED("completed"),
+    FAILED("failed"),
+    CANCELLED("cancelled"),
+}
+
+enum class AiToolCallStatus(val value: String) {
+    PROPOSED("proposed"),
+    AWAITING_APPROVAL("awaiting_approval"),
+    EXECUTING("executing"),
+    SUCCEEDED("succeeded"),
+    FAILED("failed"),
+    DENIED("denied"),
+    EXPIRED("expired"),
+}
+
+enum class AiApprovalStatus(val value: String) {
+    PENDING("pending"),
+    APPROVED("approved"),
+    DENIED("denied"),
+    EXPIRED("expired"),
+}
+
+data class AiRunSession(
+    val internalRunId: Long,
+    val runId: String,
+    val internalConversationId: Int,
+    val conversationId: String,
+    val projectId: Long?,
+    val status: AiRunStatus,
+    val currentRound: Int,
+    val messages: List<LlmMessage>,
+    val pendingToolCalls: List<StoredAiToolCall>,
+    val pendingApproval: StoredAiApproval?,
+    val outputContent: String?,
+    val created: Boolean,
+)
+
+data class StoredAiToolCall(
+    val internalId: Long,
+    val resourceId: String,
+    val runId: Long,
+    val providerCallId: String,
+    val name: String,
+    val arguments: JsonObject?,
+    val readOnly: Boolean,
+    val status: AiToolCallStatus,
+)
+
+data class AiTurnCheckpoint(
+    val completed: Boolean,
+    val toolCalls: List<StoredAiToolCall>,
+)
+
+data class StartAiRun(
+    val organizationId: Int,
+    val userId: Int,
+    val conversationId: String?,
+    val runId: String?,
+    val projectId: Long?,
+    val message: String,
+)
+
+data class StoredAiApproval(
+    val internalId: Long,
+    val resourceId: String,
+    val runId: Long,
+    val runResourceId: String,
+    val conversationResourceId: String,
+    val toolCall: StoredAiToolCall,
+    val status: AiApprovalStatus,
+    val response: String?,
+)
+
+sealed interface AiApprovalClaim {
+    data class Execute(val approval: StoredAiApproval) : AiApprovalClaim
+    data class Denied(val approval: StoredAiApproval) : AiApprovalClaim
+    data class Completed(val approval: StoredAiApproval, val response: String) : AiApprovalClaim
+    data class InFlight(val approval: StoredAiApproval) : AiApprovalClaim
+    data object Expired : AiApprovalClaim
+    data object Cancelled : AiApprovalClaim
+    data object Missing : AiApprovalClaim
+}
+
+interface AiExecutionStore {
+    fun beginRun(request: StartAiRun): AiRunSession
+
+    fun resumeRun(internalRunId: Long): AiRunSession
+
+    fun checkpointCompletion(
+        session: AiRunSession,
+        round: Int,
+        response: LlmResponse,
+        readOnlyTools: Set<String>,
+        cost: LlmCost,
+    ): AiTurnCheckpoint
+
+    fun completeRun(runId: Long, content: String)
+
+    fun claimToolExecution(toolCall: StoredAiToolCall): Boolean
+
+    fun recordToolResult(toolCall: StoredAiToolCall, summary: String, isError: Boolean)
+
+    fun createApproval(session: AiRunSession, toolCall: StoredAiToolCall, requestedBy: Int): StoredAiApproval
+
+    fun claimApproval(resourceId: String, organizationId: Int, actorUserId: Int, approve: Boolean): AiApprovalClaim
+
+    fun recordApprovalResponse(approvalId: Long, response: String)
+
+    fun requestCancellation(runResourceId: String, organizationId: Int, actorUserId: Int): Boolean
+
+    fun isCancellationRequested(internalRunId: Long): Boolean
+
+    fun failRun(runId: Long, code: String, message: String)
+}
+
+class ExposedAiExecutionStore(
+    private val now: () -> kotlin.time.Instant = Clock.System::now,
+) : AiExecutionStore {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    override fun beginRun(request: StartAiRun): AiRunSession = transaction {
+        val organizationId = request.organizationId
+        val userId = request.userId
+        val conversationId = request.conversationId
+        val projectId = request.projectId
+        val message = request.message
+        val requestedRunId = request.runId?.let(::parsePublicUuid) ?: Uuid.random()
+        val idempotencyKey = requestedRunId.toString()
+        val fingerprint = sha256("${projectId.orEmpty()}|$message")
+        val existing = AiRuns
+            .selectAll()
+            .where {
+                (AiRuns.organization_id eq organizationId) and
+                    (AiRuns.user_id eq userId) and
+                    (AiRuns.idempotency_key eq idempotencyKey)
+            }
+            .firstOrNull()
+
+        if (existing != null) {
+            check(existing[AiRuns.request_fingerprint] == fingerprint) {
+                "runId was already used for a different assistant request"
+            }
+            val existingConversation = AiConversations
+                .selectAll()
+                .where { AiConversations.id eq existing[AiRuns.conversation_id] }
+                .first()
+            conversationId?.let { requestedConversationId ->
+                check(parsePublicUuid(requestedConversationId) == existingConversation[AiConversations.resource_id]) {
+                    "runId belongs to a different conversation"
+                }
+            }
+            return@transaction loadSession(
+                existing[AiRuns.id],
+                ConversationRecord(
+                    existingConversation[AiConversations.id],
+                    existingConversation[AiConversations.resource_id],
+                ),
+                created = false,
+            )
+        }
+
+        val conversation = resolveConversation(organizationId, userId, conversationId, projectId, message)
+        val instant = now()
+        val internalRunId = AiRuns.insert {
+            it[resource_id] = requestedRunId
+            it[organization_id] = organizationId
+            it[AiRuns.user_id] = userId
+            it[AiRuns.conversation_id] = conversation.internalId
+            it[AiRuns.project_id] = projectId
+            it[idempotency_key] = idempotencyKey
+            it[request_fingerprint] = fingerprint
+            it[status] = AiRunStatus.RUNNING.value
+            it[started_at] = instant
+            it[created_at] = instant
+            it[updated_at] = instant
+        } get AiRuns.id
+        appendMessage(conversation.internalId, internalRunId, LlmMessage("user", message))
+
+        loadSession(internalRunId, conversation, created = true)
+    }
+
+    override fun resumeRun(internalRunId: Long): AiRunSession = transaction {
+        val run = AiRuns.selectAll().where { AiRuns.id eq internalRunId }.first()
+        val conversation = AiConversations
+            .selectAll()
+            .where { AiConversations.id eq run[AiRuns.conversation_id] }
+            .first()
+        loadSession(
+            internalRunId,
+            ConversationRecord(conversation[AiConversations.id], conversation[AiConversations.resource_id]),
+            created = false,
+        )
+    }
+
+    override fun checkpointCompletion(
+        session: AiRunSession,
+        round: Int,
+        response: LlmResponse,
+        readOnlyTools: Set<String>,
+        cost: LlmCost,
+    ): AiTurnCheckpoint = transaction {
+        val run = AiRuns.selectAll().where { AiRuns.id eq session.internalRunId }.first()
+        if (run[AiRuns.current_round] >= round) {
+            return@transaction AiTurnCheckpoint(
+                completed = run[AiRuns.status] == AiRunStatus.COMPLETED.value,
+                toolCalls = loadToolCalls(session.internalRunId, round),
+            )
+        }
+
+        val instant = now()
+        val completed = response.toolCalls.isEmpty()
+        appendMessage(
+            session.internalConversationId,
+            session.internalRunId,
+            LlmMessage(
+                role = "assistant",
+                content = response.content.ifBlank { null },
+                toolCalls = response.toolCalls,
+            ),
+        )
+        AiRuns.update({ AiRuns.id eq session.internalRunId }) {
+            it[status] = if (completed) AiRunStatus.COMPLETED.value else AiRunStatus.RUNNING.value
+            it[current_round] = round
+            it[provider] = response.provider
+            it[model] = response.model
+            it[input_tokens] = run[AiRuns.input_tokens] + response.inputTokens.coerceAtLeast(0)
+            it[output_tokens] = run[AiRuns.output_tokens] + response.outputTokens.coerceAtLeast(0)
+            it[AiRuns.cost_usd] = run[AiRuns.cost_usd] + cost.totalCost
+            it[cost_metadata] = json.encodeToString(
+                buildJsonObject {
+                    put("currency", cost.currency)
+                    put("lastRound", round)
+                    put("lastInputCost", cost.inputCost.toPlainString())
+                    put("lastOutputCost", cost.outputCost.toPlainString())
+                    put("lastTotalCost", cost.totalCost.toPlainString())
+                },
+            )
+            it[output_content] = response.content.takeIf { content -> completed && content.isNotBlank() }
+            it[updated_at] = instant
+            if (completed) it[completed_at] = instant
+            it[version] = run[AiRuns.version] + 1
+        }
+
+        response.toolCalls.forEach { call ->
+            AiToolCalls.insert {
+                it[resource_id] = Uuid.random()
+                it[organization_id] = run[AiRuns.organization_id]
+                it[run_id] = session.internalRunId
+                it[AiToolCalls.round] = round
+                it[provider_call_id] = call.id
+                it[tool_name] = call.name
+                it[AiToolCalls.arguments] = call.arguments?.let { arguments -> json.encodeToString(arguments) }
+                it[arguments_valid] = call.arguments != null
+                it[read_only] = call.name in readOnlyTools
+                it[status] = AiToolCallStatus.PROPOSED.value
+                it[effect_idempotency_key] = "${session.runId}:$round:${call.id}"
+                it[created_at] = instant
+                it[updated_at] = instant
+            }
+        }
+
+        AiTurnCheckpoint(
+            completed = completed,
+            toolCalls = loadToolCalls(session.internalRunId, round),
+        )
+    }
+
+    override fun completeRun(runId: Long, content: String) {
+        transaction {
+            val run = AiRuns.selectAll().where { AiRuns.id eq runId }.firstOrNull()
+                ?: return@transaction
+            val status = AiRunStatus.entries.first { value -> value.value == run[AiRuns.status] }
+            if (status in TERMINAL_RUN_STATUSES) return@transaction
+            val instant = now()
+            appendMessage(
+                run[AiRuns.conversation_id],
+                runId,
+                LlmMessage(role = "assistant", content = content),
+            )
+            AiRuns.update({ AiRuns.id eq runId }) {
+                it[AiRuns.status] = AiRunStatus.COMPLETED.value
+                it[output_content] = content
+                it[completed_at] = instant
+                it[updated_at] = instant
+                it[version] = run[AiRuns.version] + 1
+            }
+        }
+    }
+
+    override fun claimToolExecution(toolCall: StoredAiToolCall): Boolean = transaction {
+        val row = AiToolCalls.selectAll().where { AiToolCalls.id eq toolCall.internalId }.firstOrNull()
+            ?: return@transaction false
+        val current = AiToolCallStatus.entries.first { status -> status.value == row[AiToolCalls.status] }
+        if (current == AiToolCallStatus.SUCCEEDED || current == AiToolCallStatus.FAILED) {
+            return@transaction false
+        }
+        if (current == AiToolCallStatus.EXECUTING) return@transaction toolCall.readOnly
+        if (current != AiToolCallStatus.PROPOSED) return@transaction false
+        AiToolCalls.update({ AiToolCalls.id eq toolCall.internalId }) {
+            it[status] = AiToolCallStatus.EXECUTING.value
+            it[started_at] = now()
+            it[updated_at] = now()
+        }
+        true
+    }
+
+    override fun recordToolResult(toolCall: StoredAiToolCall, summary: String, isError: Boolean) {
+        transaction {
+            val row = AiToolCalls.selectAll().where { AiToolCalls.id eq toolCall.internalId }.firstOrNull()
+                ?: return@transaction
+            val status = AiToolCallStatus.entries.first { value -> value.value == row[AiToolCalls.status] }
+            if (row[AiToolCalls.result_summary] != null) return@transaction
+            if (status == AiToolCallStatus.SUCCEEDED || status == AiToolCallStatus.FAILED) return@transaction
+            val instant = now()
+            val evidenceResourceId = Uuid.random()
+            val resultContent = buildJsonObject {
+                put("summary", summary)
+                put("isError", isError)
+                put("toolCallId", toolCall.resourceId)
+            }
+            AiToolCalls.update({ AiToolCalls.id eq toolCall.internalId }) {
+                it[AiToolCalls.status] = when {
+                    status == AiToolCallStatus.DENIED -> AiToolCallStatus.DENIED.value
+                    status == AiToolCallStatus.EXPIRED -> AiToolCallStatus.EXPIRED.value
+                    isError -> AiToolCallStatus.FAILED.value
+                    else -> AiToolCallStatus.SUCCEEDED.value
+                }
+                it[result] = json.encodeToString(resultContent)
+                it[result_summary] = summary
+                it[AiToolCalls.is_error] = isError
+                it[result_audit_event_id] = evidenceResourceId
+                it[completed_at] = instant
+                it[updated_at] = instant
+            }
+            val run = AiRuns.selectAll().where { AiRuns.id eq toolCall.runId }.first()
+            AiRunEvidence.insert {
+                it[resource_id] = evidenceResourceId
+                it[organization_id] = run[AiRuns.organization_id]
+                it[run_id] = toolCall.runId
+                it[evidence_type] = TOOL_OUTCOME_EVIDENCE_TYPE
+                it[source_name] = toolCall.name
+                it[source_resource_id] = toolCall.resourceId
+                it[content] = json.encodeToString(resultContent)
+                it[created_at] = instant
+            }
+            AiApprovals.update({ AiApprovals.tool_call_id eq toolCall.internalId }) {
+                it[result_audit_event_id] = evidenceResourceId
+                it[updated_at] = instant
+            }
+            appendMessage(
+                run[AiRuns.conversation_id],
+                toolCall.runId,
+                LlmMessage(role = "tool", content = summary, toolCallId = toolCall.providerCallId),
+            )
+        }
+    }
+
+    override fun createApproval(
+        session: AiRunSession,
+        toolCall: StoredAiToolCall,
+        requestedBy: Int,
+    ): StoredAiApproval = transaction {
+        val existing = AiApprovals.selectAll().where { AiApprovals.tool_call_id eq toolCall.internalId }.firstOrNull()
+        if (existing != null) return@transaction mapApproval(existing)
+
+        val instant = now()
+        val proposal = buildProposal(toolCall)
+        val approvalId = AiApprovals.insert {
+            it[resource_id] = Uuid.random()
+            it[organization_id] = organizationIdForRun(session.internalRunId)
+            it[run_id] = session.internalRunId
+            it[tool_call_id] = toolCall.internalId
+            it[AiApprovals.requested_by] = requestedBy
+            it[incident_resource_id] = incidentResourceId(toolCall.arguments)
+            it[incident_version] = incidentVersion(toolCall.arguments)
+            it[proposed_command] = proposal
+            it[proposal_sha256] = sha256(proposal)
+            it[status] = AiApprovalStatus.PENDING.value
+            it[expires_at] = instant + APPROVAL_TTL
+            it[created_at] = instant
+            it[updated_at] = instant
+        } get AiApprovals.id
+        AiToolCalls.update({ AiToolCalls.id eq toolCall.internalId }) {
+            it[status] = AiToolCallStatus.AWAITING_APPROVAL.value
+            it[updated_at] = instant
+        }
+        AiRuns.update({ AiRuns.id eq session.internalRunId }) {
+            it[status] = AiRunStatus.WAITING_FOR_APPROVAL.value
+            it[updated_at] = instant
+        }
+        mapApproval(AiApprovals.selectAll().where { AiApprovals.id eq approvalId }.first())
+    }
+
+    override fun claimApproval(
+        resourceId: String,
+        organizationId: Int,
+        actorUserId: Int,
+        approve: Boolean,
+    ): AiApprovalClaim = transaction {
+        val parsedId = runCatching { Uuid.parse(resourceId) }.getOrNull() ?: return@transaction AiApprovalClaim.Missing
+        val row = AiApprovals
+            .selectAll()
+            .where {
+                (AiApprovals.resource_id eq parsedId) and
+                    (AiApprovals.organization_id eq organizationId)
+            }
+            .firstOrNull()
+            ?: return@transaction AiApprovalClaim.Missing
+        val approval = mapApproval(row)
+        unavailableApprovalClaim(row, approval)?.let { claim -> return@transaction claim }
+
+        claimApprovalDecision(approval, actorUserId, approve)
+    }
+
+    private fun claimApprovalDecision(
+        approval: StoredAiApproval,
+        actorUserId: Int,
+        approve: Boolean,
+    ): AiApprovalClaim {
+        val instant = now()
+        val nextApprovalStatus = if (approve) AiApprovalStatus.APPROVED else AiApprovalStatus.DENIED
+        val nextToolStatus = if (approve) AiToolCallStatus.EXECUTING else AiToolCallStatus.DENIED
+        val decisionClaimed = AiApprovals.update({
+            (AiApprovals.id eq approval.internalId) and
+                (AiApprovals.status eq AiApprovalStatus.PENDING.value)
+        }) {
+            it[status] = nextApprovalStatus.value
+            it[decided_by] = actorUserId
+            it[decided_at] = instant
+            it[updated_at] = instant
+        }
+        if (decisionClaimed == 0) {
+            return existingDecisionClaim(loadApproval(approval.internalId))
+        }
+        val activeRun = AiRuns.update({
+            (AiRuns.id eq approval.runId) and
+                (
+                    (AiRuns.status eq AiRunStatus.WAITING_FOR_APPROVAL.value) or
+                        (AiRuns.status eq AiRunStatus.RUNNING.value)
+                )
+        }) {
+            it[status] = AiRunStatus.RUNNING.value
+            it[updated_at] = instant
+        }
+        if (activeRun == 0) {
+            val latestRunStatus = AiRuns.selectAll().where { AiRuns.id eq approval.runId }.first()[AiRuns.status]
+            return if (latestRunStatus == AiRunStatus.CANCELLED.value) {
+                AiApprovalClaim.Cancelled
+            } else {
+                AiApprovalClaim.InFlight(loadApproval(approval.internalId))
+            }
+        }
+        AiToolCalls.update({ AiToolCalls.id eq approval.toolCall.internalId }) {
+            it[status] = nextToolStatus.value
+            it[updated_at] = instant
+            if (approve) it[started_at] = instant
+        }
+        val claimed = loadApproval(approval.internalId)
+        return if (approve) AiApprovalClaim.Execute(claimed) else AiApprovalClaim.Denied(claimed)
+    }
+
+    override fun recordApprovalResponse(approvalId: Long, response: String) {
+        transaction {
+            AiApprovals.update({ AiApprovals.id eq approvalId }) {
+                it[AiApprovals.response] = response
+                it[updated_at] = now()
+            }
+        }
+    }
+
+    override fun requestCancellation(runResourceId: String, organizationId: Int, actorUserId: Int): Boolean =
+        transaction {
+            val resourceId = runCatching { Uuid.parse(runResourceId) }.getOrNull() ?: return@transaction false
+            val row = AiRuns
+                .selectAll()
+                .where {
+                    (AiRuns.resource_id eq resourceId) and
+                        (AiRuns.organization_id eq organizationId)
+                }
+                .firstOrNull()
+                ?: return@transaction false
+            val status = AiRunStatus.entries.first { value -> value.value == row[AiRuns.status] }
+            if (status == AiRunStatus.COMPLETED || status == AiRunStatus.FAILED) return@transaction false
+            if (status == AiRunStatus.CANCELLED) return@transaction true
+            val instant = now()
+            AiRuns.update({ AiRuns.id eq row[AiRuns.id] }) {
+                it[AiRuns.status] = AiRunStatus.CANCELLED.value
+                it[cancellation_requested_at] = instant
+                it[cancellation_requested_by] = actorUserId
+                it[completed_at] = instant
+                it[updated_at] = instant
+            }
+            true
+        }
+
+    override fun isCancellationRequested(internalRunId: Long): Boolean = transaction {
+        AiRuns
+            .selectAll()
+            .where { AiRuns.id eq internalRunId }
+            .firstOrNull()
+            ?.let { row ->
+                row[AiRuns.status] == AiRunStatus.CANCELLED.value || row[AiRuns.cancellation_requested_at] != null
+            }
+            ?: true
+    }
+
+    override fun failRun(runId: Long, code: String, message: String) {
+        transaction {
+            val run = AiRuns.selectAll().where { AiRuns.id eq runId }.firstOrNull()
+                ?: return@transaction
+            val currentStatus = AiRunStatus.entries.first { value -> value.value == run[AiRuns.status] }
+            if (currentStatus in TERMINAL_RUN_STATUSES) return@transaction
+            val instant = now()
+            AiRuns.update({ AiRuns.id eq runId }) {
+                it[status] = AiRunStatus.FAILED.value
+                it[error_code] = code
+                it[error_message] = message
+                it[completed_at] = instant
+                it[updated_at] = instant
+            }
+        }
+    }
+
+    private fun resolveConversation(
+        organizationId: Int,
+        userId: Int,
+        conversationId: String?,
+        projectId: Long?,
+        message: String,
+    ): ConversationRecord {
+        val requestedId = conversationId?.let(::parsePublicUuid)
+        if (requestedId != null) {
+            val row = AiConversations
+                .selectAll()
+                .where {
+                    (AiConversations.resource_id eq requestedId) and
+                        (AiConversations.organization_id eq organizationId) and
+                        (AiConversations.user_id eq userId)
+                }
+                .firstOrNull()
+                ?: throw IllegalArgumentException("Conversation not found")
+            return ConversationRecord(row[AiConversations.id], row[AiConversations.resource_id])
+        }
+
+        val resourceId = Uuid.random()
+        val instant = now()
+        val internalId = AiConversations.insert {
+            it[resource_id] = resourceId
+            it[organization_id] = organizationId
+            it[AiConversations.user_id] = userId
+            it[title] = message.take(MAX_CONVERSATION_TITLE)
+            it[AiConversations.project_id] = projectId
+            it[channel] = ASSISTANT_CHANNEL
+            it[created_at] = instant
+            it[updated_at] = instant
+        } get AiConversations.id
+        return ConversationRecord(internalId, resourceId)
+    }
+
+    private fun loadSession(runId: Long, conversation: ConversationRecord, created: Boolean): AiRunSession {
+        val row = AiRuns.selectAll().where { AiRuns.id eq runId }.first()
+        return AiRunSession(
+            internalRunId = runId,
+            runId = row[AiRuns.resource_id].toString(),
+            internalConversationId = conversation.internalId,
+            conversationId = conversation.resourceId.toString(),
+            projectId = row[AiRuns.project_id],
+            status = AiRunStatus.entries.first { status -> status.value == row[AiRuns.status] },
+            currentRound = row[AiRuns.current_round],
+            messages = loadMessages(conversation.internalId),
+            pendingToolCalls = loadPendingToolCalls(runId, row[AiRuns.current_round]),
+            pendingApproval = loadPendingApproval(runId),
+            outputContent = row[AiRuns.output_content],
+            created = created,
+        )
+    }
+
+    private fun loadMessages(conversationId: Int): List<LlmMessage> = AiMessages
+        .selectAll()
+        .where { AiMessages.conversation_id eq conversationId }
+        .orderBy(AiMessages.id to SortOrder.ASC)
+        .map { row ->
+            val rawToolCalls = row[AiMessages.tool_calls]
+            LlmMessage(
+                role = row[AiMessages.role],
+                content = row[AiMessages.content].takeIf(String::isNotBlank),
+                toolCallId = row[AiMessages.tool_call_id],
+                toolCalls = rawToolCalls
+                    ?.let { encoded -> json.decodeFromString<List<LlmToolCall>>(encoded) }
+                    .orEmpty(),
+            )
+        }
+
+    private fun appendMessage(conversationId: Int, runId: Long, message: LlmMessage) {
+        val sequence = AiMessages
+            .selectAll()
+            .where { AiMessages.conversation_id eq conversationId }
+            .maxOfOrNull { row -> row[AiMessages.sequence_number] ?: row[AiMessages.id].toLong() }
+            ?.plus(1)
+            ?: 1L
+        AiMessages.insert {
+            it[resource_id] = Uuid.random()
+            it[conversation_id] = conversationId
+            it[AiMessages.run_id] = runId
+            it[role] = message.role
+            it[content] = message.content.orEmpty()
+            it[tool_call_id] = message.toolCallId
+            it[tool_calls] = message.toolCalls
+                .takeIf(List<LlmToolCall>::isNotEmpty)
+                ?.let { calls -> json.encodeToString(calls) }
+            it[sequence_number] = sequence
+            it[created_at] = now()
+        }
+        AiConversations.update({ AiConversations.id eq conversationId }) {
+            it[updated_at] = now()
+            it[state_version] = AiConversations.state_version + 1
+        }
+    }
+
+    private fun loadToolCalls(runId: Long, round: Int): List<StoredAiToolCall> = AiToolCalls
+        .selectAll()
+        .where { (AiToolCalls.run_id eq runId) and (AiToolCalls.round eq round) }
+        .orderBy(AiToolCalls.id to SortOrder.ASC)
+        .map(::mapToolCall)
+
+    private fun loadPendingToolCalls(runId: Long, round: Int): List<StoredAiToolCall> =
+        loadToolCalls(runId, round).filter { toolCall ->
+            toolCall.status in setOf(
+                AiToolCallStatus.PROPOSED,
+                AiToolCallStatus.AWAITING_APPROVAL,
+                AiToolCallStatus.EXECUTING,
+            )
+        }
+
+    private fun loadPendingApproval(runId: Long): StoredAiApproval? = AiApprovals
+        .selectAll()
+        .where { AiApprovals.run_id eq runId }
+        .orderBy(AiApprovals.id to SortOrder.DESC)
+        .firstOrNull { row ->
+            row[AiApprovals.status] == AiApprovalStatus.PENDING.value ||
+                (row[AiApprovals.status] == AiApprovalStatus.APPROVED.value && row[AiApprovals.response] == null)
+        }
+        ?.let(::mapApproval)
+
+    private fun mapToolCall(row: org.jetbrains.exposed.v1.core.ResultRow): StoredAiToolCall {
+        val encodedArguments = row[AiToolCalls.arguments]
+        val arguments = encodedArguments
+            ?.takeIf { row[AiToolCalls.arguments_valid] }
+            ?.let { encoded -> runCatching { json.decodeFromString<JsonObject>(encoded) }.getOrNull() }
+        return StoredAiToolCall(
+            internalId = row[AiToolCalls.id],
+            resourceId = row[AiToolCalls.resource_id].toString(),
+            runId = row[AiToolCalls.run_id],
+            providerCallId = row[AiToolCalls.provider_call_id],
+            name = row[AiToolCalls.tool_name],
+            arguments = arguments,
+            readOnly = row[AiToolCalls.read_only],
+            status = AiToolCallStatus.entries.first { status -> status.value == row[AiToolCalls.status] },
+        )
+    }
+
+    private fun mapApproval(row: org.jetbrains.exposed.v1.core.ResultRow): StoredAiApproval {
+        val run = AiRuns.selectAll().where { AiRuns.id eq row[AiApprovals.run_id] }.first()
+        val conversation = AiConversations
+            .selectAll()
+            .where { AiConversations.id eq run[AiRuns.conversation_id] }
+            .first()
+        val toolCall = AiToolCalls
+            .selectAll()
+            .where { AiToolCalls.id eq row[AiApprovals.tool_call_id] }
+            .first()
+        return StoredAiApproval(
+            internalId = row[AiApprovals.id],
+            resourceId = row[AiApprovals.resource_id].toString(),
+            runId = row[AiApprovals.run_id],
+            runResourceId = run[AiRuns.resource_id].toString(),
+            conversationResourceId = conversation[AiConversations.resource_id].toString(),
+            toolCall = mapToolCall(toolCall),
+            status = AiApprovalStatus.entries.first { status -> status.value == row[AiApprovals.status] },
+            response = row[AiApprovals.response],
+        )
+    }
+
+    private fun loadApproval(approvalId: Long): StoredAiApproval = mapApproval(
+        AiApprovals.selectAll().where { AiApprovals.id eq approvalId }.first(),
+    )
+
+    private fun existingDecisionClaim(approval: StoredAiApproval): AiApprovalClaim = approval.response
+        ?.let { response -> AiApprovalClaim.Completed(approval, response) }
+        ?: AiApprovalClaim.InFlight(approval)
+
+    private fun unavailableApprovalClaim(
+        row: org.jetbrains.exposed.v1.core.ResultRow,
+        approval: StoredAiApproval,
+    ): AiApprovalClaim? {
+        val runStatus = AiRuns
+            .selectAll()
+            .where { AiRuns.id eq approval.runId }
+            .first()[AiRuns.status]
+        if (runStatus == AiRunStatus.CANCELLED.value) return AiApprovalClaim.Cancelled
+        if (approval.status == AiApprovalStatus.PENDING && row[AiApprovals.expires_at] <= now()) {
+            expireApproval(row[AiApprovals.id], row[AiApprovals.tool_call_id], row[AiApprovals.run_id])
+            return AiApprovalClaim.Expired
+        }
+        return when (approval.status) {
+            AiApprovalStatus.APPROVED, AiApprovalStatus.DENIED -> existingDecisionClaim(approval)
+            AiApprovalStatus.EXPIRED -> AiApprovalClaim.Expired
+            AiApprovalStatus.PENDING -> null
+        }
+    }
+
+    private fun expireApproval(approvalId: Long, toolCallId: Long, runId: Long) {
+        val instant = now()
+        AiApprovals.update({ AiApprovals.id eq approvalId }) {
+            it[status] = AiApprovalStatus.EXPIRED.value
+            it[updated_at] = instant
+        }
+        AiToolCalls.update({ AiToolCalls.id eq toolCallId }) {
+            it[status] = AiToolCallStatus.EXPIRED.value
+            it[updated_at] = instant
+        }
+        AiRuns.update({ AiRuns.id eq runId }) {
+            it[status] = AiRunStatus.FAILED.value
+            it[error_code] = "approval_expired"
+            it[error_message] = "The proposed tool action expired before approval"
+            it[completed_at] = instant
+            it[updated_at] = instant
+        }
+    }
+
+    private fun organizationIdForRun(runId: Long): Int = AiRuns
+        .selectAll()
+        .where { AiRuns.id eq runId }
+        .first()[AiRuns.organization_id]
+
+    private fun buildProposal(toolCall: StoredAiToolCall): String = json.encodeToString(
+        JsonObject.serializer(),
+        buildJsonObject {
+            put("tool", toolCall.name)
+            put("arguments", toolCall.arguments ?: JsonObject(emptyMap()))
+            put("effectIdempotencyKey", "${toolCall.runId}:${toolCall.providerCallId}")
+        },
+    )
+
+    private fun incidentResourceId(arguments: JsonObject?): Uuid? {
+        val raw = arguments?.get("incidentId")?.jsonPrimitive?.contentOrNull
+            ?: arguments?.get("incident_id")?.jsonPrimitive?.contentOrNull
+            ?: return null
+        return runCatching { Uuid.parse(raw) }.getOrNull()
+    }
+
+    private fun incidentVersion(arguments: JsonObject?): Long? =
+        arguments?.get("expectedVersion")?.jsonPrimitive?.longOrNull
+            ?: arguments?.get("incidentVersion")?.jsonPrimitive?.longOrNull
+            ?: arguments?.get("incident_version")?.jsonPrimitive?.longOrNull
+
+    private fun parsePublicUuid(raw: String): Uuid = runCatching { Uuid.parse(raw.trim()) }
+        .getOrElse { throw IllegalArgumentException("Expected an opaque UUID") }
+
+    private fun Long?.orEmpty(): String = this?.toString().orEmpty()
+
+    private fun sha256(value: String): String = MessageDigest
+        .getInstance("SHA-256")
+        .digest(value.toByteArray(Charsets.UTF_8))
+        .joinToString("") { byte -> "%02x".format(byte) }
+
+    private data class ConversationRecord(val internalId: Int, val resourceId: Uuid)
+
+    private companion object {
+        const val ASSISTANT_CHANNEL = "assistant"
+        const val MAX_CONVERSATION_TITLE = 100
+        const val TOOL_OUTCOME_EVIDENCE_TYPE = "tool_outcome"
+        val APPROVAL_TTL = 15.minutes
+        val TERMINAL_RUN_STATUSES = setOf(
+            AiRunStatus.COMPLETED,
+            AiRunStatus.FAILED,
+            AiRunStatus.CANCELLED,
+        )
+    }
+}

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/ai/services/AiAssistantServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/ai/services/AiAssistantServiceTest.kt
@@ -6,6 +6,7 @@ package com.moneat.enterprise.ai.services
 
 import com.moneat.enterprise.ai.llm.LlmCapability
 import com.moneat.enterprise.ai.llm.LlmConfig
+import com.moneat.enterprise.ai.llm.LlmCost
 import com.moneat.enterprise.ai.llm.LlmMessage
 import com.moneat.enterprise.ai.llm.LlmProvider
 import com.moneat.enterprise.ai.llm.LlmResponse
@@ -27,6 +28,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.Test
 import java.io.StringWriter
+import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
@@ -70,15 +72,12 @@ class AiAssistantServiceTest {
             ),
         )
 
-        val service = AiAssistantService(registry, fakeClient)
+        val service = AiAssistantService(registry, fakeClient, FakeAiExecutionStore())
         val writer = StringWriter()
 
         service.streamAssistant(
             writer = writer,
-            userId = 11,
-            orgId = 7,
-            message = "What errors happened recently?",
-            conversationId = null,
+            command = assistantCommand(11, 7, "What errors happened recently?"),
         )
 
         val events = parseEvents(writer.toString())
@@ -125,15 +124,12 @@ class AiAssistantServiceTest {
             ),
         )
 
-        val service = AiAssistantService(registry, fakeClient)
+        val service = AiAssistantService(registry, fakeClient, FakeAiExecutionStore())
         val writer = StringWriter()
 
         service.streamAssistant(
             writer = writer,
-            userId = 5,
-            orgId = 99,
-            message = "Create a project named edge-01",
-            conversationId = null,
+            command = assistantCommand(5, 99, "Create a project named edge-01"),
         )
 
         val events = parseEvents(writer.toString())
@@ -192,14 +188,11 @@ class AiAssistantServiceTest {
                 LlmResponse(content = "No tool call required."),
             ),
         )
-        val service = AiAssistantService(registry, fakeClient)
+        val service = AiAssistantService(registry, fakeClient, FakeAiExecutionStore())
 
         service.streamAssistant(
             writer = StringWriter(),
-            userId = 1,
-            orgId = 1,
-            message = "hello",
-            conversationId = null,
+            command = assistantCommand(1, 1, "hello"),
         )
 
         val queryLogsFunction = fakeClient
@@ -243,12 +236,9 @@ class AiAssistantServiceTest {
         )
         val writer = StringWriter()
 
-        AiAssistantService(registry, fakeClient).streamAssistant(
+        AiAssistantService(registry, fakeClient, FakeAiExecutionStore()).streamAssistant(
             writer = writer,
-            userId = 1,
-            orgId = 1,
-            message = "list issues",
-            conversationId = null,
+            command = assistantCommand(1, 1, "list issues"),
         )
 
         val events = parseEvents(writer.toString())
@@ -260,6 +250,146 @@ class AiAssistantServiceTest {
                     event["isError"]?.jsonPrimitive?.content == "true"
             },
         )
+    }
+
+    @Test
+    fun `completed run retry replays durable response without another provider call`() = runBlocking {
+        val store = FakeAiExecutionStore()
+        val provider = FakeLlmProvider(mutableListOf(LlmResponse(content = "Durable answer")))
+        val runId = UUID.randomUUID().toString()
+        val firstWriter = StringWriter()
+
+        AiAssistantService(McpToolRegistry(), provider, store).streamAssistant(
+            writer = firstWriter,
+            command = assistantCommand(4, 8, "investigate", runId = runId),
+        )
+        val conversationId = parseEvents(firstWriter.toString())
+            .first { event -> event["type"]?.jsonPrimitive?.content == "done" }["conversationId"]
+            ?.jsonPrimitive
+            ?.content
+
+        val retryWriter = StringWriter()
+        AiAssistantService(McpToolRegistry(), provider, store).streamAssistant(
+            writer = retryWriter,
+            command = assistantCommand(4, 8, "investigate", conversationId, runId),
+        )
+
+        assertEquals(1, provider.callCount)
+        assertTrue(retryWriter.toString().contains("Durable answer"))
+    }
+
+    @Test
+    fun `pending approval survives restart and repeated confirmation cannot repeat mutation`() = runBlocking {
+        var executions = 0
+        val registry = McpToolRegistry().apply {
+            register(
+                object : McpTool {
+                    override val name = "create_project"
+                    override val description = "Create project"
+                    override val readOnly = false
+                    override val inputSchema = InputSchema()
+                    override suspend fun execute(args: JsonObject, context: McpContext): ToolCallResult {
+                        executions += 1
+                        return ToolCallResult(content = listOf(ToolContent(text = "created")))
+                    }
+                },
+            )
+        }
+        val provider = FakeLlmProvider(
+            mutableListOf(
+                LlmResponse(
+                    content = "",
+                    toolCalls = listOf(
+                        LlmToolCall("call-restart", "create_project", JsonObject(emptyMap())),
+                    ),
+                ),
+                LlmResponse(content = "Completed after restart"),
+            ),
+        )
+        val store = FakeAiExecutionStore()
+        val writer = StringWriter()
+        AiAssistantService(registry, provider, store).streamAssistant(
+            writer = writer,
+            command = assistantCommand(9, 12, "create it", runId = UUID.randomUUID().toString()),
+        )
+        val requestId = parseEvents(writer.toString())
+            .first { event -> event["type"]?.jsonPrimitive?.content == "confirmation_needed" }["requestId"]
+            ?.jsonPrimitive
+            ?.content
+        assertNotNull(requestId)
+
+        val restartedService = AiAssistantService(registry, provider, store)
+        val first = restartedService.confirmPendingAction(
+            userId = 9,
+            orgId = 12,
+            request = AiAssistantConfirmRequest(requestId),
+        )
+        val replay = restartedService.confirmPendingAction(
+            userId = 9,
+            orgId = 12,
+            request = AiAssistantConfirmRequest(requestId),
+        )
+
+        assertEquals(1, executions)
+        assertEquals("Completed after restart", first.response)
+        assertEquals(first, replay)
+    }
+
+    @Test
+    fun `rejected mutation is durable and repeated rejection replays the response`() = runBlocking {
+        var executions = 0
+        val registry = McpToolRegistry().apply {
+            register(
+                object : McpTool {
+                    override val name = "create_project"
+                    override val description = "Create project"
+                    override val readOnly = false
+                    override val inputSchema = InputSchema()
+                    override suspend fun execute(args: JsonObject, context: McpContext): ToolCallResult {
+                        executions += 1
+                        return ToolCallResult(content = listOf(ToolContent(text = "unexpected")))
+                    }
+                },
+            )
+        }
+        val provider = FakeLlmProvider(
+            mutableListOf(
+                LlmResponse(
+                    content = "",
+                    toolCalls = listOf(
+                        LlmToolCall("call-denied", "create_project", JsonObject(emptyMap())),
+                    ),
+                ),
+                LlmResponse(content = "I left the project unchanged."),
+            ),
+        )
+        val store = FakeAiExecutionStore()
+        val writer = StringWriter()
+        AiAssistantService(registry, provider, store).streamAssistant(
+            writer = writer,
+            command = assistantCommand(9, 12, "create it"),
+        )
+        val requestId = parseEvents(writer.toString())
+            .first { event -> event["type"]?.jsonPrimitive?.content == "confirmation_needed" }["requestId"]
+            ?.jsonPrimitive
+            ?.content
+        assertNotNull(requestId)
+
+        val service = AiAssistantService(registry, provider, store)
+        val first = service.confirmPendingAction(
+            userId = 9,
+            orgId = 12,
+            request = AiAssistantConfirmRequest(requestId, approve = false),
+        )
+        val replay = service.confirmPendingAction(
+            userId = 9,
+            orgId = 12,
+            request = AiAssistantConfirmRequest(requestId, approve = false),
+        )
+
+        assertEquals(0, executions)
+        assertFalse(first.approved)
+        assertEquals(first, replay)
     }
 
     private fun parseEvents(raw: String): List<JsonObject> {
@@ -276,6 +406,22 @@ class AiAssistantServiceTest {
             }
         return events
     }
+
+    private fun assistantCommand(
+        userId: Int,
+        organizationId: Int,
+        message: String,
+        conversationId: String? = null,
+        runId: String? = null,
+    ) = AiAssistantStreamCommand(
+        userId = userId,
+        organizationId = organizationId,
+        message = message,
+        conversationId = conversationId,
+        runId = runId,
+        projectId = null,
+        userTimezone = null,
+    )
 }
 
 private class FakeLlmProvider(
@@ -306,4 +452,211 @@ private class FakeLlmProvider(
     override fun isEnabled(): Boolean = true
 
     override fun capabilities(): Set<LlmCapability> = LlmCapability.entries.toSet()
+}
+
+private class FakeAiExecutionStore : AiExecutionStore {
+    private val runs = linkedMapOf<Long, MutableRun>()
+    private val runIds = mutableMapOf<String, Long>()
+    private val tools = mutableMapOf<Long, StoredAiToolCall>()
+    private val approvals = mutableMapOf<Long, StoredAiApproval>()
+    private var nextRunId = 1L
+    private var nextToolId = 1L
+    private var nextApprovalId = 1L
+
+    override fun beginRun(request: StartAiRun): AiRunSession {
+        val publicRunId = request.runId ?: UUID.randomUUID().toString()
+        val existing = runIds[publicRunId]
+        if (existing != null) return session(runs.getValue(existing), created = false)
+
+        val internalId = nextRunId++
+        val run = MutableRun(
+            internalId = internalId,
+            publicId = publicRunId,
+            organizationId = request.organizationId,
+            userId = request.userId,
+            conversationId = request.conversationId ?: UUID.randomUUID().toString(),
+            projectId = request.projectId,
+            messages = mutableListOf(LlmMessage("user", request.message)),
+        )
+        runs[internalId] = run
+        runIds[publicRunId] = internalId
+        return session(run, created = true)
+    }
+
+    override fun resumeRun(internalRunId: Long): AiRunSession = session(runs.getValue(internalRunId), created = false)
+
+    override fun checkpointCompletion(
+        session: AiRunSession,
+        round: Int,
+        response: LlmResponse,
+        readOnlyTools: Set<String>,
+        cost: LlmCost,
+    ): AiTurnCheckpoint {
+        val run = runs.getValue(session.internalRunId)
+        run.currentRound = round
+        run.messages += LlmMessage("assistant", response.content.ifBlank { null }, toolCalls = response.toolCalls)
+        if (response.toolCalls.isEmpty()) {
+            run.status = AiRunStatus.COMPLETED
+            run.output = response.content
+        }
+        val stored = response.toolCalls.map { call ->
+            val id = nextToolId++
+            StoredAiToolCall(
+                internalId = id,
+                resourceId = UUID.randomUUID().toString(),
+                runId = run.internalId,
+                providerCallId = call.id,
+                name = call.name,
+                arguments = call.arguments,
+                readOnly = call.name in readOnlyTools,
+                status = AiToolCallStatus.PROPOSED,
+            ).also { tools[id] = it }
+        }
+        return AiTurnCheckpoint(response.toolCalls.isEmpty(), stored)
+    }
+
+    override fun completeRun(runId: Long, content: String) {
+        val run = runs[runId] ?: return
+        if (run.status in setOf(AiRunStatus.COMPLETED, AiRunStatus.FAILED, AiRunStatus.CANCELLED)) return
+        run.messages += LlmMessage("assistant", content)
+        run.output = content
+        run.status = AiRunStatus.COMPLETED
+    }
+
+    override fun claimToolExecution(toolCall: StoredAiToolCall): Boolean {
+        val current = tools[toolCall.internalId] ?: return false
+        if (current.status == AiToolCallStatus.EXECUTING && current.readOnly) return true
+        if (current.status != AiToolCallStatus.PROPOSED) return false
+        tools[toolCall.internalId] = current.copy(status = AiToolCallStatus.EXECUTING)
+        return true
+    }
+
+    override fun recordToolResult(toolCall: StoredAiToolCall, summary: String, isError: Boolean) {
+        val current = tools[toolCall.internalId] ?: return
+        val terminalStatus = if (current.status == AiToolCallStatus.DENIED) {
+            AiToolCallStatus.DENIED
+        } else if (isError) {
+            AiToolCallStatus.FAILED
+        } else {
+            AiToolCallStatus.SUCCEEDED
+        }
+        tools[toolCall.internalId] = current.copy(status = terminalStatus)
+        val run = runs.getValue(toolCall.runId)
+        if (run.messages.none { message -> message.role == "tool" && message.toolCallId == toolCall.providerCallId }) {
+            run.messages += LlmMessage("tool", summary, toolCall.providerCallId)
+        }
+    }
+
+    override fun createApproval(
+        session: AiRunSession,
+        toolCall: StoredAiToolCall,
+        requestedBy: Int,
+    ): StoredAiApproval {
+        approvals.values.firstOrNull { it.toolCall.internalId == toolCall.internalId }?.let { return it }
+        val id = nextApprovalId++
+        val approval = StoredAiApproval(
+            internalId = id,
+            resourceId = UUID.randomUUID().toString(),
+            runId = session.internalRunId,
+            runResourceId = session.runId,
+            conversationResourceId = session.conversationId,
+            toolCall = toolCall.copy(status = AiToolCallStatus.AWAITING_APPROVAL),
+            status = AiApprovalStatus.PENDING,
+            response = null,
+        )
+        tools[toolCall.internalId] = approval.toolCall
+        approvals[id] = approval
+        runs.getValue(session.internalRunId).status = AiRunStatus.WAITING_FOR_APPROVAL
+        return approval
+    }
+
+    override fun claimApproval(
+        resourceId: String,
+        organizationId: Int,
+        actorUserId: Int,
+        approve: Boolean,
+    ): AiApprovalClaim {
+        val entry = approvals.entries.firstOrNull { it.value.resourceId == resourceId }
+            ?: return AiApprovalClaim.Missing
+        val approval = entry.value
+        if (approval.status == AiApprovalStatus.APPROVED) {
+            return approval.response
+                ?.let { AiApprovalClaim.Completed(approval, it) }
+                ?: AiApprovalClaim.InFlight(approval)
+        }
+        if (approval.status == AiApprovalStatus.DENIED) {
+            return approval.response
+                ?.let { AiApprovalClaim.Completed(approval, it) }
+                ?: AiApprovalClaim.InFlight(approval)
+        }
+        val status = if (approve) AiApprovalStatus.APPROVED else AiApprovalStatus.DENIED
+        val toolStatus = if (approve) AiToolCallStatus.EXECUTING else AiToolCallStatus.DENIED
+        val claimed = approval.copy(
+            status = status,
+            toolCall = approval.toolCall.copy(status = toolStatus),
+        )
+        approvals[entry.key] = claimed
+        tools[claimed.toolCall.internalId] = claimed.toolCall
+        runs.getValue(claimed.runId).status = AiRunStatus.RUNNING
+        return if (approve) AiApprovalClaim.Execute(claimed) else AiApprovalClaim.Denied(claimed)
+    }
+
+    override fun recordApprovalResponse(approvalId: Long, response: String) {
+        approvals.computeIfPresent(approvalId) { _, approval -> approval.copy(response = response) }
+    }
+
+    override fun requestCancellation(runResourceId: String, organizationId: Int, actorUserId: Int): Boolean {
+        val run = runIds[runResourceId]?.let(runs::get) ?: return false
+        if (run.organizationId != organizationId) return false
+        run.status = AiRunStatus.CANCELLED
+        return true
+    }
+
+    override fun isCancellationRequested(internalRunId: Long): Boolean =
+        runs[internalRunId]?.status == AiRunStatus.CANCELLED
+
+    override fun failRun(runId: Long, code: String, message: String) {
+        runs[runId]?.status = AiRunStatus.FAILED
+    }
+
+    private fun session(run: MutableRun, created: Boolean): AiRunSession {
+        val pendingTools = tools.values.filter { tool ->
+            tool.runId == run.internalId && tool.status in setOf(
+                AiToolCallStatus.PROPOSED,
+                AiToolCallStatus.AWAITING_APPROVAL,
+                AiToolCallStatus.EXECUTING,
+            )
+        }
+        val pendingApproval = approvals.values.lastOrNull { approval ->
+            approval.runId == run.internalId && approval.response == null &&
+                approval.status in setOf(AiApprovalStatus.PENDING, AiApprovalStatus.APPROVED)
+        }
+        return AiRunSession(
+            internalRunId = run.internalId,
+            runId = run.publicId,
+            internalConversationId = run.internalId.toInt(),
+            conversationId = run.conversationId,
+            projectId = run.projectId,
+            status = run.status,
+            currentRound = run.currentRound,
+            messages = run.messages.toList(),
+            pendingToolCalls = pendingTools,
+            pendingApproval = pendingApproval,
+            outputContent = run.output,
+            created = created,
+        )
+    }
+
+    private data class MutableRun(
+        val internalId: Long,
+        val publicId: String,
+        val organizationId: Int,
+        val userId: Int,
+        val conversationId: String,
+        val projectId: Long?,
+        val messages: MutableList<LlmMessage>,
+        var status: AiRunStatus = AiRunStatus.RUNNING,
+        var currentRound: Int = 0,
+        var output: String? = null,
+    )
 }

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/ai/services/AiExecutionStoreTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/ai/services/AiExecutionStoreTest.kt
@@ -1,0 +1,283 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.ai.services
+
+import com.moneat.ai.AiConversations
+import com.moneat.ai.AiMessages
+import com.moneat.enterprise.ai.llm.LlmResponse
+import com.moneat.enterprise.ai.llm.LlmCost
+import com.moneat.enterprise.ai.llm.LlmToolCall
+import com.moneat.enterprise.ai.models.AiApprovals
+import com.moneat.enterprise.ai.models.AiRunEvidence
+import com.moneat.enterprise.ai.models.AiRuns
+import com.moneat.enterprise.ai.models.AiToolCalls
+import com.moneat.enterprise.sso.support.EnterpriseTestDatabaseHelper
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+class AiExecutionStoreTest {
+    private val store = ExposedAiExecutionStore()
+
+    @BeforeEach
+    fun resetDatabase() {
+        EnterpriseTestDatabaseHelper.resetSchema(
+            AiTestUsers,
+            AiTestOrganizations,
+            AiConversations,
+            AiRuns,
+            AiMessages,
+            AiToolCalls,
+            AiRunEvidence,
+            AiApprovals,
+        )
+    }
+
+    @Test
+    fun `run retries restore one scoped conversation without duplicating the user message`() {
+        val firstActor = seedActor("first")
+        val secondActor = seedActor("second")
+        val runId = Uuid.random().toString()
+        val first = store.beginRun(startRun(firstActor, "Investigate", runId = runId))
+        val retryWithoutConversation = store.beginRun(startRun(firstActor, "Investigate", runId = runId))
+        val retry = store.beginRun(
+            startRun(firstActor, "Investigate", conversationId = first.conversationId, runId = runId),
+        )
+
+        assertTrue(first.created)
+        assertFalse(retryWithoutConversation.created)
+        assertEquals(first.conversationId, retryWithoutConversation.conversationId)
+        assertFalse(retry.created)
+        assertEquals(1, retry.messages.count { message -> message.role == "user" })
+        transaction {
+            assertEquals(1, AiConversations.selectAll().count())
+        }
+        assertFailsWith<IllegalStateException> {
+            store.beginRun(startRun(firstActor, "Different", first.conversationId, runId))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            store.beginRun(startRun(secondActor, "Cross-org", first.conversationId))
+        }
+    }
+
+    @Test
+    fun `approval persists exact proposal and becomes idempotent after a response`() {
+        val actor = seedActor("approval")
+        val incidentId = Uuid.random()
+        val session = store.beginRun(startRun(actor, "Resolve incident"))
+        val checkpoint = store.checkpointCompletion(
+            session = session,
+            round = 1,
+            response = LlmResponse(
+                content = "",
+                toolCalls = listOf(
+                    LlmToolCall(
+                        id = "provider-call",
+                        name = "resolve_incident",
+                        arguments = JsonObject(
+                            mapOf(
+                                "incidentId" to JsonPrimitive(incidentId.toString()),
+                                "expectedVersion" to JsonPrimitive(7),
+                            ),
+                        ),
+                    ),
+                ),
+                inputTokens = 12,
+                outputTokens = 4,
+                model = "test-model",
+                provider = "test-provider",
+            ),
+            readOnlyTools = emptySet(),
+            cost = llmCost("0.000004"),
+        )
+        val approval = store.createApproval(session, checkpoint.toolCalls.single(), actor.userId)
+
+        transaction {
+            val row = AiApprovals.selectAll().where { AiApprovals.id eq approval.internalId }.single()
+            assertEquals(incidentId, row[AiApprovals.incident_resource_id])
+            assertEquals(7, row[AiApprovals.incident_version])
+            assertEquals(64, row[AiApprovals.proposal_sha256].length)
+            assertTrue(row[AiApprovals.proposed_command].contains("resolve_incident"))
+            assertTrue(row[AiApprovals.expires_at] > row[AiApprovals.created_at])
+            val run = AiRuns.selectAll().where { AiRuns.id eq session.internalRunId }.single()
+            assertEquals(12, run[AiRuns.input_tokens])
+            assertEquals(4, run[AiRuns.output_tokens])
+            assertEquals(BigDecimal("0.00000400"), run[AiRuns.cost_usd])
+            assertTrue(run[AiRuns.cost_metadata].contains("lastTotalCost"))
+        }
+
+        val claimed = assertIs<AiApprovalClaim.Execute>(
+            store.claimApproval(approval.resourceId, actor.orgId, actor.userId, approve = true),
+        )
+        assertIs<AiApprovalClaim.InFlight>(
+            store.claimApproval(approval.resourceId, actor.orgId, actor.userId, approve = true),
+        )
+        store.recordToolResult(claimed.approval.toolCall, "resolved", isError = false)
+        transaction {
+            val tool = AiToolCalls.selectAll().where { AiToolCalls.id eq claimed.approval.toolCall.internalId }.single()
+            val auditEventId = assertNotNull(tool[AiToolCalls.result_audit_event_id])
+            val evidence = AiRunEvidence.selectAll().where { AiRunEvidence.resource_id eq auditEventId }.single()
+            assertEquals("tool_outcome", evidence[AiRunEvidence.evidence_type])
+            assertTrue(evidence[AiRunEvidence.content].contains("resolved"))
+            val updatedApproval = AiApprovals.selectAll().where { AiApprovals.id eq approval.internalId }.single()
+            assertEquals(auditEventId, updatedApproval[AiApprovals.result_audit_event_id])
+        }
+        store.recordApprovalResponse(approval.internalId, "{\"response\":\"resolved\"}")
+        val replay = assertIs<AiApprovalClaim.Completed>(
+            store.claimApproval(approval.resourceId, actor.orgId, actor.userId, approve = true),
+        )
+        assertEquals("{\"response\":\"resolved\"}", replay.response)
+    }
+
+    @Test
+    fun `new store instance resumes checkpointed messages and pending approval`() {
+        val actor = seedActor("restart")
+        val session = store.beginRun(startRun(actor, "Create project"))
+        val checkpoint = store.checkpointCompletion(
+            session,
+            1,
+            LlmResponse(
+                content = "",
+                toolCalls = listOf(LlmToolCall("call-1", "create_project", JsonObject(emptyMap()))),
+            ),
+            emptySet(),
+            llmCost(),
+        )
+        val approval = store.createApproval(session, checkpoint.toolCalls.single(), actor.userId)
+
+        val restored = ExposedAiExecutionStore().resumeRun(session.internalRunId)
+
+        assertEquals(AiRunStatus.WAITING_FOR_APPROVAL, restored.status)
+        assertEquals(2, restored.messages.size)
+        val restoredApproval = assertNotNull(restored.pendingApproval)
+        assertEquals(approval.resourceId, restoredApproval.resourceId)
+        assertEquals(AiToolCallStatus.AWAITING_APPROVAL, restored.pendingToolCalls.single().status)
+    }
+
+    @Test
+    fun `cancellation is scoped and durable`() {
+        val actor = seedActor("cancel")
+        val other = seedActor("other")
+        val session = store.beginRun(startRun(actor, "Long investigation"))
+
+        assertFalse(store.requestCancellation(session.runId, other.orgId, other.userId))
+        assertTrue(store.requestCancellation(session.runId, actor.orgId, actor.userId))
+        assertTrue(ExposedAiExecutionStore().isCancellationRequested(session.internalRunId))
+        assertEquals(AiRunStatus.CANCELLED, ExposedAiExecutionStore().resumeRun(session.internalRunId).status)
+    }
+
+    @Test
+    fun `expired approval cannot execute and fails the run`() {
+        var now = Instant.parse("2026-08-22T00:00:00Z")
+        val expiringStore = ExposedAiExecutionStore { now }
+        val actor = seedActor("expiry")
+        val session = expiringStore.beginRun(startRun(actor, "Mutate"))
+        val checkpoint = expiringStore.checkpointCompletion(
+            session,
+            1,
+            LlmResponse(
+                content = "",
+                toolCalls = listOf(LlmToolCall("call-expiry", "create_project", JsonObject(emptyMap()))),
+            ),
+            emptySet(),
+            llmCost(),
+        )
+        val approval = expiringStore.createApproval(session, checkpoint.toolCalls.single(), actor.userId)
+
+        now += 16.minutes
+
+        assertIs<AiApprovalClaim.Expired>(
+            expiringStore.claimApproval(approval.resourceId, actor.orgId, actor.userId, approve = true),
+        )
+        assertEquals(AiRunStatus.FAILED, expiringStore.resumeRun(session.internalRunId).status)
+    }
+
+    private fun seedActor(slug: String): Actor = transaction {
+        val userId = AiTestUsers.insert {
+            it[email] = "$slug@example.test"
+            it[password_hash] = "x"
+            it[name] = slug
+        } get AiTestUsers.id
+        val orgId = AiTestOrganizations.insert {
+            it[name] = "Organization $slug"
+            it[AiTestOrganizations.slug] = slug
+        } get AiTestOrganizations.id
+        Actor(orgId, userId)
+    }
+
+    private fun startRun(
+        actor: Actor,
+        message: String,
+        conversationId: String? = null,
+        runId: String? = null,
+    ) = StartAiRun(
+        organizationId = actor.orgId,
+        userId = actor.userId,
+        conversationId = conversationId,
+        runId = runId,
+        projectId = null,
+        message = message,
+    )
+
+    private fun llmCost(total: String = "0") = LlmCost(
+        inputCost = BigDecimal.ZERO,
+        outputCost = BigDecimal(total),
+        totalCost = BigDecimal(total),
+    )
+
+    private data class Actor(val orgId: Int, val userId: Int)
+
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun connectDatabase() {
+            TransactionManager.defaultDatabase = Database.connect(
+                url = "jdbc:h2:mem:moneat_ai_runs;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
+                driver = "org.h2.Driver",
+            )
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun clearDatabase() {
+            TransactionManager.defaultDatabase = null
+        }
+    }
+}
+
+private object AiTestUsers : Table("users") {
+    val id = integer("id").autoIncrement()
+    val email = varchar("email", 255)
+    val password_hash = varchar("password_hash", 255)
+    val name = varchar("name", 255).nullable()
+    override val primaryKey = PrimaryKey(id)
+}
+
+private object AiTestOrganizations : Table("organizations") {
+    val id = integer("id").autoIncrement()
+    val name = varchar("name", 255)
+    val slug = varchar("slug", 255)
+    override val primaryKey = PrimaryKey(id)
+}


### PR DESCRIPTION
## Summary
- persist organization-scoped AI conversations, runs, messages, tool calls, evidence, outcomes, and approvals
- resume runs safely after restart and make approval and mutation retries idempotent
- record actor, incident version, proposal hash, expiry, cancellation, token, and cost metadata

## Validation
- migration version check against origin/develop (V170)
- focused AI execution and assistant tests
- enterprise Detekt
- no rollout gate introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - AI assistant sessions can resume after interruptions without losing conversation progress.
  - Added durable tracking for tool actions, approvals, results, and execution status.
  - Added the ability to cancel active AI runs.
  - Assistant responses and confirmations now include run identifiers.
  - Added project and channel context for AI conversations.

- **Bug Fixes**
  - Prevented duplicate processing of repeated requests and confirmations.
  - Improved recovery of pending approvals and interrupted tool executions.
  - Added clearer validation and conflict handling for invalid or repeated actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->