### PR TITLE
feat(slack): add incident announcement cards

### DIFF
--- a/backend/src/main/kotlin/com/moneat/notifications/services/SlackOutboundDeliveryService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/SlackOutboundDeliveryService.kt
@@ -59,6 +59,7 @@ data class SlackOutboundDelivery(
     val payload: String,
     val desiredVersion: Int,
     val attemptCount: Int,
+    val providerMessageTs: String? = null,
 )
 
 sealed interface SlackOutboundSendResult {
@@ -234,6 +235,14 @@ class SlackOutboundDeliveryService(
         return resourceId
     }
 
+    fun find(resourceId: String): SlackOutboundDelivery? = transaction {
+        SlackOutboundDeliveries
+            .selectAll()
+            .where { SlackOutboundDeliveries.resourceId eq Uuid.parse(resourceId) }
+            .singleOrNull()
+            ?.toDelivery()
+    }
+
     suspend fun process(resourceId: String, sender: SlackOutboundSender): Boolean {
         val delivery = claim(resourceId) ?: return false
         return when (val result = sender.send(delivery)) {
@@ -399,6 +408,7 @@ class SlackOutboundDeliveryService(
             payload = this[SlackOutboundDeliveries.payload],
             desiredVersion = this[SlackOutboundDeliveries.desiredVersion],
             attemptCount = this[SlackOutboundDeliveries.attemptCount] + 1,
+            providerMessageTs = this[SlackOutboundDeliveries.providerMessageTs],
         )
 
     companion object {

--- a/backend/src/main/kotlin/com/moneat/shared/models/SlackOutboundModels.kt
+++ b/backend/src/main/kotlin/com/moneat/shared/models/SlackOutboundModels.kt
@@ -24,6 +24,7 @@ import kotlin.uuid.Uuid
 
 enum class SlackOutboundOperation(val wire: String, val endpoint: String) {
     MESSAGE("MESSAGE", "chat.postMessage"),
+    MESSAGE_UPDATE("MESSAGE_UPDATE", "chat.update"),
     CHANNEL_CREATE("CHANNEL_CREATE", "conversations.create"),
     CHANNEL_UPDATE("CHANNEL_UPDATE", "conversations.rename"),
     INVITE("INVITE", "conversations.invite"),

--- a/backend/src/main/resources/db/migration/V171__incident_slack_announcements.sql
+++ b/backend/src/main/resources/db/migration/V171__incident_slack_announcements.sql
@@ -1,0 +1,52 @@
+-- Versioned incident announcement rules and durable Slack card state.
+CREATE TABLE native_incident_announcement_rules (
+    id SERIAL PRIMARY KEY,
+    resource_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    name VARCHAR(160) NOT NULL,
+    version INTEGER NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    team_id VARCHAR(255),
+    channel_id VARCHAR(255),
+    announce_triage BOOLEAN NOT NULL DEFAULT FALSE,
+    allow_private BOOLEAN NOT NULL DEFAULT FALSE,
+    allow_test BOOLEAN NOT NULL DEFAULT FALSE,
+    conditions JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_native_incident_announcement_rule_resource UNIQUE (organization_id, resource_id),
+    CONSTRAINT uq_native_incident_announcement_rule_version UNIQUE (organization_id, name, version)
+);
+
+CREATE INDEX idx_native_incident_announcement_rule_enabled
+    ON native_incident_announcement_rules(organization_id, enabled);
+
+CREATE TABLE native_incident_announcements (
+    id SERIAL PRIMARY KEY,
+    resource_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    incident_id INTEGER NOT NULL REFERENCES on_call_incidents(id) ON DELETE CASCADE,
+    rule_key VARCHAR(160) NOT NULL,
+    rule_version INTEGER NOT NULL,
+    team_id VARCHAR(255) NOT NULL,
+    channel_id VARCHAR(255) NOT NULL,
+    desired_version INTEGER NOT NULL,
+    event_type VARCHAR(80) NOT NULL,
+    state VARCHAR(24) NOT NULL DEFAULT 'PENDING',
+    delivery_resource_id UUID,
+    provider_message_ts VARCHAR(64),
+    thread_message_ts VARCHAR(64),
+    card_payload TEXT NOT NULL,
+    last_error TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_native_incident_announcement_resource UNIQUE (organization_id, resource_id),
+    CONSTRAINT uq_native_incident_announcement_destination
+        UNIQUE (organization_id, incident_id, rule_key, team_id, channel_id),
+    CONSTRAINT chk_native_incident_announcement_state
+        CHECK (state IN ('PENDING', 'ACTIVE', 'FAILED', 'ARCHIVED'))
+);
+
+CREATE INDEX idx_native_incident_announcement_incident
+    ON native_incident_announcements(organization_id, incident_id, desired_version);

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/announcements/IncidentAnnouncementModels.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/announcements/IncidentAnnouncementModels.kt
@@ -1,0 +1,101 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.incidents.announcements
+
+import com.moneat.enterprise.oncall.models.OnCallIncidents
+import com.moneat.enterprise.oncall.models.requiredJsonb
+import com.moneat.shared.models.Organizations
+import kotlinx.serialization.Serializable
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
+import org.jetbrains.exposed.v1.datetime.timestamp
+import kotlin.time.Clock
+import kotlin.uuid.Uuid
+
+/** Conditions are evaluated against the canonical incident snapshot, never against an alert route. */
+@Serializable
+data class IncidentAnnouncementRuleConditions(
+    val incidentTypes: Set<String> = emptySet(),
+    val severities: Set<String> = emptySet(),
+    val services: Set<String> = emptySet(),
+    val teams: Set<String> = emptySet(),
+    val fields: Map<String, Set<String>> = emptyMap(),
+    val visibilities: Set<String> = emptySet(),
+)
+
+data class IncidentAnnouncementContext(
+    val incidentType: String?,
+    val severity: String?,
+    val service: String?,
+    val team: String?,
+    val fields: Map<String, String>,
+    val visibility: String,
+    val mode: String,
+    val status: String,
+)
+
+fun IncidentAnnouncementRuleConditions.matches(context: IncidentAnnouncementContext): Boolean =
+    (incidentTypes.isEmpty() || incidentTypes.contains(context.incidentType)) &&
+        (severities.isEmpty() || severities.contains(context.severity)) &&
+        (services.isEmpty() || services.contains(context.service)) &&
+        (teams.isEmpty() || teams.contains(context.team)) &&
+        (visibilities.isEmpty() || visibilities.contains(context.visibility)) &&
+        fields.all { (key, values) -> values.isEmpty() || values.contains(context.fields[key]) }
+
+object NativeIncidentAnnouncementRules : IntIdTable("native_incident_announcement_rules") {
+    val resourceId = uuid("resource_id").clientDefault { Uuid.random() }
+    val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
+    val name = varchar("name", 160)
+    val version = integer("version")
+    val enabled = bool("enabled").default(true)
+    val teamId = varchar("team_id", 255).nullable()
+    val channelId = varchar("channel_id", 255).nullable()
+    val announceTriage = bool("announce_triage").default(false)
+    val allowPrivate = bool("allow_private").default(false)
+    val allowTest = bool("allow_test").default(false)
+    val conditions = requiredJsonb("conditions")
+    val createdBy = integer("created_by").nullable()
+    val createdAt = timestamp("created_at").clientDefault { Clock.System.now() }
+    val updatedAt = timestamp("updated_at").clientDefault { Clock.System.now() }
+
+    init {
+        uniqueIndex(organizationId, resourceId)
+        uniqueIndex(organizationId, name, version)
+    }
+}
+
+enum class IncidentAnnouncementState(val wire: String) {
+    PENDING("PENDING"),
+    ACTIVE("ACTIVE"),
+    FAILED("FAILED"),
+    ARCHIVED("ARCHIVED"),
+}
+
+/** One stable card per incident/rule/destination; desiredVersion makes retries converge. */
+object NativeIncidentAnnouncements : IntIdTable("native_incident_announcements") {
+    val resourceId = uuid("resource_id").clientDefault { Uuid.random() }
+    val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
+    val incidentId = integer("incident_id").references(OnCallIncidents.id, onDelete = ReferenceOption.CASCADE)
+    val ruleKey = varchar("rule_key", 160)
+    val ruleVersion = integer("rule_version")
+    val teamId = varchar("team_id", 255)
+    val channelId = varchar("channel_id", 255)
+    val desiredVersion = integer("desired_version")
+    val eventType = varchar("event_type", 80)
+    val state = varchar("state", 24).default(IncidentAnnouncementState.PENDING.wire)
+    val deliveryResourceId = uuid("delivery_resource_id").nullable()
+    val providerMessageTs = varchar("provider_message_ts", 64).nullable()
+    val threadMessageTs = varchar("thread_message_ts", 64).nullable()
+    val cardPayload = text("card_payload")
+    val lastError = text("last_error").nullable()
+    val createdAt = timestamp("created_at").clientDefault { Clock.System.now() }
+    val updatedAt = timestamp("updated_at").clientDefault { Clock.System.now() }
+
+    init {
+        uniqueIndex(organizationId, resourceId)
+        uniqueIndex(organizationId, incidentId, ruleKey, teamId, channelId)
+        index(false, organizationId, incidentId, desiredVersion)
+    }
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/announcements/IncidentAnnouncementService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/announcements/IncidentAnnouncementService.kt
@@ -1,0 +1,568 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.incidents.announcements
+
+import com.moneat.enterprise.incidents.events.NativeIncidentDomainEvent
+import com.moneat.enterprise.incidents.models.NativeIncidentStatus
+import com.moneat.enterprise.oncall.models.OnCallIncidents
+import com.moneat.config.EnvConfig
+import com.moneat.notifications.services.SlackOutboundDeliveryService
+import com.moneat.notifications.services.SlackOutboundEnqueueRequest
+import com.moneat.shared.models.OrganizationIntegrations
+import com.moneat.shared.models.SlackOutboundOperation
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.put
+import kotlinx.serialization.Serializable
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.isNotNull
+import org.jetbrains.exposed.v1.jdbc.insertIgnore
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import kotlin.time.Clock
+import kotlin.uuid.Uuid
+
+class IncidentAnnouncementService(
+    private val outboundDeliveryService: SlackOutboundDeliveryService = SlackOutboundDeliveryService(),
+    private val enqueue: ((SlackOutboundEnqueueRequest) -> String)? = null,
+    private val clock: Clock = Clock.System,
+) {
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    fun listRules(organizationId: Int): List<IncidentAnnouncementRuleDefinition> = transaction {
+        NativeIncidentAnnouncementRules
+            .selectAll()
+            .where { NativeIncidentAnnouncementRules.organizationId eq organizationId }
+            .sortedWith(
+                compareBy(
+                    { it[NativeIncidentAnnouncementRules.name] },
+                    { it[NativeIncidentAnnouncementRules.version] },
+                ),
+            )
+            .map(::ruleDefinition)
+    }
+
+    fun createRule(
+        organizationId: Int,
+        actorUserId: Int,
+        request: CreateIncidentAnnouncementRule,
+    ): IncidentAnnouncementRuleDefinition = transaction {
+        require(request.name.isNotBlank() && request.name.length <= MAX_RULE_NAME_LENGTH) {
+            "Announcement rule name is required and must be at most $MAX_RULE_NAME_LENGTH characters"
+        }
+        require(request.channelId.isNullOrBlank() || !request.teamId.isNullOrBlank()) {
+            "A Slack team is required when a channel is specified"
+        }
+        val version = NativeIncidentAnnouncementRules
+            .selectAll()
+            .where { NativeIncidentAnnouncementRules.organizationId eq organizationId }
+            .filter { it[NativeIncidentAnnouncementRules.name] == request.name.trim() }
+            .maxOfOrNull { it[NativeIncidentAnnouncementRules.version] }
+            ?.plus(1) ?: 1
+        val id = NativeIncidentAnnouncementRules.insertIgnore {
+            it[resourceId] = Uuid.random()
+            it[NativeIncidentAnnouncementRules.organizationId] = organizationId
+            it[name] = request.name.trim()
+            it[NativeIncidentAnnouncementRules.version] = version
+            it[enabled] = request.enabled
+            it[teamId] = request.teamId?.trim()?.takeIf(String::isNotEmpty)
+            it[channelId] = request.channelId?.trim()?.takeIf(String::isNotEmpty)
+            it[announceTriage] = request.announceTriage
+            it[allowPrivate] = request.allowPrivate
+            it[allowTest] = request.allowTest
+            it[conditions] = mapOf(
+                "rules" to json.encodeToJsonElement(
+                    IncidentAnnouncementRuleConditions.serializer(),
+                    request.conditions,
+                ),
+            )
+            it[createdBy] = actorUserId
+            it[createdAt] = clock.now()
+            it[updatedAt] = clock.now()
+        }.insertedCount
+        require(id == 1) { "Announcement rule could not be created" }
+        NativeIncidentAnnouncementRules
+            .selectAll()
+            .where {
+                (NativeIncidentAnnouncementRules.organizationId eq organizationId) and
+                    (NativeIncidentAnnouncementRules.name eq request.name.trim()) and
+                    (NativeIncidentAnnouncementRules.version eq version)
+            }
+            .single()
+            .let(::ruleDefinition)
+    }
+
+    suspend fun consume(event: NativeIncidentDomainEvent, deliveryKey: String) {
+        require(deliveryKey.isNotBlank()) { "Incident announcement delivery key is required" }
+        val snapshot = snapshot(event) ?: return
+        if (!shouldAnnounce(event, snapshot)) return
+        destinations(event.organizationId).forEach { destination ->
+            if (event.eventType == "INCIDENT_DECLARE" &&
+                snapshot.status == NativeIncidentStatus.TRIAGE.wire &&
+                !destination.announceTriage
+            ) {
+                return@forEach
+            }
+            if (!destination.conditions.matches(snapshot.context) || !destination.allowed(snapshot)) return@forEach
+            announce(event, snapshot, destination)
+        }
+    }
+
+    private fun announce(
+        event: NativeIncidentDomainEvent,
+        snapshot: IncidentSnapshot,
+        destination: AnnouncementDestination,
+    ) {
+        val existing = transaction {
+            NativeIncidentAnnouncements
+                .selectAll()
+                .where {
+                    (NativeIncidentAnnouncements.organizationId eq event.organizationId) and
+                        (NativeIncidentAnnouncements.incidentId eq event.incidentId) and
+                        (NativeIncidentAnnouncements.ruleKey eq destination.ruleKey) and
+                        (NativeIncidentAnnouncements.teamId eq destination.teamId) and
+                        (NativeIncidentAnnouncements.channelId eq destination.channelId)
+                }
+                .singleOrNull()
+        }
+        if (existing != null && existing[NativeIncidentAnnouncements.desiredVersion] >= event.aggregateVersion) return
+        val previousTs = existing?.get(NativeIncidentAnnouncements.providerMessageTs)
+            ?: existing?.get(NativeIncidentAnnouncements.deliveryResourceId)?.toString()?.let { id ->
+                outboundDeliveryService.find(id)?.providerMessageTs
+            }
+        val isUpdate = previousTs != null
+        val cardPayload = cardPayload(snapshot, destination.channelId, previousTs)
+        val idempotencyKey =
+            "incident:${snapshot.resourceId}:announcement:${destination.ruleKey}:${destination.teamId}" +
+                ":${destination.channelId}:card"
+        val request = SlackOutboundEnqueueRequest(
+            organizationId = event.organizationId,
+            teamId = destination.teamId,
+            channelId = destination.channelId,
+            operation = if (isUpdate) SlackOutboundOperation.MESSAGE_UPDATE else SlackOutboundOperation.MESSAGE,
+            idempotencyKey = idempotencyKey,
+            payload = cardPayload,
+            desiredVersion = event.aggregateVersion,
+        )
+        try {
+            val deliveryId = enqueue(request)
+            persistAnnouncement(event, destination, cardPayload, previousTs, deliveryId)
+            if (previousTs != null && isMaterialUpdate(event.eventType)) {
+                enqueueThread(event, snapshot, destination, previousTs)
+            }
+        } catch (error: Exception) {
+            recordFailure(event, destination, error.message ?: "Slack announcement enqueue failed")
+        }
+    }
+
+    private fun persistAnnouncement(
+        event: NativeIncidentDomainEvent,
+        destination: AnnouncementDestination,
+        cardPayload: String,
+        previousTs: String?,
+        deliveryId: String,
+    ) {
+        transaction {
+            NativeIncidentAnnouncements.insertIgnore {
+                it[resourceId] = Uuid.random()
+                it[organizationId] = event.organizationId
+                it[incidentId] = event.incidentId
+                it[ruleKey] = destination.ruleKey
+                it[ruleVersion] = destination.ruleVersion
+                it[NativeIncidentAnnouncements.teamId] = destination.teamId
+                it[NativeIncidentAnnouncements.channelId] = destination.channelId
+                it[desiredVersion] = event.aggregateVersion
+                it[eventType] = event.eventType
+                it[state] = IncidentAnnouncementState.PENDING.wire
+                it[deliveryResourceId] = Uuid.parse(deliveryId)
+                it[providerMessageTs] = previousTs
+                it[NativeIncidentAnnouncements.cardPayload] = cardPayload
+                it[createdAt] = clock.now()
+                it[updatedAt] = clock.now()
+            }
+            NativeIncidentAnnouncements.update({ announcementPredicate(event, destination) }) {
+                it[ruleVersion] = destination.ruleVersion
+                it[desiredVersion] = event.aggregateVersion
+                it[eventType] = event.eventType
+                it[state] = announcementState(event.eventType)
+                it[deliveryResourceId] = Uuid.parse(deliveryId)
+                it[providerMessageTs] = previousTs
+                it[NativeIncidentAnnouncements.cardPayload] = cardPayload
+                it[lastError] = null
+                it[updatedAt] = clock.now()
+            }
+        }
+    }
+
+    private fun recordFailure(event: NativeIncidentDomainEvent, destination: AnnouncementDestination, message: String) {
+        transaction {
+            NativeIncidentAnnouncements.update({ announcementPredicate(event, destination) }) {
+                it[state] = IncidentAnnouncementState.FAILED.wire
+                it[lastError] = message.take(MAX_ERROR_LENGTH)
+                it[updatedAt] = clock.now()
+            }
+        }
+    }
+
+    private fun announcementPredicate(
+        event: NativeIncidentDomainEvent,
+        destination: AnnouncementDestination,
+    ) =
+        (NativeIncidentAnnouncements.organizationId eq event.organizationId) and
+            (NativeIncidentAnnouncements.incidentId eq event.incidentId) and
+            (NativeIncidentAnnouncements.ruleKey eq destination.ruleKey) and
+            (NativeIncidentAnnouncements.teamId eq destination.teamId) and
+            (NativeIncidentAnnouncements.channelId eq destination.channelId)
+
+    private fun announcementState(eventType: String): String =
+        if (eventType in TERMINAL_EVENT_TYPES) {
+            IncidentAnnouncementState.ARCHIVED.wire
+        } else {
+            IncidentAnnouncementState.PENDING.wire
+        }
+
+    private fun enqueueThread(
+        event: NativeIncidentDomainEvent,
+        snapshot: IncidentSnapshot,
+        destination: AnnouncementDestination,
+        threadTs: String,
+    ) {
+        val payload = json.encodeToString(
+            buildJsonObject {
+                put("channel", destination.channelId)
+                put("thread_ts", threadTs)
+                put("text", "Incident update: ${snapshot.title}")
+                put("blocks", buildJsonArray {
+                    add(buildJsonObject {
+                        put("type", "section")
+                        put("text", buildJsonObject {
+                            put("type", "mrkdwn")
+                            put("text", "*${event.eventType.replace('_', ' ')}* · version ${event.aggregateVersion}")
+                        })
+                    })
+                })
+            },
+        )
+        val threadKey =
+            "incident:${snapshot.resourceId}:announcement:${destination.ruleKey}:thread:" +
+                event.aggregateVersion
+        enqueue(
+            SlackOutboundEnqueueRequest(
+                organizationId = event.organizationId,
+                teamId = destination.teamId,
+                channelId = destination.channelId,
+                operation = SlackOutboundOperation.MESSAGE,
+                idempotencyKey = threadKey,
+                payload = payload,
+                desiredVersion = event.aggregateVersion,
+            ),
+        )
+    }
+
+    private fun snapshot(event: NativeIncidentDomainEvent): IncidentSnapshot? = transaction {
+        OnCallIncidents.selectAll().where {
+            (OnCallIncidents.organizationId eq event.organizationId) and
+                (OnCallIncidents.id eq event.incidentId)
+        }.singleOrNull()?.let { row ->
+            val fields = row[OnCallIncidents.declarationSnapshot].mapValues { (_, value) -> value.asText() }
+            IncidentSnapshot(
+                resourceId = row[OnCallIncidents.resourceId].toString(),
+                title = row[OnCallIncidents.title],
+                summary = row[OnCallIncidents.summary] ?: row[OnCallIncidents.description],
+                incidentType = row[OnCallIncidents.incidentType],
+                severity = row[OnCallIncidents.severity],
+                status = row[OnCallIncidents.status],
+                mode = row[OnCallIncidents.mode],
+                visibility = row[OnCallIncidents.visibility],
+                reporter = row[OnCallIncidents.declaredBy].toString(),
+                fields = fields,
+            )
+        }
+    }
+
+    private fun destinations(organizationId: Int): List<AnnouncementDestination> = transaction {
+        val configured = NativeIncidentAnnouncementRules.selectAll().where {
+            (NativeIncidentAnnouncementRules.organizationId eq organizationId) and
+                (NativeIncidentAnnouncementRules.enabled eq true)
+        }.map { row ->
+            val conditions = json.decodeFromJsonElement(
+                IncidentAnnouncementRuleConditions.serializer(),
+                row[NativeIncidentAnnouncementRules.conditions]["rules"] as? JsonObject
+                    ?: JsonObject(emptyMap()),
+            )
+            val channel = row[NativeIncidentAnnouncementRules.channelId]
+            val teams = OrganizationIntegrations.selectAll().where {
+                (OrganizationIntegrations.organization_id eq organizationId) and
+                    (OrganizationIntegrations.integration_type eq "slack") and
+                    (OrganizationIntegrations.enabled eq true) and
+                    OrganizationIntegrations.team_id.isNotNull()
+            }.filter { integration ->
+                row[NativeIncidentAnnouncementRules.teamId] == null ||
+                    integration[OrganizationIntegrations.team_id] == row[NativeIncidentAnnouncementRules.teamId]
+            }
+            val integrations = if (channel == null) teams else listOf(null)
+            integrations.mapNotNull { integration ->
+                val resolvedChannel = channel ?: integration?.get(OrganizationIntegrations.channel_id)
+                val team =
+                    row[NativeIncidentAnnouncementRules.teamId] ?: integration?.get(OrganizationIntegrations.team_id)
+                destinationOrNull(row, conditions, team, resolvedChannel)
+            }
+        }.flatten()
+        return@transaction configured.ifEmpty {
+            OrganizationIntegrations.selectAll().where {
+                (OrganizationIntegrations.organization_id eq organizationId) and
+                    (OrganizationIntegrations.integration_type eq "slack") and
+                    (OrganizationIntegrations.enabled eq true) and
+                    OrganizationIntegrations.team_id.isNotNull() and
+                    OrganizationIntegrations.channel_id.isNotNull()
+            }.mapNotNull { row ->
+                val team = row[OrganizationIntegrations.team_id]
+                val channel = row[OrganizationIntegrations.channel_id]
+                if (team.isNullOrBlank() || channel.isNullOrBlank()) null else defaultDestination(team, channel)
+            }
+        }
+    }
+
+    private fun shouldAnnounce(event: NativeIncidentDomainEvent, snapshot: IncidentSnapshot): Boolean {
+        if (event.eventType == "INCIDENT_ROLE_INSTRUCTIONS") return false
+        if (snapshot.mode == "TEST" || snapshot.visibility == "PRIVATE") {
+            return destinations(event.organizationId).any { it.allowPrivate || it.allowTest }
+        }
+        return true
+    }
+
+    private fun cardPayload(snapshot: IncidentSnapshot, channelId: String, messageTs: String?): String =
+        json.encodeToString(
+            buildJsonObject {
+                put("channel", channelId)
+                messageTs?.let { put("ts", it) }
+                put("text", "Incident: ${snapshot.title}")
+                put("blocks", buildJsonArray {
+                    add(buildJsonObject {
+                        put("type", "header")
+                        put("text", buildJsonObject {
+                            put("type", "plain_text")
+                            put("text", "🔥 ${snapshot.title.take(MAX_TITLE_LENGTH)}")
+                            put("emoji", true)
+                        })
+                    })
+                    add(buildJsonObject {
+                        put("type", "section")
+                        put("fields", buildJsonArray {
+                            add(field("Status", snapshot.status))
+                            add(field("Severity", snapshot.severity ?: "Unclassified"))
+                            add(field("Type", snapshot.incidentType ?: "Unclassified"))
+                            add(field("Reporter", snapshot.reporter))
+                            add(field("Channel", channelId))
+                            snapshot.fields.entries.take(MAX_CUSTOM_FIELDS).forEach { (key, value) ->
+                                add(field(key.replace('_', ' ').replaceFirstChar(Char::uppercase), value))
+                            }
+                        })
+                    })
+                    snapshot.summary?.let { summary ->
+                        add(buildJsonObject {
+                            put("type", "section")
+                            put("text", buildJsonObject {
+                                put("type", "mrkdwn")
+                                put("text", summary.take(MAX_SUMMARY_LENGTH))
+                            })
+                        })
+                    }
+                    add(buildJsonObject {
+                        put("type", "context")
+                        put("elements", buildJsonArray {
+                            add(buildJsonObject {
+                                put("type", "mrkdwn")
+                                put("text", "<${homepage(snapshot.resourceId)}|Open incident homepage>")
+                            })
+                        })
+                    })
+                    add(buildJsonObject {
+                        put("type", "actions")
+                        put("elements", buildJsonArray {
+                            add(action("Accept", "incident_accept:${snapshot.resourceId}"))
+                            add(action("Merge", "incident_merge:${snapshot.resourceId}"))
+                            add(action("Decline", "incident_decline:${snapshot.resourceId}"))
+                        })
+                    })
+                })
+            },
+        )
+
+    private fun field(label: String, value: String): JsonObject = buildJsonObject {
+        put("type", "mrkdwn")
+        put("text", "*$label:*\n${value.take(MAX_FIELD_LENGTH)}")
+    }
+
+    private fun action(label: String, actionId: String): JsonObject = buildJsonObject {
+        put("type", "button")
+        put("text", buildJsonObject { put("type", "plain_text"); put("text", label) })
+        put("action_id", actionId)
+        put("value", actionId.substringAfter(':'))
+    }
+
+    private fun JsonElement.asText(): String = (this as? JsonPrimitive)?.contentOrNull.orEmpty()
+
+    private fun homepage(resourceId: String): String =
+        "${EnvConfig.get("FRONTEND_URL", "https://moneat.io")}/on-call/incidents/$resourceId"
+
+    private fun isMaterialUpdate(eventType: String): Boolean =
+        eventType in setOf(
+            "INCIDENT_ACCEPT",
+            "INCIDENT_UPDATE",
+            "INCIDENT_TRANSITION",
+            "INCIDENT_RESOLVE",
+            "INCIDENT_CLOSE",
+            "INCIDENT_CANCEL",
+            "INCIDENT_MERGE",
+        )
+
+    private data class IncidentSnapshot(
+        val resourceId: String,
+        val title: String,
+        val summary: String?,
+        val incidentType: String?,
+        val severity: String?,
+        val status: String,
+        val mode: String,
+        val visibility: String,
+        val reporter: String,
+        val fields: Map<String, String>,
+    ) {
+        val context: IncidentAnnouncementContext
+            get() = IncidentAnnouncementContext(
+                incidentType = incidentType,
+                severity = severity,
+                service = fields["service"],
+                team = fields["team"],
+                fields = fields,
+                visibility = visibility,
+                mode = mode,
+                status = status,
+            )
+    }
+
+    private data class AnnouncementDestination(
+        val ruleKey: String,
+        val ruleVersion: Int,
+        val teamId: String,
+        val channelId: String,
+        val conditions: IncidentAnnouncementRuleConditions,
+        val announceTriage: Boolean,
+        val allowPrivate: Boolean,
+        val allowTest: Boolean,
+    ) {
+        fun allowed(snapshot: IncidentSnapshot): Boolean =
+            (snapshot.mode != "TEST" || allowTest) && (snapshot.visibility != "PRIVATE" || allowPrivate) &&
+                (snapshot.status != NativeIncidentStatus.TRIAGE.wire || announceTriage)
+    }
+
+    private fun enqueue(request: SlackOutboundEnqueueRequest): String =
+        enqueue?.invoke(request) ?: outboundDeliveryService.enqueueAndWake(request)
+
+    companion object {
+        private const val MAX_RULE_NAME_LENGTH = 160
+        private const val MAX_ERROR_LENGTH = 1_000
+        private const val MAX_TITLE_LENGTH = 120
+        private const val MAX_SUMMARY_LENGTH = 1_500
+        private const val MAX_FIELD_LENGTH = 200
+        private const val MAX_CUSTOM_FIELDS = 6
+        private val TERMINAL_EVENT_TYPES =
+            setOf("INCIDENT_RESOLVE", "INCIDENT_CLOSE", "INCIDENT_CANCEL", "INCIDENT_DECLINE", "INCIDENT_MERGE")
+    }
+
+    private fun destinationOrNull(
+        row: org.jetbrains.exposed.v1.core.ResultRow,
+        conditions: IncidentAnnouncementRuleConditions,
+        team: String?,
+        channel: String?,
+    ): AnnouncementDestination? {
+        if (channel.isNullOrBlank() || team.isNullOrBlank()) return null
+        return AnnouncementDestination(
+            ruleKey = row[NativeIncidentAnnouncementRules.resourceId].toString(),
+            ruleVersion = row[NativeIncidentAnnouncementRules.version],
+            teamId = team,
+            channelId = channel,
+            conditions = conditions,
+            announceTriage = row[NativeIncidentAnnouncementRules.announceTriage],
+            allowPrivate = row[NativeIncidentAnnouncementRules.allowPrivate],
+            allowTest = row[NativeIncidentAnnouncementRules.allowTest],
+        )
+    }
+
+    private fun defaultDestination(team: String, channel: String) = AnnouncementDestination(
+        ruleKey = "default:$team:$channel",
+        ruleVersion = 1,
+        teamId = team,
+        channelId = channel,
+        conditions = IncidentAnnouncementRuleConditions(),
+        announceTriage = false,
+        allowPrivate = false,
+        allowTest = false,
+    )
+
+    private fun ruleDefinition(row: org.jetbrains.exposed.v1.core.ResultRow): IncidentAnnouncementRuleDefinition {
+        val conditions = json.decodeFromJsonElement(
+            IncidentAnnouncementRuleConditions.serializer(),
+            row[NativeIncidentAnnouncementRules.conditions]["rules"] ?: JsonObject(emptyMap()),
+        )
+        return IncidentAnnouncementRuleDefinition(
+            id = row[NativeIncidentAnnouncementRules.resourceId].toString(),
+            name = row[NativeIncidentAnnouncementRules.name],
+            version = row[NativeIncidentAnnouncementRules.version],
+            enabled = row[NativeIncidentAnnouncementRules.enabled],
+            teamId = row[NativeIncidentAnnouncementRules.teamId],
+            channelId = row[NativeIncidentAnnouncementRules.channelId],
+            announceTriage = row[NativeIncidentAnnouncementRules.announceTriage],
+            allowPrivate = row[NativeIncidentAnnouncementRules.allowPrivate],
+            allowTest = row[NativeIncidentAnnouncementRules.allowTest],
+            conditions = conditions,
+        )
+    }
+}
+
+@Serializable
+data class CreateIncidentAnnouncementRuleRequest(
+    val name: String,
+    val teamId: String? = null,
+    val channelId: String? = null,
+    val enabled: Boolean = true,
+    val announceTriage: Boolean = false,
+    val allowPrivate: Boolean = false,
+    val allowTest: Boolean = false,
+    val conditions: IncidentAnnouncementRuleConditions = IncidentAnnouncementRuleConditions(),
+)
+
+data class CreateIncidentAnnouncementRule(
+    val name: String,
+    val teamId: String?,
+    val channelId: String?,
+    val enabled: Boolean,
+    val announceTriage: Boolean,
+    val allowPrivate: Boolean,
+    val allowTest: Boolean,
+    val conditions: IncidentAnnouncementRuleConditions,
+)
+
+@Serializable
+data class IncidentAnnouncementRuleDefinition(
+    val id: String,
+    val name: String,
+    val version: Int,
+    val enabled: Boolean,
+    val teamId: String?,
+    val channelId: String?,
+    val announceTriage: Boolean,
+    val allowPrivate: Boolean,
+    val allowTest: Boolean,
+    val conditions: IncidentAnnouncementRuleConditions,
+)

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/events/IncidentAnnouncementEventConsumer.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/events/IncidentAnnouncementEventConsumer.kt
@@ -1,0 +1,17 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.incidents.events
+
+import com.moneat.enterprise.incidents.announcements.IncidentAnnouncementService
+
+class IncidentAnnouncementEventConsumer(
+    private val announcementService: IncidentAnnouncementService = IncidentAnnouncementService(),
+) : NativeIncidentEventConsumer {
+    override val name: String = "incident-announcements"
+
+    override suspend fun consume(event: NativeIncidentDomainEvent, deliveryKey: String) {
+        announcementService.consume(event, deliveryKey)
+    }
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
@@ -22,6 +22,7 @@ import com.moneat.enterprise.incidents.commands.IncidentCommandActor
 import com.moneat.enterprise.incidents.events.IncidentOutboxService
 import com.moneat.enterprise.incidents.events.IncidentOutboxWorker
 import com.moneat.enterprise.incidents.events.IncidentResponseEventConsumer
+import com.moneat.enterprise.incidents.events.IncidentAnnouncementEventConsumer
 import com.moneat.enterprise.incidents.events.IncidentSlackChannelEventConsumer
 import com.moneat.enterprise.incidents.events.WorkflowIncidentEventConsumer
 import com.moneat.enterprise.incidents.response.IncidentResponseActivationService
@@ -154,6 +155,7 @@ class OnCallModule :
                         WorkflowIncidentEventConsumer(),
                         IncidentResponseEventConsumer(incidentResponseActivationService),
                         IncidentSlackChannelEventConsumer(),
+                        IncidentAnnouncementEventConsumer(),
                     ),
                 ),
             )

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/IncidentConfigurationRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/IncidentConfigurationRoutes.kt
@@ -5,6 +5,9 @@
 package com.moneat.enterprise.oncall.routes
 
 import com.moneat.enterprise.incidents.commands.IncidentCommandException
+import com.moneat.enterprise.incidents.announcements.CreateIncidentAnnouncementRule
+import com.moneat.enterprise.incidents.announcements.CreateIncidentAnnouncementRuleRequest
+import com.moneat.enterprise.incidents.announcements.IncidentAnnouncementService
 import com.moneat.enterprise.incidents.commands.IncidentEntitlement
 import com.moneat.enterprise.incidents.config.CreateIncidentCustomField
 import com.moneat.enterprise.incidents.config.CreateIncidentForm
@@ -87,11 +90,13 @@ data class CreateIncidentRoleRequest(
 internal fun Route.registerIncidentConfigurationRoutes(
     service: IncidentConfigurationService,
     responderService: IncidentResponderService,
+    announcementService: IncidentAnnouncementService,
     incidentEntitlement: IncidentEntitlement,
 ) {
     route("/v1/on-call/incident-configuration") {
         authenticate("auth-jwt") {
             installNativeIncidentEntitlementGate("NativeIncidentConfigurationGate", incidentEntitlement)
+            registerIncidentAnnouncementRuleRoutes(announcementService)
             route("/types") {
                 get {
                     val context = call.requireUserContext() ?: return@get
@@ -232,6 +237,38 @@ internal fun Route.registerIncidentConfigurationRoutes(
                         )
                     }
                 }
+            }
+        }
+    }
+}
+
+private fun Route.registerIncidentAnnouncementRuleRoutes(service: IncidentAnnouncementService) {
+    route("/announcement-rules") {
+        get {
+            val context = call.requireUserContext() ?: return@get
+            call.respond(service.listRules(context.organizationId))
+        }
+        post {
+            val context = call.requireIncidentAdminContext() ?: return@post
+            val request = call.receive<CreateIncidentAnnouncementRuleRequest>()
+            call.respondConfigurationFailure {
+                call.respond(
+                    HttpStatusCode.Created,
+                    service.createRule(
+                        organizationId = context.organizationId,
+                        actorUserId = context.userId,
+                        request = CreateIncidentAnnouncementRule(
+                            name = request.name,
+                            teamId = request.teamId,
+                            channelId = request.channelId,
+                            enabled = request.enabled,
+                            announceTriage = request.announceTriage,
+                            allowPrivate = request.allowPrivate,
+                            allowTest = request.allowTest,
+                            conditions = request.conditions,
+                        ),
+                    ),
+                )
             }
         }
     }

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutes.kt
@@ -10,6 +10,7 @@ import com.moneat.alerts.models.AlertEpisodes
 import com.moneat.enterprise.FeatureRegistry
 import com.moneat.enterprise.NativeIncidentEntitlementStatus
 import com.moneat.enterprise.incidents.commands.AcceptIncidentCommand
+import com.moneat.enterprise.incidents.announcements.IncidentAnnouncementService
 import com.moneat.enterprise.incidents.commands.DeclareIncidentCommand
 import com.moneat.enterprise.incidents.commands.DeclineIncidentCommand
 import com.moneat.enterprise.incidents.commands.MergeIncidentCommand
@@ -221,6 +222,7 @@ private data class IncidentRouteServices(
     val alertServiceProvider: () -> OnCallAlertService,
     val incidentService: OnCallIncidentService,
     val configurationService: IncidentConfigurationService,
+    val announcementService: IncidentAnnouncementService,
     val responderService: IncidentResponderService,
     val timelineService: IncidentTimelineService,
     val responseService: IncidentResponseActivationService?,
@@ -241,6 +243,7 @@ fun Route.incidentRoutes(
             alertServiceProvider = alertServiceProvider,
             incidentService = onCallIncidentService,
             configurationService = IncidentConfigurationService(),
+            announcementService = IncidentAnnouncementService(),
             responderService = IncidentResponderService(),
             timelineService = IncidentTimelineService(),
             responseService = incidentResponseActivationService,
@@ -252,6 +255,7 @@ fun Route.incidentRoutes(
     registerIncidentConfigurationRoutes(
         services.configurationService,
         services.responderService,
+        services.announcementService,
         incidentEntitlement,
     )
 }

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/IncidentTestDatabase.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/IncidentTestDatabase.kt
@@ -18,6 +18,8 @@ import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRouteRevisions
 import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRouteTargets
 import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRoutes
 import com.moneat.enterprise.incidents.models.NativeIncidentAlertEpisodeLinks
+import com.moneat.enterprise.incidents.announcements.NativeIncidentAnnouncementRules
+import com.moneat.enterprise.incidents.announcements.NativeIncidentAnnouncements
 import com.moneat.enterprise.incidents.models.NativeIncidentCommands
 import com.moneat.enterprise.incidents.models.NativeIncidentCustomFieldOptions
 import com.moneat.enterprise.incidents.models.NativeIncidentCustomFields
@@ -101,6 +103,8 @@ object IncidentTestDatabase {
             NativeIncidentResponseActivations,
             NativeIncidentResponseTargets,
             NativeIncidentSlackChannels,
+            NativeIncidentAnnouncementRules,
+            NativeIncidentAnnouncements,
             EnterpriseAlertRoutes,
             EnterpriseAlertRouteConditionGroups,
             EnterpriseAlertRouteConditions,

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/announcements/IncidentAnnouncementServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/announcements/IncidentAnnouncementServiceTest.kt
@@ -1,0 +1,161 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.incidents.announcements
+
+import com.moneat.enterprise.incidents.IncidentTestDatabase
+import com.moneat.enterprise.incidents.SeededMember
+import com.moneat.enterprise.incidents.events.NativeIncidentDomainEvent
+import com.moneat.enterprise.incidents.models.NativeIncidentStatus
+import com.moneat.enterprise.oncall.models.OnCallIncidents
+import com.moneat.notifications.services.SlackOutboundEnqueueRequest
+import com.moneat.shared.models.OrganizationIntegrations
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonPrimitive
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+class IncidentAnnouncementServiceTest {
+    private lateinit var member: SeededMember
+    private lateinit var incidentResourceId: Uuid
+    private val now = Instant.parse("2026-08-25T00:00:00Z")
+
+    @BeforeEach
+    fun setUp() {
+        IncidentTestDatabase.reset()
+        member = IncidentTestDatabase.seedMember("announcement-org")
+        incidentResourceId = seedIncident(NativeIncidentStatus.ACTIVE.wire)
+        transaction {
+            OrganizationIntegrations.insert {
+                it[organization_id] = member.organizationId
+                it[integration_type] = "slack"
+                it[access_token] = "token"
+                it[team_id] = "T-announcements"
+                it[channel_id] = "C-announcements"
+                it[enabled] = true
+                it[created_at] = now
+                it[updated_at] = now
+            }
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        IncidentTestDatabase.clearReference()
+    }
+
+    @Test
+    fun `active incident creates one stable card and suppresses same version replay`() = runBlocking {
+        val requests = mutableListOf<SlackOutboundEnqueueRequest>()
+        val service = IncidentAnnouncementService(
+            enqueue = { request -> requests += request; Uuid.random().toString() },
+        )
+        val event = event("INCIDENT_DECLARE", 1, NativeIncidentStatus.ACTIVE.wire)
+
+        service.consume(event, "delivery-1")
+        service.consume(event, "delivery-1")
+
+        assertEquals(1, requests.size)
+        assertEquals("MESSAGE", requests.single().operation.wire)
+        assertTrue(requests.single().payload.contains("incident_accept"))
+        assertTrue(requests.single().payload.contains("Incident summary"))
+        assertEquals(1, transaction { NativeIncidentAnnouncements.selectAll().count() })
+    }
+
+    @Test
+    fun `triage card waits for acceptance unless rule opts in`() = runBlocking {
+        incidentResourceId = seedIncident(NativeIncidentStatus.TRIAGE.wire)
+        val requests = mutableListOf<SlackOutboundEnqueueRequest>()
+        val service = IncidentAnnouncementService(
+            enqueue = { request -> requests += request; Uuid.random().toString() },
+        )
+
+        service.consume(event("INCIDENT_DECLARE", 1, NativeIncidentStatus.TRIAGE.wire), "triage-declare")
+        assertEquals(0, requests.size)
+
+        transaction {
+            OnCallIncidents.update({ OnCallIncidents.resourceId eq incidentResourceId }) {
+                it[OnCallIncidents.status] = NativeIncidentStatus.ACTIVE.wire
+                it[OnCallIncidents.severity] = "SEV-1"
+                it[OnCallIncidents.version] = 2
+            }
+        }
+        service.consume(event("INCIDENT_ACCEPT", 2, NativeIncidentStatus.ACTIVE.wire), "triage-accept")
+        assertEquals(1, requests.size)
+    }
+
+    @Test
+    fun `conditions filter severity service and fields`() {
+        val conditions = IncidentAnnouncementRuleConditions(
+            severities = setOf("SEV-1"),
+            services = setOf("payments"),
+            fields = mapOf("environment" to setOf("production")),
+        )
+        val matching = IncidentAnnouncementContext(
+            incidentType = null,
+            severity = "SEV-1",
+            service = "payments",
+            team = null,
+            fields = mapOf("environment" to "production"),
+            visibility = "ORGANIZATION",
+            mode = "LIVE",
+            status = "ACTIVE",
+        )
+        assertTrue(conditions.matches(matching))
+        assertEquals(false, conditions.matches(matching.copy(severity = "SEV-3")))
+    }
+
+    private fun seedIncident(status: String): Uuid = transaction {
+        val resourceId = Uuid.random()
+        OnCallIncidents.insert {
+            it[OnCallIncidents.resourceId] = resourceId
+            it[organizationId] = member.organizationId
+            it[title] = "Database unavailable"
+            it[description] = "Incident summary"
+            it[severity] = if (status == NativeIncidentStatus.TRIAGE.wire) null else "SEV-1"
+            it[OnCallIncidents.status] = status
+            it[mode] = "LIVE"
+            it[visibility] = "ORGANIZATION"
+            it[incidentType] = "Outage"
+            it[declarationSnapshot] = mapOf("service" to JsonPrimitive("payments"))
+            it[version] = 1
+            it[declaredBy] = member.userId
+            it[declaredAt] = now
+            it[createdAt] = now
+            it[updatedAt] = now
+        }
+        resourceId
+    }
+
+    private fun event(type: String, version: Int, status: String) = NativeIncidentDomainEvent(
+        id = version,
+        resourceId = Uuid.random().toString(),
+        organizationId = member.organizationId,
+        incidentId = transaction {
+            OnCallIncidents
+                .selectAll()
+                .where { OnCallIncidents.resourceId eq incidentResourceId }
+                .single()[OnCallIncidents.id]
+                .value
+        },
+        eventType = type,
+        aggregateVersion = version,
+        idempotencyKey = "event-$version",
+        payload = mapOf(
+            "incidentId" to JsonPrimitive(incidentResourceId.toString()),
+            "status" to JsonPrimitive(status),
+        ),
+        createdAt = now.toString(),
+    )
+}


### PR DESCRIPTION
Summary: versioned incident announcement rules, stable Slack cards, idempotent updates, threaded material updates, and authenticated configuration routes. Validation: enterprise Detekt, focused announcement tests, migration checker, and git diff check. Migration: V171__incident_slack_announcements.sql.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Slack incident announcement rules with configurable destinations, conditions, and announcement options.
  * Added automatic Slack incident announcements with durable status tracking and message updates.
  * Added endpoints to list announcement rules and allow administrators to create them.
  * Added support for filtering announcements by incident properties such as severity, service, team, and visibility.
* **Tests**
  * Added coverage for announcement creation, replay prevention, triage handling, and condition matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->