### PR TITLE
feat: add Slack incident context and declaration options

### DIFF
--- a/backend/src/main/kotlin/com/moneat/enterprise/OnCallBridge.kt
+++ b/backend/src/main/kotlin/com/moneat/enterprise/OnCallBridge.kt
@@ -117,6 +117,8 @@ data class OnCallIncidentDeclaration(
     val severity: String,
     val commandKey: String,
     val origin: String = "WORKFLOW",
+    val mode: String = "LIVE",
+    val visibility: String = "ORGANIZATION",
     val formDefinitionId: Int? = null,
     val formDefinitionSnapshot: Map<String, JsonElement> = emptyMap(),
     val formValues: Map<String, JsonElement> = emptyMap(),

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
@@ -37,6 +37,11 @@ import com.moneat.enterprise.incidents.config.IncidentFormFieldDefinition
 import com.moneat.enterprise.incidents.config.ResolvedIncidentForm
 import com.moneat.enterprise.incidents.models.IncidentCustomFieldValueType
 import com.moneat.enterprise.incidents.models.IncidentFormStage
+import com.moneat.enterprise.incidents.models.NativeIncidentMode
+import com.moneat.enterprise.incidents.models.NativeIncidentVisibility
+import com.moneat.enterprise.incidents.slack.IncidentSlackChannelState
+import com.moneat.enterprise.incidents.slack.NativeIncidentSlackChannels
+import com.moneat.enterprise.oncall.models.OnCallIncidents
 import com.moneat.enterprise.oncall.routes.deviceRoutes
 import com.moneat.enterprise.oncall.routes.escalationRoutes
 import com.moneat.enterprise.oncall.routes.incidentRoutes
@@ -354,6 +359,8 @@ class OnCallModule :
                     title = declaration.title,
                     description = declaration.description,
                     severity = declaration.severity,
+                    mode = parseIncidentMode(declaration.mode),
+                    visibility = parseIncidentVisibility(declaration.visibility),
                     formDefinitionId = declaration.formDefinitionId,
                     formDefinitionSnapshot = declaration.formDefinitionSnapshot,
                     formValues = declaration.formValues,
@@ -382,14 +389,60 @@ class OnCallModule :
             return submitSlackIncident(root, value, deliveryId)
         }
         if (requestType == "events" || requestType == "mentions") return null
+        slackCommandResponse(requestType, root, value)?.let { return it }
+
+        return openSlackIncident(root, value)
+    }
+
+    private fun slackCommandResponse(
+        requestType: String,
+        root: JsonObject?,
+        value: (String) -> String?,
+    ): String? {
+        if (requestType != "commands" && requestType != "shortcuts") return null
+        incidentResourceIdForSlackChannel(root, value)?.let { return slackIncidentCommandMenu(it) }
         if (requestType == "commands" && value("text")?.trim()?.lowercase() in SLACK_INCIDENT_HELP_COMMANDS) {
             return slackIncidentCommandMenu()
         }
         if (requestType == "shortcuts" && value("callback_id") == SLACK_INCIDENT_MENU_CALLBACK_ID) {
             return slackIncidentCommandMenu()
         }
+        return null
+    }
 
