### PR TITLE
fix: remove trivial profile title fallback

### DIFF
--- a/dashboard/src/routes/profiles.$profileId.tsx
+++ b/dashboard/src/routes/profiles.$profileId.tsx
@@ -244,7 +244,7 @@ function ProfileDetailPage() {
           <div className="space-y-0.5 min-w-0">
             <div className="flex items-center gap-2 flex-wrap">
               <h1 className="text-xl font-semibold tracking-tight leading-tight">
-                {profile?.service || 'Profile'}
+                {profile.service}
               </h1>
               {profile && (
                 <Badge


### PR DESCRIPTION
Remove an unreachable profile title fallback flagged by CodeQL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Profile detail headers now display the profile’s service name when available, instead of showing a generic “Profile” label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->