### PR TITLE
feat(slack): add incident declaration entry points

### DIFF
--- a/backend/src/main/kotlin/com/moneat/enterprise/OnCallBridge.kt
+++ b/backend/src/main/kotlin/com/moneat/enterprise/OnCallBridge.kt
@@ -74,6 +74,13 @@ interface OnCallBridge {
     /** Declare an operational incident and return the declared incident resource ID. */
     suspend fun declareIncident(declaration: OnCallIncidentDeclaration): String?
 
+    /** Handle an authenticated Slack command, shortcut, or interaction. */
+    suspend fun handleSlackInbound(
+        requestType: String,
+        payload: String,
+        deliveryId: String?,
+    ): String? = null
+
     /** Get a declared incident by ID for a user. */
     fun getIncident(
         incidentId: Int,
@@ -107,6 +114,7 @@ data class OnCallIncidentDeclaration(
     val description: String?,
     val severity: String,
     val commandKey: String,
+    val origin: String = "WORKFLOW",
 )
 
 /** Lightweight data carrier for priority info, avoiding enterprise model dependency. */

--- a/backend/src/main/kotlin/com/moneat/notifications/services/SlackInstallationService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/SlackInstallationService.kt
@@ -813,6 +813,17 @@ class SlackInstallationService internal constructor(
             ?.get(SlackWorkspaceBindings.slackInstallationId)
     }
 
+    fun organizationIdForTeam(teamId: String): Int? = transaction {
+        SlackWorkspaceBindings
+            .selectAll()
+            .where {
+                (SlackWorkspaceBindings.teamId eq teamId) and
+                    (SlackWorkspaceBindings.enabled eq true)
+            }
+            .firstOrNull()
+            ?.get(SlackWorkspaceBindings.organizationId)
+    }
+
     fun bindEnterpriseWorkspace(
         organizationId: Int,
         installationId: String,

--- a/backend/src/main/kotlin/com/moneat/notifications/services/SlackService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/SlackService.kt
@@ -46,10 +46,12 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.selectAll
@@ -320,6 +322,32 @@ class SlackService(
             return SlackOutboundSendResult.Failed("Slack message is missing a destination channel")
         }
         return sendOutboundOperation(delivery, accessToken)
+    }
+
+    suspend fun openModal(
+        organizationId: Int,
+        installationId: Int,
+        triggerId: String,
+        view: JsonObject,
+    ): Boolean {
+        val config = installationService.botConfigByInternalId(organizationId, installationId) ?: return false
+        return suspendRunCatching {
+            val response = httpClient.post("https://slack.com/api/views.open") {
+                contentType(ContentType.Application.Json)
+                header("Authorization", "Bearer ${config.accessToken}")
+                setBody(
+                    buildJsonObject {
+                        put("trigger_id", triggerId)
+                        put("view", view)
+                    }.toString(),
+                )
+            }
+            if (response.status != HttpStatusCode.OK) return@suspendRunCatching false
+            json.parseToJsonElement(response.bodyAsText()).jsonObject["ok"]?.jsonPrimitive?.booleanOrNull == true
+        }.getOrElse { error ->
+            logger.warn("Failed to open Slack modal", error)
+            false
+        }
     }
 
     private suspend fun sendOutboundOperation(

--- a/backend/src/main/kotlin/com/moneat/org/routes/IntegrationRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/org/routes/IntegrationRoutes.kt
@@ -18,6 +18,7 @@ package com.moneat.org.routes
 
 import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.config.EnvConfig
+import com.moneat.enterprise.FeatureRegistry
 import com.moneat.notifications.services.DiscordService
 import com.moneat.notifications.services.SlackInboundGateway
 import com.moneat.notifications.services.SlackInboundRequestException
@@ -38,6 +39,7 @@ import com.moneat.shared.models.SlackUserMappings
 import com.moneat.utils.ErrorResponse
 import com.moneat.utils.MessageResponse
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.ContentType
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.auth.authenticate
 import io.ktor.server.auth.jwt.JWTPrincipal
@@ -48,6 +50,7 @@ import io.ktor.server.request.receive
 import io.ktor.server.request.receiveText
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondRedirect
+import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
@@ -1278,6 +1281,17 @@ fun Route.integrationCallbackRoutes() {
                     val accepted = slackInboundGateway.accept(call.request.headers, rawBody, requestType)
                     if (accepted.challenge != null) {
                         call.respond(mapOf("challenge" to accepted.challenge))
+                    } else if (!accepted.duplicate) {
+                        val bridgeResponse = FeatureRegistry.getOnCallBridge()?.handleSlackInbound(
+                            requestType = requestType.wire,
+                            payload = rawBody,
+                            deliveryId = accepted.deliveryId,
+                        )
+                        if (bridgeResponse != null) {
+                            call.respondText(bridgeResponse, ContentType.Application.Json)
+                        } else {
+                            call.respond(HttpStatusCode.Accepted, accepted)
+                        }
                     } else {
                         call.respond(HttpStatusCode.Accepted, accepted)
                     }

--- a/backend/src/test/kotlin/com/moneat/notifications/services/SlackInstallationServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/notifications/services/SlackInstallationServiceTest.kt
@@ -27,6 +27,7 @@ import com.moneat.testsupport.TestDatabaseHelper
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -168,6 +169,79 @@ class SlackInstallationServiceTest {
                 internalInstallationId,
                 "trigger-1",
                 buildJsonObject { put("type", "modal") },
+            ),
+        )
+    }
+
+    @Test
+    fun `does not open a modal for a disabled installation`() = runBlocking {
+        val organizationId = seedOrganization("Disabled modal")
+        service.storeOAuthGrant(
+            organizationId,
+            reauthorizeInstallationId = null,
+            capabilityIds = emptyList(),
+            grant = grant("T-DISABLED-MODAL", "Disabled", service.requestedScopes(emptyList())),
+        )
+        transaction {
+            SlackWorkspaceBindings.update({ SlackWorkspaceBindings.teamId eq "T-DISABLED-MODAL" }) {
+                it[enabled] = false
+            }
+        }
+        val slackService = SlackService(
+            HttpClient(MockEngine) {
+                engine { addHandler { respond("{}") } }
+            },
+            service,
+        )
+        assertFalse(slackService.openModal(organizationId, 1, "trigger-1", buildJsonObject { }))
+    }
+
+    @Test
+    fun `does not open a modal when Slack returns a non-OK response`() = runBlocking {
+        val organizationId = seedOrganization("Non OK modal")
+        service.storeOAuthGrant(
+            organizationId,
+            reauthorizeInstallationId = null,
+            capabilityIds = emptyList(),
+            grant = grant("T-NON-OK-MODAL", "Non OK", service.requestedScopes(emptyList())),
+        )
+        val installationId = assertNotNull(service.internalInstallationIdForTeam(organizationId, "T-NON-OK-MODAL"))
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { respond("{}", status = HttpStatusCode.BadRequest) }
+            }
+        }
+        assertFalse(
+            SlackService(client, service).openModal(
+                organizationId,
+                installationId,
+                "trigger-1",
+                buildJsonObject { },
+            ),
+        )
+    }
+
+    @Test
+    fun `does not open a modal when Slack rejects the view`() = runBlocking {
+        val organizationId = seedOrganization("Rejected modal")
+        service.storeOAuthGrant(
+            organizationId,
+            reauthorizeInstallationId = null,
+            capabilityIds = emptyList(),
+            grant = grant("T-REJECTED-MODAL", "Rejected", service.requestedScopes(emptyList())),
+        )
+        val installationId = assertNotNull(service.internalInstallationIdForTeam(organizationId, "T-REJECTED-MODAL"))
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { respond("{\"ok\":false}") }
+            }
+        }
+        assertFalse(
+            SlackService(client, service).openModal(
+                organizationId,
+                installationId,
+                "trigger-1",
+                buildJsonObject { },
             ),
         )
     }

