### PR TITLE
feat(slack): publish interactive alert cards

### DIFF
--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteSlackActionService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteSlackActionService.kt
@@ -1,0 +1,291 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.services
+
+import com.moneat.alerts.models.AlertEpisodes
+import com.moneat.alerts.services.AlertEpisodeService
+import com.moneat.enterprise.alertroutes.commands.AlertGroupActor
+import com.moneat.enterprise.alertroutes.commands.CreateAlertGroupTriageCommand
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertGroupEscalations
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertGroupMembers
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertGroups
+import com.moneat.enterprise.incidents.authorization.SlackIncidentAccessRequest
+import com.moneat.enterprise.incidents.authorization.SlackIncidentAccessStatus
+import com.moneat.enterprise.incidents.authorization.SlackIncidentAction
+import com.moneat.enterprise.incidents.authorization.SlackIncidentAuthorizationService
+import com.moneat.enterprise.incidents.commands.IncidentCommandActor
+import com.moneat.enterprise.incidents.commands.IncidentCommandService
+import com.moneat.enterprise.incidents.commands.SetIncidentParticipationCommand
+import com.moneat.enterprise.incidents.models.IncidentParticipationType
+import com.moneat.enterprise.incidents.models.NativeIncidentVisibility
+import com.moneat.enterprise.oncall.models.OnCallIncidents
+import com.moneat.enterprise.oncall.services.OnCallAlertService
+import com.moneat.notifications.services.SlackIdentityRequest
+import com.moneat.notifications.services.SlackIdentityResolution
+import com.moneat.notifications.services.SlackIdentityResolver
+import com.moneat.notifications.services.SlackInstallationService
+import com.moneat.shared.models.OrganizationIntegrations
+import com.moneat.shared.services.toUuidOrNull
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.uuid.Uuid
+
+private data class AlertActionContext(
+    val groupId: Uuid,
+    val groupVersion: Int,
+    val episodeId: Int,
+    val episodeTitle: String,
+    val incidentId: Int?,
+    val onCallAlertId: Int?,
+)
+
+/** Executes Slack alert-card actions through the canonical alert and incident commands. */
+class AlertRouteSlackActionService(
+    private val slackInstallationService: SlackInstallationService,
+    onCallAlertServiceProvider: () -> OnCallAlertService,
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+    private val identityResolver = SlackIdentityResolver()
+    private val incidentAuthorization = SlackIncidentAuthorizationService()
+    private val incidentCommands = IncidentCommandService()
+    private val alertGroupCommands = AlertGroupCommandService()
+    private val alertEpisodeService = AlertEpisodeService()
+    private val onCallAlertService by lazy(onCallAlertServiceProvider)
+
+    fun handle(payload: String, deliveryId: String?): String? {
+        val root = payloadRoot(payload) ?: return null
+        if (root["type"]?.jsonPrimitive?.contentOrNull != "block_actions") return null
+        val action = root["actions"]?.jsonArray?.firstOrNull()?.jsonObject
+            ?: return response("No action was selected.")
+        val actionId = action["action_id"]?.jsonPrimitive?.contentOrNull
+            ?: return response("This action is unavailable.")
+        val value = action["value"]?.jsonPrimitive?.contentOrNull
+        val teamId = root["team"]?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull
+        val slackUserId = root["user"]?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull
+        val organizationId = teamId?.let(::organizationIdForTeam)
+        val identity = identityResolver.resolve(
+            SlackIdentityRequest(teamId = teamId, userId = slackUserId, organizationId = organizationId),
+        )
+        val resolvedOrganizationId = identity.organizationId
+        val resolvedUserId = identity.userId
+        if (!identity.isMapped || resolvedOrganizationId == null || resolvedUserId == null) {
+            return response(identity.message)
+        }
+        val actionContext = actionContext(actionId, value, resolvedOrganizationId)
+        return dispatchAction(actionId, identity, actionContext, value, deliveryId)
+    }
+
+    private fun dispatchAction(
+        actionId: String,
+        identity: SlackIdentityResolution,
+        context: AlertActionContext?,
+        value: String?,
+        deliveryId: String?,
+    ): String {
+        val organizationId = requireNotNull(identity.organizationId)
+        val userId = requireNotNull(identity.userId)
+        return when (actionId) {
+            "declare_incident" -> declare(organizationId, userId, context, deliveryId)
+            "join_incident" -> join(organizationId, userId, identity, value, deliveryId)
+            "acknowledge_alert" -> acknowledge(identity, context)
+            "silence_alert" -> silence(identity, context)
+            "resolve_alert" -> resolve(identity, context)
+            "confirm_grouping" -> response("This alert is already grouped by the matched route.")
+            "unrelated_alert", "merge_alert_group" ->
+                response("Use the alert group view to review this grouping decision.")
+            else -> response("This alert action is not supported.")
+        }
+    }
+
+    private fun actionContext(actionId: String, value: String?, organizationId: Int): AlertActionContext? =
+        when (actionId) {
+            "declare_incident", "acknowledge_alert", "silence_alert", "resolve_alert" ->
+                value?.let { findByEpisode(organizationId, it) }
+            else -> null
+        }
+
+    private fun organizationIdForTeam(teamId: String): Int? = transaction {
+        OrganizationIntegrations.selectAll().where {
+            (OrganizationIntegrations.integration_type eq "slack") and
+                (OrganizationIntegrations.team_id eq teamId) and
+                (OrganizationIntegrations.enabled eq true)
+        }.firstOrNull()?.get(OrganizationIntegrations.organization_id)
+    }
+
+    private fun declare(
+        organizationId: Int,
+        userId: Int,
+        context: AlertActionContext?,
+        deliveryId: String?,
+    ): String {
+        if (context == null) return response("The alert group is no longer available.")
+        if (context.incidentId != null) return response("This alert group is already linked to an incident.")
+        val result = alertGroupCommands.execute(
+            CreateAlertGroupTriageCommand(
+                commandKey = "slack-alert-declare:${deliveryId ?: Uuid.random()}",
+                actor = AlertGroupActor(organizationId, userId, "SLACK"),
+                groupId = context.groupId,
+                expectedVersion = context.groupVersion,
+                title = context.episodeTitle,
+            ),
+        )
+        return response("Incident ${result.group.incidentId ?: "created"} opened in triage.")
+    }
+
+    private fun join(
+        organizationId: Int,
+        userId: Int,
+        identity: SlackIdentityResolution,
+        value: String?,
+        deliveryId: String?,
+    ): String {
+        val resourceId = value?.toUuidOrNull() ?: return response("This incident is no longer available.")
+        val incident = transaction {
+            OnCallIncidents.selectAll().where {
+                (OnCallIncidents.organizationId eq organizationId) and
+                    (OnCallIncidents.resourceId eq resourceId)
+            }.singleOrNull()
+        } ?: return response("This incident is no longer available.")
+        val incidentId = incident[OnCallIncidents.id].value
+        val visibility = visibility(incident[OnCallIncidents.visibility])
+            ?: return response("This incident has an invalid visibility.")
+        if (visibility == NativeIncidentVisibility.PRIVATE) {
+            val decision = incidentAuthorization.authorize(
+                SlackIncidentAccessRequest(
+                    identity,
+                    organizationId,
+                    incidentId,
+                    visibility,
+                    SlackIncidentAction.RESPOND,
+                ),
+            )
+            if (decision.status != SlackIncidentAccessStatus.ALLOWED) {
+                return response("You are not authorized to join this private incident.")
+            }
+        }
+        incidentCommands.execute(
+            SetIncidentParticipationCommand(
+                commandKey = "slack-alert-join:${deliveryId ?: Uuid.random()}",
+                actor = IncidentCommandActor(organizationId, userId, "SLACK"),
+                incidentId = incidentId,
+                userId = userId,
+                participationType = IncidentParticipationType.PARTICIPANT,
+            ),
+        )
+        return response("You joined the incident.")
+    }
+
+    private fun acknowledge(identity: SlackIdentityResolution, context: AlertActionContext?): String {
+        if (context == null || context.onCallAlertId == null) {
+            return response("No page is attached to this alert group.")
+        }
+        if (!canRespondToIncident(identity, context)) {
+            return response("You are not authorized to acknowledge this alert.")
+        }
+        onCallAlertService.acknowledge(context.onCallAlertId, requireNotNull(identity.userId))
+        return response("Alert acknowledged.")
+    }
+
+    private fun silence(identity: SlackIdentityResolution, context: AlertActionContext?): String {
+        if (context == null) return response("The alert episode is no longer available.")
+        if (!canRespondToIncident(identity, context)) return response("You are not authorized to silence this alert.")
+        alertEpisodeService.suppressEpisode(
+            requireNotNull(identity.organizationId),
+            context.episodeId,
+            identity.userId,
+            "Silenced from Slack",
+        )
+        return response("Alert silenced.")
+    }
+
+    private fun resolve(identity: SlackIdentityResolution, context: AlertActionContext?): String {
+        if (context == null || context.onCallAlertId == null) {
+            return response("No page is attached to this alert group.")
+        }
+        if (!canRespondToIncident(identity, context)) {
+            return response("You are not authorized to resolve this alert.")
+        }
+        onCallAlertService.resolve(context.onCallAlertId, requireNotNull(identity.userId))
+        return response("Alert resolved.")
+    }
+
+    private fun canRespondToIncident(identity: SlackIdentityResolution, context: AlertActionContext): Boolean {
+        val organizationId = requireNotNull(identity.organizationId)
+        val incidentId = context.incidentId ?: return true
+        val incident = transaction {
+            OnCallIncidents.selectAll().where {
+                OnCallIncidents.id eq EntityID(incidentId, OnCallIncidents)
+            }.singleOrNull()
+        } ?: return false
+        val visibility = visibility(incident[OnCallIncidents.visibility]) ?: return false
+        if (visibility != NativeIncidentVisibility.PRIVATE) return true
+        return incidentAuthorization.authorize(
+            SlackIncidentAccessRequest(
+                identity = identity,
+                organizationId = organizationId,
+                incidentId = incidentId,
+                visibility = visibility,
+                action = SlackIncidentAction.RESPOND,
+            ),
+        ).allowed
+    }
+
+    private fun findByEpisode(organizationId: Int, resourceId: String): AlertActionContext? {
+        val episodeResourceId = resourceId.toUuidOrNull() ?: return null
+        return transaction {
+            val episode = AlertEpisodes.selectAll().where {
+                (AlertEpisodes.organizationId eq organizationId) and
+                    (AlertEpisodes.resourceId eq episodeResourceId)
+            }.singleOrNull() ?: return@transaction null
+            val episodeId = episode[AlertEpisodes.id].value
+            val member = EnterpriseAlertGroupMembers.selectAll().where {
+                (EnterpriseAlertGroupMembers.organizationId eq organizationId) and
+                    (EnterpriseAlertGroupMembers.alertEpisodeId eq episodeId)
+            }.singleOrNull() ?: return@transaction null
+            val group = EnterpriseAlertGroups.selectAll().where {
+                (EnterpriseAlertGroups.organizationId eq organizationId) and
+                    (EnterpriseAlertGroups.id eq member[EnterpriseAlertGroupMembers.groupId])
+            }.singleOrNull() ?: return@transaction null
+            val escalation = EnterpriseAlertGroupEscalations.selectAll().where {
+                (EnterpriseAlertGroupEscalations.organizationId eq organizationId) and
+                    (EnterpriseAlertGroupEscalations.groupId eq group[EnterpriseAlertGroups.id].value)
+            }.firstOrNull()
+            AlertActionContext(
+                groupId = group[EnterpriseAlertGroups.resourceId],
+                groupVersion = group[EnterpriseAlertGroups.version],
+                episodeId = episodeId,
+                episodeTitle = episode[AlertEpisodes.title].orEmpty(),
+                incidentId = group[EnterpriseAlertGroups.incidentId],
+                onCallAlertId = escalation?.get(EnterpriseAlertGroupEscalations.onCallAlertId),
+            )
+        }
+    }
+
+    private fun payloadRoot(payload: String): JsonObject? {
+        val root = payload.trimStart()
+        if (root.startsWith("{")) return runCatching { json.parseToJsonElement(root).jsonObject }.getOrNull()
+        val encoded = io.ktor.http.parseQueryString(payload)["payload"] ?: return null
+        return runCatching { json.parseToJsonElement(encoded).jsonObject }.getOrNull()
+    }
+
+    private fun visibility(value: String): NativeIncidentVisibility? =
+        NativeIncidentVisibility.entries.firstOrNull { it.wire == value.uppercase() }
+
+    private fun response(message: String): String = buildJsonObject {
+        put("response_type", "ephemeral")
+        put("text", message)
+    }.toString()
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteSlackCardService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteSlackCardService.kt
@@ -1,0 +1,271 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.services
+
+import com.moneat.alerts.services.AlertFanoutContext
+import com.moneat.enterprise.incidents.models.NativeIncidentStatus
+import com.moneat.enterprise.incidents.slack.IncidentSlackChannelState
+import com.moneat.enterprise.incidents.slack.NativeIncidentSlackChannels
+import com.moneat.enterprise.oncall.models.OnCallIncidents
+import com.moneat.notifications.services.SlackOutboundDeliveryService
+import com.moneat.notifications.services.SlackOutboundEnqueueRequest
+import com.moneat.shared.models.OrganizationIntegrations
+import com.moneat.shared.models.SlackOutboundDeliveries
+import com.moneat.shared.models.SlackOutboundOperation
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.addJsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.isNotNull
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.slf4j.LoggerFactory
+import kotlin.uuid.Uuid
+
+private data class SlackCardDestination(
+    val teamId: String?,
+    val channelId: String,
+)
+
+/** Publishes alert state to configured Slack channels without evaluating routes or paging. */
+class AlertRouteSlackCardService(
+    private val outboundDeliveryService: SlackOutboundDeliveryService = SlackOutboundDeliveryService(),
+    private val enqueue: ((SlackOutboundEnqueueRequest) -> String)? = null,
+) {
+    private val logger = LoggerFactory.getLogger(AlertRouteSlackCardService::class.java)
+    private val json = Json { encodeDefaults = true }
+
+    fun publish(context: AlertFanoutContext, outcome: com.moneat.alerts.services.AlertRouteExecutionOutcome) {
+        if (outcome.state != com.moneat.alerts.services.AlertRouteExecutionState.MATCHED) return
+        val episode = context.episode ?: return
+        val groupId = outcome.groupId ?: return
+        val destinations = destinations(context.event.organizationId, outcome.incidentId)
+        destinations.forEach { destination ->
+            if (context.deliverySilenced) return@forEach
+            val version = cardVersion(context)
+            val idempotencyKey =
+                "alert-card:${episode.resourceId}:$groupId:${destination.teamId}:${destination.channelId}"
+            val providerMessageTs = providerMessageTs(context.event.organizationId, idempotencyKey)
+            val request = SlackOutboundEnqueueRequest(
+                organizationId = context.event.organizationId,
+                teamId = destination.teamId,
+                channelId = destination.channelId,
+                operation = if (providerMessageTs == null) {
+                    SlackOutboundOperation.MESSAGE
+                } else {
+                    SlackOutboundOperation.MESSAGE_UPDATE
+                },
+                idempotencyKey = idempotencyKey,
+                payload = cardPayload(context, outcome, destination.channelId, providerMessageTs),
+                desiredVersion = version,
+            )
+            try {
+                if (enqueue != null) {
+                    enqueue.invoke(request)
+                } else {
+                    outboundDeliveryService.enqueueAndWake(request)
+                }
+            } catch (error: Exception) {
+                logger.warn("Unable to enqueue alert Slack card for group {}", groupId, error)
+            }
+        }
+    }
+
+    internal fun cardPayload(
+        context: AlertFanoutContext,
+        outcome: com.moneat.alerts.services.AlertRouteExecutionOutcome,
+        channelId: String,
+        providerMessageTs: String? = null,
+    ): String {
+        val event = context.event
+        val episode = requireNotNull(context.episode)
+        val incident = outcome.incidentId?.let { incidentSnapshot(event.organizationId, it) }
+        val incidentState = incident?.second ?: "Not declared"
+        val owner = event.metadata["team"]?.toString()?.trim('"')
+            ?: event.metadata["service_name"]?.toString()?.trim('"')
+            ?: "Unassigned"
+        val fallback = "${event.priority.wire} alert: ${event.title}"
+        return json.encodeToString(
+            buildJsonObject {
+                put("channel", channelId)
+                providerMessageTs?.let { put("ts", it) }
+                put("text", fallback)
+                putJsonArray("blocks") {
+                    addJsonObject {
+                        put("type", "header")
+                        putJsonObject("text") {
+                            put("type", "plain_text")
+                            put("text", "${priorityEmoji(event.priority.wire)} ${event.title.take(MAX_TITLE_LENGTH)}")
+                            put("emoji", true)
+                        }
+                    }
+                    addJsonObject {
+                        put("type", "section")
+                        putJsonObject("text") {
+                            put("type", "mrkdwn")
+                            put(
+                                "text",
+                                "*Source:* ${event.source.name}\n*Severity:* ${event.priority.wire}" +
+                                    "\n*Owner:* $owner\n*Alert state:* ${event.status.name}" +
+                                    "\n*Incident state:* $incidentState",
+                            )
+                        }
+                    }
+                    addJsonObject {
+                        put("type", "section")
+                        putJsonObject("text") {
+                            put("type", "mrkdwn")
+                            put(
+                                "text",
+                                "*Deduplication:* `${event.deduplicationKey.take(MAX_FIELD_LENGTH)}`\n" +
+                                    "*Episode:* `${episode.episodeKey.take(MAX_FIELD_LENGTH)}`",
+                            )
+                        }
+                    }
+                    addJsonObject {
+                        put("type", "context")
+                        putJsonArray("elements") {
+                            addJsonObject {
+                                put("type", "mrkdwn")
+                                put(
+                                    "text",
+                                    "Alert group `${outcome.groupId}` · route `${outcome.matchedRouteId}` " +
+                                        "(revision ${outcome.matchedRouteRevision ?: 0})",
+                                )
+                            }
+                        }
+                    }
+                    addJsonObject {
+                        put("type", "actions")
+                        putJsonArray("elements") {
+                            add(
+                                action(
+                                    "declare_incident",
+                                    "Declare incident",
+                                    "primary",
+                                    episode.resourceId.toString(),
+                                ),
+                            )
+                            add(action("join_incident", "Join incident", null, outcome.incidentId))
+                            add(action("acknowledge_alert", "Acknowledge", null, episode.resourceId.toString()))
+                            add(action("silence_alert", "Silence", null, episode.resourceId.toString()))
+                            add(action("resolve_alert", "Resolve", null, episode.resourceId.toString()))
+                            add(action("confirm_grouping", "Confirm grouping", null, outcome.groupId))
+                            add(action("unrelated_alert", "Unrelated", "danger", outcome.groupId))
+                            add(action("merge_alert_group", "Merge", null, outcome.groupId))
+                        }
+                    }
+                    addJsonObject {
+                        put("type", "actions")
+                        putJsonArray("elements") {
+                            add(linkButton("Open source", event.moneatUrl))
+                            add(linkButton("Open Moneat", event.moneatUrl))
+                        }
+                    }
+                }
+            },
+        )
+    }
+
+    private fun providerMessageTs(organizationId: Int, idempotencyKey: String): String? = transaction {
+        SlackOutboundDeliveries.selectAll().where {
+            (SlackOutboundDeliveries.organizationId eq organizationId) and
+                (SlackOutboundDeliveries.idempotencyKey eq idempotencyKey)
+        }.singleOrNull()?.get(SlackOutboundDeliveries.providerMessageTs)
+    }
+
+    private fun cardVersion(context: AlertFanoutContext): Int {
+        val sequence = context.episodeDecision?.notificationSequence ?: context.episode?.episodeSeq ?: 0
+        val terminalOffset = if (context.event.status == com.moneat.alerts.models.AlertStatus.RESOLVED) 1 else 0
+        return (sequence * 2 + terminalOffset).coerceAtLeast(1)
+    }
+
+    private fun destinations(
+        organizationId: Int,
+        incidentResourceId: String?,
+    ): List<SlackCardDestination> = transaction {
+        val incident = incidentResourceId?.let { resourceId ->
+            OnCallIncidents.selectAll().where {
+                (OnCallIncidents.organizationId eq organizationId) and
+                    (OnCallIncidents.resourceId eq Uuid.parse(resourceId))
+            }.singleOrNull()
+        }
+        if (incident != null && incident[OnCallIncidents.visibility] == "PRIVATE") {
+            return@transaction NativeIncidentSlackChannels.selectAll().where {
+                (NativeIncidentSlackChannels.organizationId eq organizationId) and
+                    (NativeIncidentSlackChannels.incidentId eq incident[OnCallIncidents.id].value) and
+                    (NativeIncidentSlackChannels.state eq IncidentSlackChannelState.ACTIVE.wire) and
+                    (NativeIncidentSlackChannels.isPrivate eq true) and
+                    NativeIncidentSlackChannels.channelId.isNotNull()
+            }.mapNotNull { row ->
+                row[NativeIncidentSlackChannels.channelId]?.let { channelId ->
+                    SlackCardDestination(row[NativeIncidentSlackChannels.teamId], channelId)
+                }
+            }
+        }
+        OrganizationIntegrations.selectAll().where {
+            (OrganizationIntegrations.organization_id eq organizationId) and
+                (OrganizationIntegrations.integration_type eq "slack") and
+                (OrganizationIntegrations.enabled eq true) and
+                OrganizationIntegrations.channel_id.isNotNull()
+        }.mapNotNull { row ->
+            row[OrganizationIntegrations.channel_id]?.let { channelId ->
+                SlackCardDestination(row[OrganizationIntegrations.team_id], channelId)
+            }
+        }
+    }
+
+    private fun incidentSnapshot(organizationId: Int, resourceId: String): Pair<String, String>? = transaction {
+        OnCallIncidents.selectAll().where {
+            (OnCallIncidents.organizationId eq organizationId) and
+                (OnCallIncidents.resourceId eq Uuid.parse(resourceId))
+        }.singleOrNull()?.let { row ->
+            row[OnCallIncidents.title] to
+                (NativeIncidentStatus.fromWire(row[OnCallIncidents.status])?.wire ?: "UNKNOWN")
+        }
+    }
+
+    private fun action(
+        actionId: String,
+        label: String,
+        style: String?,
+        value: String?,
+    ): JsonObject = buildJsonObject {
+            put("type", "button")
+            put("action_id", actionId)
+            put("text", buildJsonObject {
+                put("type", "plain_text")
+                put("text", label)
+            })
+            style?.let { put("style", it) }
+            value?.let { put("value", it) }
+    }
+
+    private fun linkButton(label: String, url: String): JsonObject = buildJsonObject {
+            put("type", "button")
+            put("text", buildJsonObject {
+                put("type", "plain_text")
+                put("text", label)
+            })
+            put("url", url)
+    }
+
+    private fun priorityEmoji(priority: String): String = when (priority) {
+        "P0" -> "🚨"
+        "P1" -> "🔴"
+        "P2" -> "🟠"
+        else -> "⚠️"
+    }
+
+    private companion object {
+        const val MAX_TITLE_LENGTH = 120
+        const val MAX_FIELD_LENGTH = 180
+    }
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/EnterpriseAlertRouteFanout.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/EnterpriseAlertRouteFanout.kt
@@ -14,6 +14,7 @@ import com.moneat.enterprise.FeatureRegistry
 /** Enterprise route-evaluation arm. Action execution is added by the downstream execution task. */
 class EnterpriseAlertRouteFanout(
     private val executionService: AlertRouteExecutionService = AlertRouteExecutionService(),
+    private val slackCardService: AlertRouteSlackCardService = AlertRouteSlackCardService(),
     private val enabled: (Int) -> Boolean = FeatureRegistry::isNativeIncidentResponseEntitled,
 ) : AlertRouteFanout, AlertRouteOutcomeFanout {
     override suspend fun process(context: AlertFanoutContext) {
@@ -27,6 +28,8 @@ class EnterpriseAlertRouteFanout(
                 reason = "Alert Route entitlement is unavailable for this organization",
             )
         }
-        return executionService.executeWithOutcome(context)
+        val outcome = executionService.executeWithOutcome(context)
+        slackCardService.publish(context, outcome)
+        return outcome
     }
 }

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
@@ -17,6 +17,7 @@ import com.moneat.enterprise.alertroutes.routes.alertGroupRoutes
 import com.moneat.enterprise.alertroutes.services.EnterpriseAlertRouteFanout
 import com.moneat.enterprise.alertroutes.services.AlertRouteExecutionService
 import com.moneat.enterprise.alertroutes.services.AlertRouteRecoveryWorker
+import com.moneat.enterprise.alertroutes.services.AlertRouteSlackActionService
 import com.moneat.enterprise.incidents.commands.DeclareIncidentCommand
 import com.moneat.enterprise.incidents.commands.IncidentCommandActor
 import com.moneat.enterprise.incidents.events.IncidentOutboxService
@@ -135,6 +136,12 @@ class OnCallModule :
         OnCallAlertService(
             escalationEngine = escalationEngine,
             responseActivationService = incidentResponseActivationService,
+        )
+    }
+    private val alertRouteSlackActionService by lazy {
+        AlertRouteSlackActionService(
+            slackInstallationService = slackInstallationService,
+            onCallAlertServiceProvider = { onCallAlertService },
         )
     }
     private val slackUserGroupSyncServiceDelegate =
