### PR TITLE
feat(incidents): capture Slack alert actions in timeline

### DIFF
--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteSlackActionService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteSlackActionService.kt
@@ -41,6 +41,7 @@ import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.time.Clock
 import kotlin.uuid.Uuid
 
 private data class AlertActionContext(
@@ -61,6 +62,7 @@ class AlertRouteSlackActionService(
     private val identityResolver = SlackIdentityResolver()
     private val incidentAuthorization = SlackIncidentAuthorizationService()
     private val incidentCommands = IncidentCommandService()
+    private val slackTimelineRecorder = SlackIncidentTimelineRecorder()
     private val alertGroupCommands = AlertGroupCommandService()
     private val alertEpisodeService = AlertEpisodeService()
     private val onCallAlertService by lazy(onCallAlertServiceProvider)
@@ -100,9 +102,9 @@ class AlertRouteSlackActionService(
         return when (actionId) {
             "declare_incident" -> declare(organizationId, userId, context, deliveryId)
             "join_incident" -> join(organizationId, userId, identity, value, deliveryId)
-            "acknowledge_alert" -> acknowledge(identity, context)
-            "silence_alert" -> silence(identity, context)
-            "resolve_alert" -> resolve(identity, context)
+            "acknowledge_alert" -> acknowledge(identity, context, deliveryId)
+            "silence_alert" -> silence(identity, context, deliveryId)
+            "resolve_alert" -> resolve(identity, context, deliveryId)
             "confirm_grouping" -> response("This alert is already grouped by the matched route.")
             "unrelated_alert", "merge_alert_group" ->
                 response("Use the alert group view to review this grouping decision.")
@@ -188,38 +190,77 @@ class AlertRouteSlackActionService(
         return response("You joined the incident.")
     }
 
-    private fun acknowledge(identity: SlackIdentityResolution, context: AlertActionContext?): String {
+    private fun acknowledge(
+        identity: SlackIdentityResolution,
+        context: AlertActionContext?,
+        deliveryId: String?,
+    ): String {
         if (context == null || context.onCallAlertId == null) {
             return response("No page is attached to this alert group.")
         }
         if (!canRespondToIncident(identity, context)) {
             return response("You are not authorized to acknowledge this alert.")
         }
-        onCallAlertService.acknowledge(context.onCallAlertId, requireNotNull(identity.userId))
+        val acknowledged = onCallAlertService.acknowledge(context.onCallAlertId, requireNotNull(identity.userId))
+        if (acknowledged) recordSlackAction(identity, context, "SLACK_ALERT_ACKNOWLEDGED", deliveryId)
         return response("Alert acknowledged.")
     }
 
-    private fun silence(identity: SlackIdentityResolution, context: AlertActionContext?): String {
+    private fun silence(
+        identity: SlackIdentityResolution,
+        context: AlertActionContext?,
+        deliveryId: String?,
+    ): String {
         if (context == null) return response("The alert episode is no longer available.")
         if (!canRespondToIncident(identity, context)) return response("You are not authorized to silence this alert.")
-        alertEpisodeService.suppressEpisode(
+        val suppressed = alertEpisodeService.suppressEpisode(
             requireNotNull(identity.organizationId),
             context.episodeId,
             identity.userId,
             "Silenced from Slack",
         )
+        if (suppressed != null) recordSlackAction(identity, context, "SLACK_ALERT_SILENCED", deliveryId)
         return response("Alert silenced.")
     }
 
-    private fun resolve(identity: SlackIdentityResolution, context: AlertActionContext?): String {
+    private fun resolve(
+        identity: SlackIdentityResolution,
+        context: AlertActionContext?,
+        deliveryId: String?,
+    ): String {
         if (context == null || context.onCallAlertId == null) {
             return response("No page is attached to this alert group.")
         }
         if (!canRespondToIncident(identity, context)) {
             return response("You are not authorized to resolve this alert.")
         }
-        onCallAlertService.resolve(context.onCallAlertId, requireNotNull(identity.userId))
+        val resolved = onCallAlertService.resolve(context.onCallAlertId, requireNotNull(identity.userId))
+        if (resolved) recordSlackAction(identity, context, "SLACK_ALERT_RESOLVED", deliveryId)
         return response("Alert resolved.")
+    }
+
+    private fun recordSlackAction(
+        identity: SlackIdentityResolution,
+        context: AlertActionContext,
+        eventType: String,
+        deliveryId: String?,
+    ) {
+        val incidentId = context.incidentId ?: return
+        val organizationId = identity.organizationId ?: return
+        val actorUserId = identity.userId ?: return
+        val observedAt = Clock.System.now()
+        slackTimelineRecorder.record(
+            SlackIncidentTimelineRecord(
+                organizationId = organizationId,
+                incidentId = incidentId,
+                actorUserId = actorUserId,
+                alertEpisodeId = context.episodeId,
+                onCallAlertId = context.onCallAlertId,
+                eventType = eventType,
+                deliveryId = deliveryId,
+                occurredAt = observedAt,
+            ),
+        )
     }
 
     private fun canRespondToIncident(identity: SlackIdentityResolution, context: AlertActionContext): Boolean {

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/SlackIncidentTimelineRecorder.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/SlackIncidentTimelineRecorder.kt
@@ -1,0 +1,56 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.services
+
+import com.moneat.enterprise.incidents.models.IncidentSourceType
+import com.moneat.enterprise.incidents.models.IncidentTimelineProvenance
+import com.moneat.enterprise.incidents.timeline.IncidentTimelineWriter
+import com.moneat.enterprise.incidents.timeline.PendingIncidentTimelineEvent
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+data class SlackIncidentTimelineRecord(
+    val organizationId: Int,
+    val incidentId: Int,
+    val actorUserId: Int,
+    val alertEpisodeId: Int,
+    val onCallAlertId: Int?,
+    val eventType: String,
+    val deliveryId: String?,
+    val occurredAt: Instant,
+)
+
+class SlackIncidentTimelineRecorder(
+    private val timelineWriter: IncidentTimelineWriter = IncidentTimelineWriter(),
+) {
+    fun record(event: SlackIncidentTimelineRecord) {
+        val sourceReference = event.deliveryId?.trim()?.takeIf(String::isNotEmpty)
+            ?: "${event.alertEpisodeId}:${event.eventType}:${event.actorUserId}:${Uuid.random()}"
+        transaction {
+            timelineWriter.record(
+                PendingIncidentTimelineEvent(
+                    organizationId = event.organizationId,
+                    incidentId = event.incidentId,
+                    eventKey = "slack:${event.eventType}:$sourceReference",
+                    eventType = event.eventType,
+                    actorUserId = event.actorUserId,
+                    details = buildJsonObject {
+                        put("origin", IncidentTimelineProvenance.SLACK.wire)
+                        put("action", event.eventType)
+                        put("alertEpisodeId", event.alertEpisodeId)
+                        event.onCallAlertId?.let { put("onCallAlertId", it) }
+                    },
+                    provenance = IncidentTimelineProvenance.SLACK,
+                    originalOccurredAt = event.occurredAt,
+                    sourceType = IncidentSourceType.SLACK_MESSAGE.wire,
+                    sourceReference = sourceReference,
+                ),
+            )
+        }
+    }
+}

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/SlackIncidentTimelineRecorderTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/SlackIncidentTimelineRecorderTest.kt
@@ -1,0 +1,84 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.services
+
+import com.moneat.enterprise.incidents.IncidentTestDatabase
+import com.moneat.enterprise.incidents.SeededMember
+import com.moneat.enterprise.incidents.commands.DeclareIncidentCommand
+import com.moneat.enterprise.incidents.commands.IncidentCommandActor
+import com.moneat.enterprise.incidents.commands.IncidentCommandPolicy
+import com.moneat.enterprise.incidents.commands.IncidentCommandService
+import com.moneat.enterprise.incidents.models.IncidentTimelineProvenance
+import com.moneat.enterprise.oncall.models.OnCallIncidentTimeline
+import com.moneat.enterprise.oncall.models.OnCallIncidents
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.time.Instant
+
+class SlackIncidentTimelineRecorderTest {
+    private lateinit var member: SeededMember
+
+    @BeforeEach
+    fun setUp() {
+        IncidentTestDatabase.reset()
+        member = IncidentTestDatabase.seedMember()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        IncidentTestDatabase.clearReference()
+    }
+
+    @Test
+    fun `records a source-linked Slack action and deduplicates delivery retries`() {
+        val incident = IncidentCommandService(policy = IncidentCommandPolicy.allowForTests()).execute(
+            DeclareIncidentCommand(
+                commandKey = "declare-slack-timeline",
+                actor = IncidentCommandActor(member.organizationId, member.userId, "REST"),
+                title = "Checkout unavailable",
+                description = null,
+                severity = "SEV-2",
+            ),
+        )
+        val occurredAt = Instant.parse("2026-08-25T00:00:00Z")
+        val event = SlackIncidentTimelineRecord(
+            organizationId = member.organizationId,
+            incidentId = incident.incidentId,
+            actorUserId = member.userId,
+            alertEpisodeId = 42,
+            onCallAlertId = 84,
+            eventType = "SLACK_ALERT_ACKNOWLEDGED",
+            deliveryId = "slack-delivery-1",
+            occurredAt = occurredAt,
+        )
+
+        SlackIncidentTimelineRecorder().record(event)
+        SlackIncidentTimelineRecorder().record(event)
+
+        transaction {
+            val timeline = OnCallIncidentTimeline.selectAll().where {
+                (OnCallIncidentTimeline.organizationId eq member.organizationId) and
+                    (OnCallIncidentTimeline.incidentId eq incident.incidentId)
+            }.toList()
+            val slackEntries = timeline.filter { it[OnCallIncidentTimeline.eventType] == event.eventType }
+            assertEquals(1, slackEntries.size)
+            val entry = slackEntries.single()
+            assertEquals(IncidentTimelineProvenance.SLACK.wire, entry[OnCallIncidentTimeline.provenance])
+            assertEquals("SLACK_MESSAGE", entry[OnCallIncidentTimeline.sourceType])
+            assertEquals(event.deliveryId, entry[OnCallIncidentTimeline.sourceReference])
+            assertEquals(occurredAt, entry[OnCallIncidentTimeline.originalOccurredAt])
+            assertNotNull(entry[OnCallIncidentTimeline.actorUserId])
+            assertEquals(incident.incidentId, entry[OnCallIncidentTimeline.incidentId])
+            assertEquals(1, OnCallIncidents.selectAll().single()[OnCallIncidents.version])
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- record successful Slack alert acknowledge, silence, and resolve actions in the incident timeline
- retain Slack provenance, source references, and alert identifiers
- deduplicate retried deliveries by delivery ID

## Tests
- ./gradlew :ee:test --tests com.moneat.enterprise.alertroutes.services.SlackIncidentTimelineRecorderTest --tests com.moneat.enterprise.incidents.commands.IncidentCommandServiceTest --no-daemon
- ./gradlew :ee:detekt --no-daemon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slack-based alert acknowledge, silence, and resolve actions now appear in incident timelines.
  * Timeline entries include the associated incident, alert, actor, delivery, action type, and timestamp.
  * Repeated deliveries are deduplicated to prevent duplicate timeline events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->