### PR TITLE
feat(incidents): scope private role instructions to assignees

### DIFF
--- a/dashboard/src/components/on-call/IncidentRolesPanel.tsx
+++ b/dashboard/src/components/on-call/IncidentRolesPanel.tsx
@@ -204,6 +204,7 @@ export function IncidentRolesPanel({
           {roleDefinitions.map((role) => {
             const assignment = assignmentByRoleId.get(role.id)
             const assignedToSelf = assignment?.assigneeUserId === currentUserId
+            const privateInstructions = assignedToSelf ? assignment?.role.privateInstructions : undefined
             return (
               <div key={role.id} className="rounded-lg border p-3">
                 <div className="flex items-start justify-between gap-3">
@@ -230,6 +231,16 @@ export function IncidentRolesPanel({
                           </li>
                         ))}
                       </ul>
+                    )}
+                    {privateInstructions && (
+                      <div className="mt-2 rounded-md border border-accent/30 bg-accent/5 p-2">
+                        <p className="text-[11px] font-medium uppercase tracking-wider text-accent-foreground">
+                          Private role instructions
+                        </p>
+                        <p className="mt-1 whitespace-pre-wrap text-xs text-muted-foreground">
+                          {privateInstructions}
+                        </p>
+                      </div>
                     )}
                   </div>
                   <div className="flex-shrink-0 text-right">

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/responders/IncidentResponderService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/responders/IncidentResponderService.kt
@@ -188,7 +188,11 @@ class IncidentResponderService {
                 ?: throw IncidentCommandNotFoundException("Incident role assignment not found")
         }
 
-    fun listAssignments(organizationId: Int, incidentId: Int): List<IncidentRoleAssignment> =
+    fun listAssignments(
+        organizationId: Int,
+        incidentId: Int,
+        viewerUserId: Int? = null,
+    ): List<IncidentRoleAssignment> =
         transaction {
             requireIncident(organizationId, incidentId)
             val rows =
@@ -212,7 +216,7 @@ class IncidentResponderService {
                     id = row[NativeIncidentRoleAssignments.resourceId].toString(),
                     role = roleDefinition(
                         requireRole(row[NativeIncidentRoleAssignments.roleDefinitionId]),
-                        includePrivateInstructions = false,
+                        includePrivateInstructions = viewerUserId == row[NativeIncidentRoleAssignments.assigneeUserId],
                     ),
                     assigneeUserId = checkNotNull(users[row[NativeIncidentRoleAssignments.assigneeUserId]]),
                     assignedByUserId = checkNotNull(users[row[NativeIncidentRoleAssignments.assignedBy]]),

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/IncidentResponderRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/IncidentResponderRoutes.kt
@@ -65,7 +65,7 @@ private fun Route.registerIncidentRoleRoutes(
     get("/{id}/roles") {
         val context = call.requireUserContext() ?: return@get
         val incidentId = call.requireIncidentId(context.organizationId) ?: return@get
-        call.respond(responderService.listAssignments(context.organizationId, incidentId))
+        call.respond(responderService.listAssignments(context.organizationId, incidentId, context.userId))
     }
     post("/{id}/roles/{roleId}/assign") {
         val context = call.requireUserContext() ?: return@post
@@ -84,7 +84,7 @@ private fun Route.registerIncidentRoleRoutes(
                     expectedVersion = request.expectedVersion,
                 ),
             )
-            call.respond(responderService.listAssignments(context.organizationId, incidentId))
+            call.respond(responderService.listAssignments(context.organizationId, incidentId, context.userId))
         }
     }
     post("/{id}/roles/{roleId}/claim") {
@@ -102,7 +102,7 @@ private fun Route.registerIncidentRoleRoutes(
                     expectedVersion = request.expectedVersion,
                 ),
             )
-            call.respond(responderService.listAssignments(context.organizationId, incidentId))
+            call.respond(responderService.listAssignments(context.organizationId, incidentId, context.userId))
         }
     }
     delete("/{id}/roles/{roleId}") {
@@ -146,7 +146,7 @@ private fun Route.registerIncidentRoleRoutes(
                     expectedVersion = request.expectedVersion,
                 ),
             )
-            call.respond(responderService.listAssignments(context.organizationId, incidentId))
+            call.respond(responderService.listAssignments(context.organizationId, incidentId, context.userId))
         }
     }
 }

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/responders/IncidentResponderServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/responders/IncidentResponderServiceTest.kt
@@ -103,6 +103,13 @@ class IncidentResponderServiceTest {
         val assignedRole = service.listAssignments(member.organizationId, incident.incidentId).single()
         assertEquals(secondUserResourceId, assignedRole.assigneeUserId)
         assertEquals(null, assignedRole.role.privateInstructions)
+        assertEquals(
+            "Keep operational details in the private responder thread.",
+            service.listAssignments(member.organizationId, incident.incidentId, secondUserId)
+                .single()
+                .role
+                .privateInstructions,
+        )
 
         commandService.execute(
             HandoverIncidentRoleCommand(

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutesTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutesTest.kt
@@ -280,7 +280,7 @@ class IncidentRoutesTest {
             "claim-commander",
         ).jsonArray()
         assertEquals(1, assignments.size)
-        assertTrue("privateInstructions" !in assignments.single().jsonObject.getValue("role").jsonObject)
+        assertTrue("privateInstructions" in assignments.single().jsonObject.getValue("role").jsonObject)
 
         val participants = postJson(
             "/v1/on-call/incidents/$incidentId/participants",


### PR DESCRIPTION
Summary:
- scope private role instructions to the assigned responder in authenticated incident responses
- render the assigned responder's private instructions in the incident roles panel
- add regression coverage for viewer scoping

Validation:
- ./gradlew :ee:test --tests com.moneat.enterprise.incidents.responders.IncidentResponderServiceTest --no-daemon
- ./gradlew :ee:detekt --no-daemon
- npm run lint
- npm run typecheck