@@ -339,6 +346,9 @@ class OnCallModule :
             root?.get(key)?.jsonPrimitive?.contentOrNull ?: form[key]
         }
         val type = root?.get("type")?.jsonPrimitive?.contentOrNull
+        if (requestType == "interactions" && type == "block_actions") {
+            return alertRouteSlackActionService.handle(payload, deliveryId)
+        }
         if (requestType == "interactions" && type == "view_submission") {
             return submitSlackIncident(root, value, deliveryId)
         }

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteSlackCardServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteSlackCardServiceTest.kt
@@ -1,0 +1,87 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.services
+
+import com.moneat.alerts.models.AlertLifecycleEvent
+import com.moneat.alerts.models.AlertPriority
+import com.moneat.alerts.models.AlertSource
+import com.moneat.alerts.models.AlertStatus
+import com.moneat.alerts.services.AlertEpisodeContext
+import com.moneat.alerts.services.AlertFanoutContext
+import com.moneat.alerts.services.AlertRouteExecutionOutcome
+import com.moneat.alerts.services.AlertRouteExecutionState
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+class AlertRouteSlackCardServiceTest {
+    @Test
+    fun `card contains alert context and shared action ids`() {
+        val episodeId = Uuid.random()
+        val context = AlertFanoutContext(
+            event = AlertLifecycleEvent(
+                title = "Checkout latency",
+                description = "Requests are timing out",
+                priority = AlertPriority.P1,
+                status = AlertStatus.FIRING,
+                source = AlertSource.UPTIME_MONITOR,
+                deduplicationKey = "checkout:latency",
+                organizationId = 7,
+                moneatUrl = "https://moneat.example/alerts/$episodeId",
+            ),
+            episodeDecision = null,
+            episode = AlertEpisodeContext(
+                id = 1,
+                resourceId = episodeId,
+                organizationId = 7,
+                source = "UPTIME_MONITOR",
+                deduplicationKey = "checkout:latency",
+                title = "Checkout latency",
+                description = "Requests are timing out",
+                priority = "P1",
+                episodeSeq = 1,
+                episodeKey = "checkout:latency#1",
+                status = "FIRING",
+                openedAt = Instant.parse("2026-08-25T00:00:00Z"),
+                lastSeenAt = Instant.parse("2026-08-25T00:00:00Z"),
+                resolvedAt = null,
+                lastNotificationAt = null,
+                notificationCount = 1,
+                suppressedAt = null,
+                suppressedByUserId = null,
+                suppressReason = null,
+            ),
+            deliverySilenced = false,
+        )
+        val outcome = AlertRouteExecutionOutcome(
+            state = AlertRouteExecutionState.MATCHED,
+            matchedRouteId = "route-1",
+            matchedRouteRevision = 3,
+            groupId = "group-1",
+        )
+
+        val payload = Json.parseToJsonElement(
+            AlertRouteSlackCardService().cardPayload(context, outcome, "C123"),
+        ).jsonObject
+        val blocks = payload["blocks"]!!.jsonArray
+        val actions = blocks.filter { it.jsonObject["type"]?.jsonPrimitive?.content == "actions" }
+            .flatMap { it.jsonObject["elements"]!!.jsonArray }
+            .mapNotNull { it.jsonObject["action_id"]?.jsonPrimitive?.content }
+
+        assertEquals("C123", payload["channel"]?.jsonPrimitive?.content)
+        assertTrue("declare_incident" in actions)
+        assertTrue("acknowledge_alert" in actions)
+        assertTrue("confirm_grouping" in actions)
+        assertTrue("unrelated_alert" in actions)
+        assertTrue("merge_alert_group" in actions)
+        assertTrue(payload.toString().contains("checkout:latency"))
+    }
+}

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/SlackIncidentDeclarationViewTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/SlackIncidentDeclarationViewTest.kt
@@ -72,4 +72,17 @@ class SlackIncidentDeclarationViewTest {
         assertTrue(slashResponse?.contains("workspace and user context") == true)
         assertTrue(interactionResponse?.contains("Link your Slack identity") == true)
     }