-        return openSlackIncident(root, value)
+    private fun incidentResourceIdForSlackChannel(
+        root: JsonObject?,
+        value: (String) -> String?,
+    ): String? {
+        val channelId = value("channel_id")
+            ?: root?.get("channel")?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull
+        if (channelId.isNullOrBlank()) return null
+        val submitter = resolveSlackSubmitter(root, value, slackInstallationService) ?: return null
+        val teamId = root?.get("team")?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull
+            ?: value("team_id")
+            ?: return null
+        return transaction {
+            val channel = NativeIncidentSlackChannels
+                .selectAll()
+                .where {
+                    (NativeIncidentSlackChannels.organizationId eq submitter.organizationId) and
+                        (NativeIncidentSlackChannels.teamId eq teamId) and
+                        (NativeIncidentSlackChannels.channelId eq channelId) and
+                        (NativeIncidentSlackChannels.state eq IncidentSlackChannelState.ACTIVE.wire)
+                }
+                .firstOrNull()
+                ?: return@transaction null
+            val incidentId = channel[NativeIncidentSlackChannels.incidentId]
+            OnCallIncidents
+                .selectAll()
+                .where {
+                    (OnCallIncidents.id eq incidentId) and
+                        (OnCallIncidents.organizationId eq submitter.organizationId)
+                }
+                .firstOrNull()
+                ?.get(OnCallIncidents.resourceId)
+                ?.toString()
+        }
     }
 
     private suspend fun openSlackIncident(
@@ -450,6 +503,10 @@ class OnCallModule :
         val description = slackViewValue(state, "description")?.trim()?.takeIf(String::isNotEmpty)
         val severity = slackViewValue(state, "severity")?.trim()?.takeIf(String::isNotEmpty) ?: "SEV-3"
         if (title.isBlank()) return slackViewErrors(mapOf("title" to "Incident title is required."))
+        val mode = parseSlackIncidentMode(slackViewValue(state, "mode"))
+            ?: return slackViewErrors(mapOf("mode" to "Choose a supported incident mode."))
+        val visibility = parseSlackIncidentVisibility(slackViewValue(state, "visibility"))
+            ?: return slackViewErrors(mapOf("visibility" to "Choose a supported incident visibility."))
         val resolvedForm = try {
             resolveSlackDeclarationForm(organizationId, state, incidentConfigurationService)
         } catch (error: IllegalArgumentException) {
@@ -464,6 +521,8 @@ class OnCallModule :
                 title = title,
                 description = description,
                 severity = severity,
+                mode = mode.wire,
+                visibility = visibility.wire,
                 commandKey = "slack:${deliveryId ?: Uuid.random()}",
                 origin = "SLACK",
                 formDefinitionId = resolvedForm?.formDefinitionId,
@@ -528,10 +587,10 @@ private fun slackEphemeral(message: String): String =
         put("text", message)
     }.toString()
 
-internal fun slackIncidentCommandMenu(): String =
+internal fun slackIncidentCommandMenu(incidentResourceId: String? = null): String =
     buildJsonObject {
         put("response_type", "ephemeral")
-        put("text", "Incident response commands")
+        put("text", if (incidentResourceId == null) "Incident response commands" else "Incident menu")
         putJsonArray("blocks") {
             addJsonObject {
                 put("type", "header")
@@ -544,10 +603,18 @@ internal fun slackIncidentCommandMenu(): String =
                 put("type", "section")
                 put(
                     "text",
-                    "*Available actions*\n" +
-                        "Overview · update · status · severity · summary · rename · roles · fields\n" +
-                        "Actions · follow-ups · timeline · decision · handover · call · status page\n" +
-                        "Escalation · resolve · cancel · reopen · workflow",
+                    if (incidentResourceId == null) {
+                        "*Available actions*\n" +
+                            "Overview · update · status · severity · summary · rename · roles · fields\n" +
+                            "Actions · follow-ups · timeline · decision · handover · call · status page\n" +
+                            "Escalation · resolve · cancel · reopen · workflow"
+                    } else {
+                        "*Incident menu*\n" +
+                            "Incident `$incidentResourceId`\n" +
+                            "Overview · update · status · severity · summary · rename · roles · fields\n" +
+                            "Actions · follow-ups · timeline · decision · handover · call · status page\n" +
+                            "Escalation · resolve · cancel · reopen · workflow"
+                    },
                 )
             }
             addJsonObject {
@@ -581,6 +648,28 @@ internal fun slackViewValue(values: JsonObject?, blockId: String): String? {
     return action["value"]?.jsonPrimitive?.contentOrNull
         ?: action["selected_option"]?.jsonObject?.get("value")?.jsonPrimitive?.contentOrNull
 }
+
+private fun parseIncidentMode(value: String): NativeIncidentMode =
+    NativeIncidentMode.entries.firstOrNull { it.wire.equals(value.trim(), ignoreCase = true) }
+        ?: throw IllegalArgumentException("Unsupported incident mode")
+
+private fun parseIncidentVisibility(value: String): NativeIncidentVisibility =
+    NativeIncidentVisibility.entries.firstOrNull { it.wire.equals(value.trim(), ignoreCase = true) }
+        ?: throw IllegalArgumentException("Unsupported incident visibility")
+
+private fun parseSlackIncidentMode(value: String?): NativeIncidentMode? =
+    if (value.isNullOrBlank()) {
+        NativeIncidentMode.LIVE
+    } else {
+        NativeIncidentMode.entries.firstOrNull { it.wire.equals(value.trim(), ignoreCase = true) }
+    }
+
+private fun parseSlackIncidentVisibility(value: String?): NativeIncidentVisibility? =
+    if (value.isNullOrBlank()) {
+        NativeIncidentVisibility.ORGANIZATION
+    } else {
+        NativeIncidentVisibility.entries.firstOrNull { it.wire.equals(value.trim(), ignoreCase = true) }
+    }
 
 private fun resolveSlackSubmitter(
     root: JsonObject?,
@@ -678,6 +767,82 @@ internal fun slackIncidentDeclarationView(
                                     put("text", severity)
                                 }
                                 put("value", severity)
+                            }
+                        }
+                    }
+                }
+            }
+            addJsonObject {
+                put("type", "input")
+                put("block_id", "mode")
+                putJsonObject("label") {
+                    put("type", "plain_text")
+                    put("text", "Incident mode")
+                }
+                putJsonObject("hint") {
+                    put("type", "plain_text")
+                    put(
+                        "text",
+                        "Live incidents can page responders. Test and retrospective incidents stay channelless " +
+                            "unless your response policy enables those actions.",
+                    )
+                }
+                putJsonObject("element") {
+                    put("type", "static_select")
+                    put("action_id", "value")
+                    putJsonObject("initial_option") {
+                        putJsonObject("text") {
+                            put("type", "plain_text")
+                            put("text", "Live")
+                        }
+                        put("value", NativeIncidentMode.LIVE.wire)
+                    }
+                    putJsonArray("options") {
+                        listOf(
+                            NativeIncidentMode.LIVE to "Live",
+                            NativeIncidentMode.RETROSPECTIVE to "Retrospective",
+                            NativeIncidentMode.TEST to "Test",
+                        ).forEach { (mode, label) ->
+                            addJsonObject {
+                                putJsonObject("text") {
+                                    put("type", "plain_text")
+                                    put("text", label)
+                                }
+                                put("value", mode.wire)
+                            }
+                        }
+                    }
+                }
+            }
+            addJsonObject {
+                put("type", "input")
+                put("block_id", "visibility")
+                putJsonObject("label") {
+                    put("type", "plain_text")
+                    put("text", "Visibility")
+                }
+                putJsonObject("element") {
+                    put("type", "static_select")
+                    put("action_id", "value")
+                    putJsonObject("initial_option") {
+                        putJsonObject("text") {
+                            put("type", "plain_text")
+                            put("text", "Organization")
+                        }
+                        put("value", NativeIncidentVisibility.ORGANIZATION.wire)
+                    }
+                    putJsonArray("options") {
+                        listOf(
+                            NativeIncidentVisibility.ORGANIZATION to "Organization",
+                            NativeIncidentVisibility.PRIVATE to "Private",
+                            NativeIncidentVisibility.PUBLIC to "Public",
+                        ).forEach { (visibility, label) ->
+                            addJsonObject {
+                                putJsonObject("text") {
+                                    put("type", "plain_text")
+                                    put("text", label)
+                                }
+                                put("value", visibility.wire)
                             }
                         }
                     }

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/SlackIncidentDeclarationViewTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/SlackIncidentDeclarationViewTest.kt
@@ -30,8 +30,20 @@ class SlackIncidentDeclarationViewTest {
         assertEquals("moneat_incident_declaration", view["callback_id"]?.toString()?.trim('"'))
         assertEquals("Checkout API is timing out", blocks?.first()?.jsonObject?.get("element")
             ?.jsonObject?.get("initial_value")?.toString()?.trim('"'))
-        assertEquals(3, blocks?.size)
-        assertNotNull(blocks?.last()?.jsonObject?.get("element")?.jsonObject?.get("options"))
+        assertEquals(5, blocks?.size)
+        assertNotNull(blocks?.get(2)?.jsonObject?.get("element")?.jsonObject?.get("options"))
+        assertEquals("mode", blocks.get(3).jsonObject["block_id"]?.toString()?.trim('"'))
+        assertEquals("visibility", blocks.get(4).jsonObject["block_id"]?.toString()?.trim('"'))
+        assertEquals(
+            "LIVE",
+            blocks.get(3).jsonObject["element"]?.jsonObject?.get("initial_option")
+                ?.jsonObject?.get("value")?.toString()?.trim('"'),
+        )
+        assertEquals(
+            "ORGANIZATION",
+            blocks.get(4).jsonObject["element"]?.jsonObject?.get("initial_option")
+                ?.jsonObject?.get("value")?.toString()?.trim('"'),
+        )
     }
 
     @Test
@@ -47,6 +59,15 @@ class SlackIncidentDeclarationViewTest {
         assertTrue(menu.contains("Incident response"))
         listOf("overview", "timeline", "handover", "status page", "resolve", "reopen", "workflow")
             .forEach { capability -> assertTrue(normalizedMenu.contains(capability)) }
+        assertTrue(menu.contains("incident_menu_declare"))
+    }
+
+    @Test
+    fun `incident menu includes the incident bound to the Slack channel`() {
+        val menu = slackIncidentCommandMenu("incident-resource-123")
+
+        assertTrue(menu.contains("Incident menu"))
+        assertTrue(menu.contains("incident-resource-123"))
         assertTrue(menu.contains("incident_menu_declare"))
     }
 
@@ -98,15 +119,15 @@ class SlackIncidentDeclarationViewTest {
 
         val blocks = slackIncidentDeclarationView(null, form)["blocks"]?.jsonArray
 
-        assertEquals(5, blocks?.size)
-        assertEquals("field_customer_impact", blocks?.get(3)?.jsonObject?.get("block_id")?.toString()?.trim('"'))
-        assertEquals("static_select", blocks?.get(3)?.jsonObject?.get("element")?.jsonObject?.get("type")
+        assertEquals(7, blocks?.size)
+        assertEquals("field_customer_impact", blocks?.get(5)?.jsonObject?.get("block_id")?.toString()?.trim('"'))
+        assertEquals("static_select", blocks?.get(5)?.jsonObject?.get("element")?.jsonObject?.get("type")
             ?.toString()?.trim('"'))
-        assertEquals(false, blocks?.get(3)?.jsonObject?.get("optional")?.toString()?.toBoolean())
-        assertEquals("Who is affected?", blocks?.get(3)?.jsonObject?.get("hint")?.jsonObject?.get("text")
+        assertEquals(false, blocks?.get(5)?.jsonObject?.get("optional")?.toString()?.toBoolean())
+        assertEquals("Who is affected?", blocks?.get(5)?.jsonObject?.get("hint")?.jsonObject?.get("text")
             ?.toString()?.trim('"'))
-        assertEquals("field_named_accounts", blocks?.get(4)?.jsonObject?.get("block_id")?.toString()?.trim('"'))
-        assertEquals("multi_static_select", blocks?.get(4)?.jsonObject?.get("element")?.jsonObject?.get("type")
+        assertEquals("field_named_accounts", blocks?.get(6)?.jsonObject?.get("block_id")?.toString()?.trim('"'))
+        assertEquals("multi_static_select", blocks?.get(6)?.jsonObject?.get("element")?.jsonObject?.get("type")
             ?.toString()?.trim('"'))
     }
 

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/SlackIncidentDeclarationViewTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/SlackIncidentDeclarationViewTest.kt
@@ -25,13 +25,13 @@ class SlackIncidentDeclarationViewTest {
     @Test
     fun `declaration modal preserves context and offers supported severities`() {
         val view = slackIncidentDeclarationView("Checkout API is timing out")
-        val blocks = view["blocks"]?.jsonArray
+        val blocks = requireNotNull(view["blocks"]?.jsonArray)
 
         assertEquals("moneat_incident_declaration", view["callback_id"]?.toString()?.trim('"'))
-        assertEquals("Checkout API is timing out", blocks?.first()?.jsonObject?.get("element")
+        assertEquals("Checkout API is timing out", blocks.first().jsonObject["element"]
             ?.jsonObject?.get("initial_value")?.toString()?.trim('"'))
-        assertEquals(5, blocks?.size)
-        assertNotNull(blocks?.get(2)?.jsonObject?.get("element")?.jsonObject?.get("options"))
+        assertEquals(5, blocks.size)
+        assertNotNull(blocks.get(2).jsonObject["element"]?.jsonObject?.get("options"))
         assertEquals("mode", blocks.get(3).jsonObject["block_id"]?.toString()?.trim('"'))
         assertEquals("visibility", blocks.get(4).jsonObject["block_id"]?.toString()?.trim('"'))
         assertEquals(


### PR DESCRIPTION
## Summary
- route /moneat requests from incident channels to the incident menu
- expose incident mode and visibility in Slack declarations
- preserve the canonical declaration command and configured response/channel behavior

## Validation
- ./gradlew :ee:compileKotlin :ee:test --tests com.moneat.enterprise.oncall.SlackIncidentDeclarationViewTest :ee:detekt --no-daemon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Slack incident forms now support live, retrospective, and test modes.
  - Incident visibility can be set to organization, private, or public.
  - Commands issued in active incident channels now display incident-specific options and include the associated incident.
- **Improvements**
  - Incident mode and visibility are validated and retained when incidents are declared.
  - Existing workflows continue to use live mode and organization visibility by default when no values are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->