--- a/backend/src/test/kotlin/com/moneat/notifications/services/SlackInstallationServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/notifications/services/SlackInstallationServiceTest.kt
@@ -27,8 +27,6 @@ import com.moneat.testsupport.TestDatabaseHelper
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
-import io.ktor.http.ContentType
-import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -46,6 +44,7 @@ import java.time.LocalTime
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -156,13 +155,12 @@ class SlackInstallationServiceTest {
         val client = HttpClient(MockEngine) {
             engine {
                 addHandler {
-                    respond("{\"ok\":true}", ContentType.Application.Json, HttpStatusCode.OK)
+                    respond("{\"ok\":true}")
                 }
             }
         }
         val slackService = SlackService(client, service)
-        val internalInstallationId = service.internalInstallationIdForTeam(organizationId, "T-MODAL")
-        assertNotNull(internalInstallationId)
+        val internalInstallationId = assertNotNull(service.internalInstallationIdForTeam(organizationId, "T-MODAL"))
 
         assertTrue(
             slackService.openModal(

--- a/backend/src/test/kotlin/com/moneat/notifications/services/SlackInstallationServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/notifications/services/SlackInstallationServiceTest.kt
@@ -24,13 +24,21 @@ import com.moneat.shared.models.SlackInstallationGrants
 import com.moneat.shared.models.SlackInstallations
 import com.moneat.shared.models.SlackWorkspaceBindings
 import com.moneat.testsupport.TestDatabaseHelper
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.Base64
@@ -115,6 +123,55 @@ class SlackInstallationServiceTest {
             assertNotEquals(ciphertexts[0], ciphertexts[1])
             assertEquals(2, SlackWorkspaceBindings.selectAll().count())
         }
+    }
+
+    @Test
+    fun `resolves only enabled workspace bindings to their organization`() {
+        val organizationId = seedOrganization("Workspace lookup")
+        service.storeOAuthGrant(
+            organizationId,
+            reauthorizeInstallationId = null,
+            capabilityIds = emptyList(),
+            grant = grant("T-LOOKUP", "Lookup", service.requestedScopes(emptyList())),
+        )
+
+        assertEquals(organizationId, service.organizationIdForTeam("T-LOOKUP"))
+        transaction {
+            SlackWorkspaceBindings.update({ SlackWorkspaceBindings.teamId eq "T-LOOKUP" }) {
+                it[enabled] = false
+            }
+        }
+        assertNull(service.organizationIdForTeam("T-LOOKUP"))
+    }
+
+    @Test
+    fun `opens an incident modal through the Slack views API`() = runBlocking {
+        val organizationId = seedOrganization("Modal lookup")
+        service.storeOAuthGrant(
+            organizationId,
+            reauthorizeInstallationId = null,
+            capabilityIds = emptyList(),
+            grant = grant("T-MODAL", "Modal", service.requestedScopes(emptyList())),
+        )
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler {
+                    respond("{\"ok\":true}", ContentType.Application.Json, HttpStatusCode.OK)
+                }
+            }
+        }
+        val slackService = SlackService(client, service)
+        val internalInstallationId = service.internalInstallationIdForTeam(organizationId, "T-MODAL")
+        assertNotNull(internalInstallationId)
+
+        assertTrue(
+            slackService.openModal(
+                organizationId,
+                internalInstallationId,
+                "trigger-1",
+                buildJsonObject { put("type", "modal") },
+            ),
+        )
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/routes/IntegrationSlackCallbackRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/IntegrationSlackCallbackRoutesTest.kt
@@ -1,0 +1,153 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.routes
+
+import com.moneat.enterprise.FeatureRegistry
+import com.moneat.enterprise.OnCallBridge
+import com.moneat.ingestion.queue.IngestionQueueClient
+import com.moneat.notifications.services.SlackInboundGateway
+import com.moneat.notifications.services.SlackInboundRequestType
+import com.moneat.org.routes.integrationCallbackRoutes
+import com.moneat.shared.models.SlackInboundDeliveries
+import com.moneat.testsupport.TestDatabaseHelper
+import com.moneat.testsupport.RouteTestSupport.installJwtAuth
+import com.moneat.testsupport.startTestKoin
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.koin.core.context.loadKoinModules
+import org.koin.dsl.module
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class IntegrationSlackCallbackRoutesTest {
+    companion object {
+        private const val SECRET = "integration-route-secret"
+        private var database: Database? = null
+    }
+
+    @BeforeTest
+    fun setUp() {
+        startTestKoin()
+        mockkObject(IngestionQueueClient)
+        every { IngestionQueueClient.enqueue(any(), any(), any()) } returns "1-0"
+        if (database == null) {
+            database = Database.connect(
+                url = "jdbc:h2:mem:moneat_slack_callback_routes;MODE=MYSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
+                driver = "org.h2.Driver",
+            )
+        }
+        TransactionManager.defaultDatabase = database
+        TestDatabaseHelper.resetSchema(SlackInboundDeliveries)
+        loadKoinModules(
+            module {
+                single<SlackInboundGateway> { SlackInboundGateway(signingSecret = SECRET) }
+            },
+        )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkObject(FeatureRegistry)
+        unmockkObject(IngestionQueueClient)
+    }
+
+    @Test
+    fun `routes a fresh Slack delivery through the on-call bridge and accepts retries`() = testApplication {
+        val bridge = mockk<OnCallBridge>()
+        coEvery { bridge.handleSlackInbound(any(), any(), any()) } returns "{\"response_type\":\"ephemeral\"}"
+        mockkObject(FeatureRegistry)
+        every { FeatureRegistry.getOnCallBridge() } returns bridge
+
+        application {
+            installJwtAuth()
+            routing { integrationCallbackRoutes() }
+        }
+
+        val body = "team_id=T1&user_id=U1&trigger_id=TR1"
+        val headers = signedHeaders(body)
+        val first = client.post("/integrations/slack/commands") {
+            headers.forEach { key, values -> header(key, values.single()) }
+            setBody(body)
+        }
+        val retry = client.post("/integrations/slack/commands") {
+            headers.forEach { key, values -> header(key, values.single()) }
+            setBody(body)
+        }
+
+        assertEquals(HttpStatusCode.OK, first.status)
+        assertEquals("{\"response_type\":\"ephemeral\"}", first.bodyAsText())
+        assertEquals(HttpStatusCode.Accepted, retry.status)
+        assertTrue(retry.bodyAsText().contains("duplicate"))
+    }
+
+    @Test
+    fun `returns accepted when the bridge declines a fresh Slack delivery`() = testApplication {
+        val bridge = mockk<OnCallBridge>()
+        coEvery { bridge.handleSlackInbound(any(), any(), any()) } returns null
+        mockkObject(FeatureRegistry)
+        every { FeatureRegistry.getOnCallBridge() } returns bridge
+
+        application {
+            installJwtAuth()
+            routing { integrationCallbackRoutes() }
+        }
+
+        val body = "team_id=T2&user_id=U2&trigger_id=TR2"
+        val response = client.post("/integrations/slack/commands") {
+            signedHeaders(body).forEach { key, values -> header(key, values.single()) }
+            setBody(body)
+        }
+
+        assertEquals(HttpStatusCode.Accepted, response.status)
+        assertTrue(response.bodyAsText().contains(SlackInboundRequestType.COMMAND.wire))
+    }
+
+    private fun signedHeaders(body: String) =
+        (System.currentTimeMillis() / 1_000L).toString().let { timestamp ->
+            headersOf(
+                "X-Slack-Request-Timestamp" to listOf(timestamp),
+                "X-Slack-Signature" to listOf(signature(body, timestamp)),
+                HttpHeaders.ContentType to listOf("application/x-www-form-urlencoded"),
+            )
+        }
+
+    private fun signature(body: String, timestamp: String): String {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(SECRET.toByteArray(), "HmacSHA256"))
+        val digest = mac.doFinal("v0:$timestamp:$body".toByteArray())
+        return "v0=" + digest.joinToString("") { "%02x".format(it) }
+    }
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
@@ -54,15 +54,32 @@ import com.moneat.mcp.McpToolContributor
 import com.moneat.mcp.protocol.McpToolRegistry
 import com.moneat.notifications.services.SlackService
 import com.moneat.notifications.services.SlackInstallationService
+import com.moneat.shared.models.SlackUserMappings
 import io.ktor.server.application.Application
+import io.ktor.http.parseQueryString
 import io.ktor.server.routing.Route
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+import kotlinx.serialization.json.addJsonObject
 import mu.KotlinLogging
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.koin.core.module.Module
 import org.koin.dsl.module
+import kotlin.uuid.Uuid
 
 private val logger = KotlinLogging.logger {}
+private const val SLACK_TITLE_PREFILL_MAX_CHARS = 150
 
 /**
  * Enterprise module for on-call management, escalation, and incident response.
@@ -301,13 +318,124 @@ class OnCallModule :
             .declareIncident(
                 DeclareIncidentCommand(
                     commandKey = declaration.commandKey,
-                    actor = IncidentCommandActor(declaration.organizationId, declaration.userId, "WORKFLOW"),
+                    actor = IncidentCommandActor(declaration.organizationId, declaration.userId, declaration.origin),
                     title = declaration.title,
                     description = declaration.description,
                     severity = declaration.severity,
                     onCallAlertId = declaration.alertId,
                 ),
             ).id
+
+    override suspend fun handleSlackInbound(
+        requestType: String,
+        payload: String,
+        deliveryId: String?,
+    ): String? {
+        val form = parseQueryString(payload)
+        val root = form["payload"]?.let { Json.parseToJsonElement(it).jsonObject }
+        val value: (String) -> String? = { key ->
+            root?.get(key)?.jsonPrimitive?.contentOrNull ?: form[key]
+        }
+        val type = root?.get("type")?.jsonPrimitive?.contentOrNull
+        if (requestType == "interactions" && type == "view_submission") {
+            return submitSlackIncident(root, value, deliveryId)
+        }
+        if (requestType == "events" || requestType == "mentions") return null
+
+        return openSlackIncident(root, value)
+    }
+
+    private suspend fun openSlackIncident(
+        root: JsonObject?,
+        value: (String) -> String?,
+    ): String? {
+        val teamId = value("team_id") ?: root?.get("team")?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull
+        val slackUserId = value("user_id") ?: root?.get("user")?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull
+        val triggerId = value("trigger_id") ?: root?.get("trigger_id")?.jsonPrimitive?.contentOrNull
+        if (teamId.isNullOrBlank() || slackUserId.isNullOrBlank()) {
+            return slackEphemeral("Slack workspace and user context are required.")
+        }
+        val organizationId = slackInstallationService.organizationIdForTeam(teamId)
+            ?: return slackEphemeral("This Slack workspace is not connected to a Moneat organization.")
+        val installationId = slackInstallationService.internalInstallationIdForTeam(organizationId, teamId)
+            ?: return slackEphemeral("This Slack workspace installation is disabled.")
+        val linkedUser = transaction {
+            SlackUserMappings
+                .selectAll()
+                .where {
+                    (SlackUserMappings.slackInstallationId eq installationId) and
+                        (SlackUserMappings.slackUserId eq slackUserId) and
+                        (SlackUserMappings.slackTeamId eq teamId)
+                }
+                .firstOrNull()
+        } != null
+        if (!linkedUser) return slackEphemeral("Link your Slack identity in Moneat before declaring an incident.")
+
+        val contextText = value("text")
+            ?: root?.get("message")?.jsonObject?.get("text")?.jsonPrimitive?.contentOrNull
+        if (triggerId.isNullOrBlank()) return slackEphemeral("Slack did not provide a modal trigger.")
+        val opened = slackService.openModal(
+            organizationId = organizationId,
+            installationId = installationId,
+            triggerId = triggerId,
+            view = slackIncidentDeclarationView(contextText),
+        )
+        return if (opened) "{}" else slackEphemeral("Moneat could not open the incident declaration form.")
+    }
+
+    private suspend fun submitSlackIncident(
+        root: JsonObject?,
+        value: (String) -> String?,
+        deliveryId: String?,
+    ): String {
+        val teamId = root?.get("team")?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull
+            ?: value("team_id")
+        val slackUserId = root?.get("user")?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull
+            ?: value("user_id")
+        val organizationId = teamId?.let(slackInstallationService::organizationIdForTeam)
+        val installationId = if (organizationId != null) {
+            slackInstallationService.internalInstallationIdForTeam(organizationId, requireNotNull(teamId))
+        } else {
+            null
+        }
+        val userId = if (organizationId != null && installationId != null && !slackUserId.isNullOrBlank()) {
+            transaction {
+                SlackUserMappings
+                    .selectAll()
+                    .where {
+                        (SlackUserMappings.slackInstallationId eq installationId) and
+                            (SlackUserMappings.slackUserId eq slackUserId) and
+                            (SlackUserMappings.slackTeamId eq teamId)
+                    }
+                    .firstOrNull()
+                    ?.get(SlackUserMappings.userId)
+            }
+        } else {
+            null
+        }
+        if (organizationId == null || userId == null) {
+            return slackEphemeral("Link your Slack identity in Moneat before declaring an incident.")
+        }
+        val state = root?.get("view")?.jsonObject?.get("state")?.jsonObject?.get("values")?.jsonObject
+        val title = slackViewValue(state, "title")?.trim().orEmpty()
+        val description = slackViewValue(state, "description")?.trim()?.takeIf(String::isNotEmpty)
+        val severity = slackViewValue(state, "severity")?.trim()?.takeIf(String::isNotEmpty) ?: "SEV-3"
+        if (title.isBlank()) return slackViewErrors(mapOf("title" to "Incident title is required."))
+        val resourceId = declareIncident(
+            OnCallIncidentDeclaration(
+                organizationId = organizationId,
+                userId = userId,
+                alertId = null,
+                title = title,
+                description = description,
+                severity = severity,
+                commandKey = "slack:${deliveryId ?: Uuid.random()}",
+                origin = "SLACK",
+            ),
+        )
+        logger.info { "Declared incident $resourceId from Slack for organization $organizationId" }
+        return buildJsonObject { put("response_action", "clear") }.toString()
+    }
 
     override fun getIncident(
         incidentId: Int,
@@ -355,3 +483,98 @@ class OnCallModule :
         userId: Int,
     ): Boolean = onCallAlertService.acknowledge(alertId, userId)
 }
+
+private fun slackEphemeral(message: String): String =
+    buildJsonObject {
+        put("response_type", "ephemeral")
+        put("text", message)
+    }.toString()
+
+internal fun slackViewErrors(errors: Map<String, String>): String =
+    buildJsonObject {
+        put("response_action", "errors")
+        putJsonObject("errors") {
+            errors.forEach { (blockId, message) -> put(blockId, message) }
+        }
+    }.toString()
+
+internal fun slackViewValue(values: JsonObject?, blockId: String): String? {
+    val block = values?.get(blockId)?.jsonObject ?: return null
+    val action = block.values.firstOrNull()?.jsonObject ?: return null
+    return action["value"]?.jsonPrimitive?.contentOrNull
+        ?: action["selected_option"]?.jsonObject?.get("value")?.jsonPrimitive?.contentOrNull
+}
+
+internal fun slackIncidentDeclarationView(prefill: String?): JsonObject =
+    buildJsonObject {
+        put("type", "modal")
+        put("callback_id", "moneat_incident_declaration")
+        putJsonObject("title") {
+            put("type", "plain_text")
+            put("text", "Declare incident")
+        }
+        putJsonObject("submit") {
+            put("type", "plain_text")
+            put("text", "Declare")
+        }
+        putJsonArray("blocks") {
+            addJsonObject {
+                put("type", "input")
+                put("block_id", "title")
+                putJsonObject("label") {
+                    put("type", "plain_text")
+                    put("text", "Title")
+                }
+                putJsonObject("element") {
+                    put("type", "plain_text_input")
+                    put("action_id", "value")
+                    prefill?.trim()?.takeIf(String::isNotEmpty)
+                        ?.let { put("initial_value", it.take(SLACK_TITLE_PREFILL_MAX_CHARS)) }
+                }
+            }
+            addJsonObject {
+                put("type", "input")
+                put("block_id", "description")
+                putJsonObject("label") {
+                    put("type", "plain_text")
+                    put("text", "Description")
+                }
+                putJsonObject("element") {
+                    put("type", "plain_text_input")
+                    put("action_id", "value")
+                    put("multiline", true)
+                    put("optional", true)
+                }
+            }
+            addJsonObject {
+                put("type", "input")
+                put("block_id", "severity")
+                putJsonObject("label") {
+                    put("type", "plain_text")
+                    put("text", "Severity")
+                }
+                putJsonObject("element") {
+                    put("type", "static_select")
+                    put("action_id", "value")
+                    putJsonObject("initial_option") {
+                        put("text", buildJsonObject {
+                            put("type", "plain_text")
+                            put("text", "SEV-3")
+                        })
+                        put("value", "SEV-3")
+                    }
+                    putJsonArray("options") {
+                        listOf("SEV-1", "SEV-2", "SEV-3", "SEV-4").forEach { severity ->
+                            addJsonObject {
+                                putJsonObject("text") {
+                                    put("type", "plain_text")
+                                    put("text", severity)
+                                }
+                                put("value", severity)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/SlackIncidentDeclarationViewTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/SlackIncidentDeclarationViewTest.kt
@@ -1,0 +1,75 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.oncall
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import org.junit.jupiter.api.Test
+import kotlinx.coroutines.runBlocking
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SlackIncidentDeclarationViewTest {
+    @Test
+    fun `declaration modal preserves context and offers supported severities`() {
+        val view = slackIncidentDeclarationView("Checkout API is timing out")
+        val blocks = view["blocks"]?.jsonArray
+
+        assertEquals("moneat_incident_declaration", view["callback_id"]?.toString()?.trim('"'))
+        assertEquals("Checkout API is timing out", blocks?.first()?.jsonObject?.get("element")
+            ?.jsonObject?.get("initial_value")?.toString()?.trim('"'))
+        assertEquals(3, blocks?.size)
+        assertNotNull(blocks?.last()?.jsonObject?.get("element")?.jsonObject?.get("options"))
+    }
+
+    @Test
+    fun `view value reader handles plain and selected option inputs`() {
+        val values = Json.parseToJsonElement(
+            """
+            {
+              "title": {"value": {"type": "plain_text_input", "value": "Database outage"}},
+              "severity": {"value": {"type": "static_select", "selected_option": {"value": "SEV-1"}}}
+            }
+            """,
+        ).jsonObject
+
+        assertEquals("Database outage", slackViewValue(values, "title"))
+        assertEquals("SEV-1", slackViewValue(values, "severity"))
+    }
+
+    @Test
+    fun `view errors keep the modal open for mobile correction`() {
+        val response = Json.parseToJsonElement(slackViewErrors(mapOf("title" to "Required"))).jsonObject
+
+        assertEquals("errors", response["response_action"]?.toString()?.trim('"'))
+        assertEquals("Required", response["errors"]?.jsonObject?.get("title")?.toString()?.trim('"'))
+    }
+
+    @Test
+    fun `event and mention deliveries do not open incident forms`() = runBlocking {
+        val module = OnCallModule()
+
+        assertNull(module.handleSlackInbound("events", "", null))
+        assertNull(module.handleSlackInbound("mentions", "", null))
+    }
+
+    @Test
+    fun `slash and interaction requests require workspace identity`() = runBlocking {
+        val module = OnCallModule()
+
+        val slashResponse = module.handleSlackInbound("commands", "", null)
+        val interactionResponse = module.handleSlackInbound(
+            "interactions",
+            "payload=%7B%22type%22%3A%22view_submission%22%7D",
+            null,
+        )
+
+        assertTrue(slashResponse?.contains("workspace and user context") == true)
+        assertTrue(interactionResponse?.contains("Link your Slack identity") == true)
+    }
+}


### PR DESCRIPTION
## Summary
- route authenticated Slack commands, shortcuts, and incident actions into the native declaration flow
- open a validated declaration modal with context prefill and severity choices
- persist Slack declarations through the canonical incident command with idempotent delivery keys

## Validation
- ./gradlew :ee:detekt :ee:test --tests com.moneat.enterprise.oncall.SlackIncidentDeclarationViewTest --no-daemon
- ./gradlew :features:org:test --tests com.moneat.routes.IntegrationRoutesTest --no-daemon
- ./gradlew :ee:compileKotlin :compileKotlin --no-daemon
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Slack-based incident declaration through an interactive modal.
  - Added support for opening Slack modals and submitting incident details.
  - Incident declarations now record their originating channel.
  - Slack responses provide validation feedback and preserve forms for corrections.
  - Added workspace validation and support for severity selection and title prefilling.

- **Bug Fixes**
  - Improved handling of unsupported Slack events, duplicate deliveries, and invalid requests.

- **Tests**
  - Added coverage for modal fields, severity selection, value extraction, workspace validation, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->