+
+    @Test
+    fun `alert-card interactions require a linked Slack identity`() = runBlocking {
+        val module = OnCallModule()
+        val response = module.handleSlackInbound(
+            "interactions",
+            "payload=%7B%22type%22%3A%22block_actions%22%2C%22actions%22%3A" +
+                "%5B%7B%22action_id%22%3A%22acknowledge_alert%22%2C%22value%22%3A%22episode%22%7D%5D%7D",
+            "delivery-1",
+        )
+
+        assertTrue(response?.contains("not linked") == true)
+    }
 }


### PR DESCRIPTION
Summary: publish source-neutral alert cards from matched route outcomes, restrict private incident cards to active private channels, and converge Slack message updates through durable delivery. Validation: focused alert-card and announcement tests, Detekt, migration checks, and diff hygiene. No independent route evaluation or paging is performed by card delivery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI assistant runs now support durable progress, resumption, cancellation, approvals, and replay-safe confirmations.
  * Slack interactions can declare incidents, acknowledge, silence, resolve, and join incidents.
  * Added Slack incident-declaration modals with validation and identity checks.
  * Added configurable Slack incident announcement rules and automated incident cards.
  * Alert-route Slack cards now support message updates and action buttons.
* **Bug Fixes**
  * Improved duplicate delivery handling and reliable Slack message tracking.
  * Added safer handling for interrupted AI runs and expired approvals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->