### PR TITLE
feat: trigger workflows for incident role changes

### DIFF
--- a/backend/features/workflows/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
+++ b/backend/features/workflows/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
@@ -53,6 +53,7 @@ import com.moneat.workflows.models.WorkflowVersions
 import com.moneat.workflows.models.Workflows
 import com.moneat.workflows.models.typedWorkflowScope
 import com.moneat.workflows.services.AlertResolvedWorkflowEvent
+import com.moneat.workflows.services.DeclaredIncidentRoleChange
 import com.moneat.workflows.services.WorkflowService
 import io.mockk.clearMocks
 import io.mockk.coEvery
@@ -1533,6 +1534,47 @@ class WorkflowServiceTest {
             assertEquals(
                 listOf("incident.id=$incidentResourceId|incident.status=resolved"),
                 runIdentities(resolvedWorkflow.id)
+            )
+        }
+
+    @Test
+    fun `declared incident role workflows include role context and deduplicate actions`() =
+        runBlocking {
+            val workflow =
+                service.createWorkflow(
+                    orgId,
+                    CreateWorkflowRequest(
+                        name = "Declared incident role changed",
+                        triggerName = "incident.role_changed",
+                        steps = emptyList(),
+                    ),
+                )
+            publish(workflow.id)
+            val incidentResourceId = "11111111-2222-4333-8444-555555555555"
+            transaction {
+                OnCallIncidents.insert {
+                    it[id] = 42
+                    it[resourceId] = kotlin.uuid.Uuid.parse(incidentResourceId)
+                    it[organizationId] = orgId
+                }
+            }
+
+            val change =
+                DeclaredIncidentRoleChange(
+                    organizationId = orgId,
+                    incidentId = 42,
+                    title = "Checkout degraded",
+                    severity = IncidentSeverity.SEV1,
+                    role = "Incident Commander",
+                    assignee = "user-resource",
+                    action = "assigned",
+                )
+            service.publishDeclaredIncidentRoleChanged(change)
+            service.publishDeclaredIncidentRoleChanged(change)
+
+            assertEquals(
+                listOf("incident.id=$incidentResourceId|incident.role_action=assigned"),
+                runIdentities(workflow.id),
             )
         }
 

--- a/backend/features/workflows/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
+++ b/backend/features/workflows/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
@@ -1568,12 +1568,19 @@ class WorkflowServiceTest {
                     role = "Incident Commander",
                     assignee = "user-resource",
                     action = "assigned",
+                    eventResourceId = "event-resource-id",
                 )
             service.publishDeclaredIncidentRoleChanged(change)
             service.publishDeclaredIncidentRoleChanged(change)
+            service.publishDeclaredIncidentRoleChanged(change.copy(eventResourceId = "event-resource-id-2"))
 
             assertEquals(
-                listOf("incident.id=$incidentResourceId|incident.role_action=assigned"),
+                listOf(
+                    "incident.id=$incidentResourceId|incident.role_action=assigned|" +
+                        "incident.role_event_id=event-resource-id",
+                    "incident.id=$incidentResourceId|incident.role_action=assigned|" +
+                        "incident.role_event_id=event-resource-id-2",
+                ),
                 runIdentities(workflow.id),
             )
         }

--- a/backend/features/workflows/src/test/kotlin/com/moneat/workflows/engine/WorkflowCatalogTest.kt
+++ b/backend/features/workflows/src/test/kotlin/com/moneat/workflows/engine/WorkflowCatalogTest.kt
@@ -63,10 +63,11 @@ class WorkflowCatalogTest {
 
         assertEquals("When an incident role changes", trigger.label)
         assertEquals(
-            listOf("incident.id", "incident.role_action"),
+            listOf("incident.id", "incident.role_action", "incident.role_event_id"),
             trigger.defaultOnceForTemplate,
         )
         assertTrue(trigger.scope.any { it.name == "incident.role" && it.type == "String" })
         assertTrue(trigger.scope.any { it.name == "incident.assignee" && it.type == "String" })
+        assertTrue(trigger.scope.any { it.name == "incident.role_event_id" && it.type == "String" })
     }
 }

--- a/backend/features/workflows/src/test/kotlin/com/moneat/workflows/engine/WorkflowCatalogTest.kt
+++ b/backend/features/workflows/src/test/kotlin/com/moneat/workflows/engine/WorkflowCatalogTest.kt
@@ -22,6 +22,7 @@ import com.moneat.workflows.engine.temporal.WORKFLOWS_EGRESS_ENABLED_ENV
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -54,5 +55,18 @@ class WorkflowCatalogTest {
         val names = WorkflowCatalog.response().steps.map { it.name }
         assertTrue(names.contains(HTTP_REQUEST_ACTION))
         assertTrue(names.contains(TRANSFORM_GRAALJS_ACTION))
+    }
+
+    @Test
+    fun `incident role trigger exposes role context and action deduplication`() {
+        val trigger = requireNotNull(WorkflowCatalog.trigger("incident.role_changed"))
+
+        assertEquals("When an incident role changes", trigger.label)
+        assertEquals(
+            listOf("incident.id", "incident.role_action"),
+            trigger.defaultOnceForTemplate,
+        )
+        assertTrue(trigger.scope.any { it.name == "incident.role" && it.type == "String" })
+        assertTrue(trigger.scope.any { it.name == "incident.assignee" && it.type == "String" })
     }
 }

--- a/backend/src/main/kotlin/com/moneat/workflows/engine/WorkflowCatalog.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/engine/WorkflowCatalog.kt
@@ -60,6 +60,9 @@ private const val INCIDENT_KIND_REFERENCE = "incident.kind"
 private const val INCIDENT_TITLE_REFERENCE = "incident.title"
 private const val INCIDENT_STATUS_REFERENCE = "incident.status"
 private const val INCIDENT_SEVERITY_REFERENCE = "incident.severity"
+private const val INCIDENT_ROLE_REFERENCE = "incident.role"
+private const val INCIDENT_ASSIGNEE_REFERENCE = "incident.assignee"
+private const val INCIDENT_ROLE_ACTION_REFERENCE = "incident.role_action"
 private const val SECURITY_RULE_ID_REFERENCE = "security.rule_id"
 private const val SECURITY_RULE_NAME_REFERENCE = "security.rule_name"
 private const val SECURITY_SEVERITY_REFERENCE = "security.severity"
@@ -303,6 +306,9 @@ object WorkflowCatalog {
         WorkflowScopeReferenceDefinition(INCIDENT_TITLE_REFERENCE, "Incident title", "String"),
         WorkflowScopeReferenceDefinition(INCIDENT_STATUS_REFERENCE, "Incident status", "IncidentStatus"),
         WorkflowScopeReferenceDefinition(INCIDENT_SEVERITY_REFERENCE, INCIDENT_SEVERITY_LABEL, "IncidentSeverity"),
+        WorkflowScopeReferenceDefinition(INCIDENT_ROLE_REFERENCE, "Incident role", "String"),
+        WorkflowScopeReferenceDefinition(INCIDENT_ASSIGNEE_REFERENCE, "Role assignee", "String"),
+        WorkflowScopeReferenceDefinition(INCIDENT_ROLE_ACTION_REFERENCE, "Role action", "String"),
         WorkflowScopeReferenceDefinition(ALERT_DEDUPLICATION_KEY_REFERENCE, DEDUPLICATION_KEY_LABEL, "String"),
         WorkflowScopeReferenceDefinition(ALERT_EPISODE_ID_REFERENCE, "Episode ID", "String"),
         WorkflowScopeReferenceDefinition(ALERT_EPISODE_KEY_REFERENCE, "Episode key", "String"),
@@ -392,6 +398,13 @@ object WorkflowCatalog {
             description = "Runs when incident routing resolves a response event.",
             scope = incidentScope,
             defaultOnceForTemplate = listOf(INCIDENT_ID_REFERENCE, INCIDENT_STATUS_REFERENCE)
+        ),
+        WorkflowTriggerDefinition(
+            name = "incident.role_changed",
+            label = "When an incident role changes",
+            description = "Runs when an incident role is assigned, claimed, handed over, or unassigned.",
+            scope = incidentScope,
+            defaultOnceForTemplate = listOf(INCIDENT_ID_REFERENCE, INCIDENT_ROLE_ACTION_REFERENCE)
         ),
         WorkflowTriggerDefinition(
             name = "security.signal",

--- a/backend/src/main/kotlin/com/moneat/workflows/engine/WorkflowCatalog.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/engine/WorkflowCatalog.kt
@@ -31,6 +31,9 @@ import com.moneat.workflows.models.ALERT_LAST_SEEN_AT_REFERENCE
 import com.moneat.workflows.models.ALERT_NOTIFICATION_KIND_REFERENCE
 import com.moneat.workflows.models.ALERT_NOTIFICATION_SEQUENCE_REFERENCE
 import com.moneat.workflows.models.ALERT_OPENED_AT_REFERENCE
+import com.moneat.workflows.models.INCIDENT_ASSIGNEE_REFERENCE
+import com.moneat.workflows.models.INCIDENT_ROLE_ACTION_REFERENCE
+import com.moneat.workflows.models.INCIDENT_ROLE_REFERENCE
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -60,9 +63,6 @@ private const val INCIDENT_KIND_REFERENCE = "incident.kind"
 private const val INCIDENT_TITLE_REFERENCE = "incident.title"
 private const val INCIDENT_STATUS_REFERENCE = "incident.status"
 private const val INCIDENT_SEVERITY_REFERENCE = "incident.severity"
-private const val INCIDENT_ROLE_REFERENCE = "incident.role"
-private const val INCIDENT_ASSIGNEE_REFERENCE = "incident.assignee"
-private const val INCIDENT_ROLE_ACTION_REFERENCE = "incident.role_action"
 private const val SECURITY_RULE_ID_REFERENCE = "security.rule_id"
 private const val SECURITY_RULE_NAME_REFERENCE = "security.rule_name"
 private const val SECURITY_SEVERITY_REFERENCE = "security.severity"

--- a/backend/src/main/kotlin/com/moneat/workflows/engine/WorkflowCatalog.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/engine/WorkflowCatalog.kt
@@ -33,6 +33,7 @@ import com.moneat.workflows.models.ALERT_NOTIFICATION_SEQUENCE_REFERENCE
 import com.moneat.workflows.models.ALERT_OPENED_AT_REFERENCE
 import com.moneat.workflows.models.INCIDENT_ASSIGNEE_REFERENCE
 import com.moneat.workflows.models.INCIDENT_ROLE_ACTION_REFERENCE
+import com.moneat.workflows.models.INCIDENT_ROLE_EVENT_ID_REFERENCE
 import com.moneat.workflows.models.INCIDENT_ROLE_REFERENCE
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -309,6 +310,7 @@ object WorkflowCatalog {
         WorkflowScopeReferenceDefinition(INCIDENT_ROLE_REFERENCE, "Incident role", "String"),
         WorkflowScopeReferenceDefinition(INCIDENT_ASSIGNEE_REFERENCE, "Role assignee", "String"),
         WorkflowScopeReferenceDefinition(INCIDENT_ROLE_ACTION_REFERENCE, "Role action", "String"),
+        WorkflowScopeReferenceDefinition(INCIDENT_ROLE_EVENT_ID_REFERENCE, "Role event ID", "String"),
         WorkflowScopeReferenceDefinition(ALERT_DEDUPLICATION_KEY_REFERENCE, DEDUPLICATION_KEY_LABEL, "String"),
         WorkflowScopeReferenceDefinition(ALERT_EPISODE_ID_REFERENCE, "Episode ID", "String"),
         WorkflowScopeReferenceDefinition(ALERT_EPISODE_KEY_REFERENCE, "Episode key", "String"),
@@ -404,7 +406,11 @@ object WorkflowCatalog {
             label = "When an incident role changes",
             description = "Runs when an incident role is assigned, claimed, handed over, or unassigned.",
             scope = incidentScope,
-            defaultOnceForTemplate = listOf(INCIDENT_ID_REFERENCE, INCIDENT_ROLE_ACTION_REFERENCE)
+            defaultOnceForTemplate = listOf(
+                INCIDENT_ID_REFERENCE,
+                INCIDENT_ROLE_ACTION_REFERENCE,
+                INCIDENT_ROLE_EVENT_ID_REFERENCE,
+            )
         ),
         WorkflowTriggerDefinition(
             name = "security.signal",

--- a/backend/src/main/kotlin/com/moneat/workflows/models/WorkflowIncidentReferences.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/models/WorkflowIncidentReferences.kt
@@ -1,0 +1,21 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.workflows.models
+
+internal const val INCIDENT_ROLE_REFERENCE = "incident.role"
+internal const val INCIDENT_ASSIGNEE_REFERENCE = "incident.assignee"
+internal const val INCIDENT_ROLE_ACTION_REFERENCE = "incident.role_action"

--- a/backend/src/main/kotlin/com/moneat/workflows/models/WorkflowIncidentReferences.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/models/WorkflowIncidentReferences.kt
@@ -19,3 +19,4 @@ package com.moneat.workflows.models
 internal const val INCIDENT_ROLE_REFERENCE = "incident.role"
 internal const val INCIDENT_ASSIGNEE_REFERENCE = "incident.assignee"
 internal const val INCIDENT_ROLE_ACTION_REFERENCE = "incident.role_action"
+internal const val INCIDENT_ROLE_EVENT_ID_REFERENCE = "incident.role_event_id"

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
@@ -160,6 +160,16 @@ data class AlertResolvedWorkflowEvent(
     val severity: AlertPriority? = null,
 )
 
+data class DeclaredIncidentRoleChange(
+    val organizationId: Int,
+    val incidentId: Int,
+    val title: String,
+    val severity: IncidentSeverity?,
+    val role: String,
+    val assignee: String?,
+    val action: String,
+)
+
 class WorkflowService(
     private val emailService: EmailService = EmailService(),
     private val slackService: SlackService = SlackService(),
@@ -1052,28 +1062,13 @@ class WorkflowService(
         )
     }
 
-    suspend fun publishDeclaredIncidentRoleChanged(
-        organizationId: Int,
-        incidentId: Int,
-        title: String,
-        severity: IncidentSeverity?,
-        role: String,
-        assignee: String?,
-        action: String,
-    ) {
+    suspend fun publishDeclaredIncidentRoleChanged(change: DeclaredIncidentRoleChange) {
         publishTrigger(
             WorkflowTriggerEvent(
                 triggerName = INCIDENT_ROLE_CHANGED_TRIGGER,
-                organizationId = organizationId,
+                organizationId = change.organizationId,
                 scope = declaredIncidentRoleScope(
-                    organizationId = organizationId,
-                    incidentId = incidentId,
-                    status = "role_changed",
-                    title = title,
-                    severity = severity?.wire.orEmpty(),
-                    role = role,
-                    assignee = assignee.orEmpty(),
-                    action = action,
+                    change = change,
                 ),
             ),
         )
@@ -1647,27 +1642,18 @@ class WorkflowService(
         ).typedWorkflowScope()
     }
 
-    private fun declaredIncidentRoleScope(
-        organizationId: Int,
-        incidentId: Int,
-        status: String,
-        title: String,
-        severity: String,
-        role: String,
-        assignee: String,
-        action: String,
-    ): Map<String, JsonElement> {
-        val incidentResourceId = declaredIncidentResourceId(organizationId, incidentId)
+    private fun declaredIncidentRoleScope(change: DeclaredIncidentRoleChange): Map<String, JsonElement> {
+        val incidentResourceId = declaredIncidentResourceId(change.organizationId, change.incidentId)
         return mapOf(
             INCIDENT_ID_REFERENCE to incidentResourceId,
             INCIDENT_KIND_REFERENCE to "native_incident",
-            INCIDENT_TITLE_REFERENCE to title,
-            INCIDENT_STATUS_REFERENCE to status,
-            INCIDENT_SEVERITY_REFERENCE to severity,
-            INCIDENT_ROLE_REFERENCE to role,
-            INCIDENT_ASSIGNEE_REFERENCE to assignee,
-            INCIDENT_ROLE_ACTION_REFERENCE to action,
-            ORGANIZATION_ID_REFERENCE to organizationResourceId(organizationId),
+            INCIDENT_TITLE_REFERENCE to change.title,
+            INCIDENT_STATUS_REFERENCE to "role_changed",
+            INCIDENT_SEVERITY_REFERENCE to change.severity?.wire.orEmpty(),
+            INCIDENT_ROLE_REFERENCE to change.role,
+            INCIDENT_ASSIGNEE_REFERENCE to change.assignee.orEmpty(),
+            INCIDENT_ROLE_ACTION_REFERENCE to change.action,
+            ORGANIZATION_ID_REFERENCE to organizationResourceId(change.organizationId),
         ).typedWorkflowScope()
     }
 

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
@@ -60,6 +60,7 @@ import com.moneat.workflows.models.ALERT_NOTIFICATION_SEQUENCE_REFERENCE
 import com.moneat.workflows.models.ALERT_OPENED_AT_REFERENCE
 import com.moneat.workflows.models.INCIDENT_ASSIGNEE_REFERENCE
 import com.moneat.workflows.models.INCIDENT_ROLE_ACTION_REFERENCE
+import com.moneat.workflows.models.INCIDENT_ROLE_EVENT_ID_REFERENCE
 import com.moneat.workflows.models.INCIDENT_ROLE_REFERENCE
 import com.moneat.workflows.models.CreateWorkflowRequest
 import com.moneat.workflows.models.ManualWorkflowRunRequest
@@ -168,6 +169,7 @@ data class DeclaredIncidentRoleChange(
     val role: String,
     val assignee: String?,
     val action: String,
+    val eventResourceId: String,
 )
 
 class WorkflowService(
@@ -1653,6 +1655,7 @@ class WorkflowService(
             INCIDENT_ROLE_REFERENCE to change.role,
             INCIDENT_ASSIGNEE_REFERENCE to change.assignee.orEmpty(),
             INCIDENT_ROLE_ACTION_REFERENCE to change.action,
+            INCIDENT_ROLE_EVENT_ID_REFERENCE to change.eventResourceId,
             ORGANIZATION_ID_REFERENCE to organizationResourceId(change.organizationId),
         ).typedWorkflowScope()
     }

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
@@ -128,6 +128,9 @@ private const val INCIDENT_KIND_REFERENCE = "incident.kind"
 private const val INCIDENT_TITLE_REFERENCE = "incident.title"
 private const val INCIDENT_STATUS_REFERENCE = "incident.status"
 private const val INCIDENT_SEVERITY_REFERENCE = "incident.severity"
+private const val INCIDENT_ROLE_REFERENCE = "incident.role"
+private const val INCIDENT_ASSIGNEE_REFERENCE = "incident.assignee"
+private const val INCIDENT_ROLE_ACTION_REFERENCE = "incident.role_action"
 private const val SECURITY_RULE_ID_REFERENCE = "security.rule_id"
 private const val SECURITY_RULE_NAME_REFERENCE = "security.rule_name"
 private const val SECURITY_SEVERITY_REFERENCE = "security.severity"
@@ -1049,6 +1052,33 @@ class WorkflowService(
         )
     }
 
+    suspend fun publishDeclaredIncidentRoleChanged(
+        organizationId: Int,
+        incidentId: Int,
+        title: String,
+        severity: IncidentSeverity?,
+        role: String,
+        assignee: String?,
+        action: String,
+    ) {
+        publishTrigger(
+            WorkflowTriggerEvent(
+                triggerName = INCIDENT_ROLE_CHANGED_TRIGGER,
+                organizationId = organizationId,
+                scope = declaredIncidentRoleScope(
+                    organizationId = organizationId,
+                    incidentId = incidentId,
+                    status = "role_changed",
+                    title = title,
+                    severity = severity?.wire.orEmpty(),
+                    role = role,
+                    assignee = assignee.orEmpty(),
+                    action = action,
+                ),
+            ),
+        )
+    }
+
     /**
      * Fires the `security.signal` workflow trigger once per **newly created or escalated** signal,
      * not once per raw agent event — eliminating the previous per-event fan-out. Repeats that merely
@@ -1617,6 +1647,30 @@ class WorkflowService(
         ).typedWorkflowScope()
     }
 
+    private fun declaredIncidentRoleScope(
+        organizationId: Int,
+        incidentId: Int,
+        status: String,
+        title: String,
+        severity: String,
+        role: String,
+        assignee: String,
+        action: String,
+    ): Map<String, JsonElement> {
+        val incidentResourceId = declaredIncidentResourceId(organizationId, incidentId)
+        return mapOf(
+            INCIDENT_ID_REFERENCE to incidentResourceId,
+            INCIDENT_KIND_REFERENCE to "native_incident",
+            INCIDENT_TITLE_REFERENCE to title,
+            INCIDENT_STATUS_REFERENCE to status,
+            INCIDENT_SEVERITY_REFERENCE to severity,
+            INCIDENT_ROLE_REFERENCE to role,
+            INCIDENT_ASSIGNEE_REFERENCE to assignee,
+            INCIDENT_ROLE_ACTION_REFERENCE to action,
+            ORGANIZATION_ID_REFERENCE to organizationResourceId(organizationId),
+        ).typedWorkflowScope()
+    }
+
     private fun securitySignalScope(
         organizationId: Int,
         signal: SignalOutcome
@@ -1678,6 +1732,7 @@ class WorkflowService(
         private const val SYNTHETIC_PASSED_TRIGGER = "synthetic.passed"
         private const val INCIDENT_CREATED_TRIGGER = "incident.created"
         private const val INCIDENT_RESOLVED_TRIGGER = "incident.resolved"
+        private const val INCIDENT_ROLE_CHANGED_TRIGGER = "incident.role_changed"
         private const val SECURITY_SIGNAL_TRIGGER = "security.signal"
         private const val API_TRIGGER = "api"
         private const val WEBHOOK_TRIGGER = "webhook"

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
@@ -58,6 +58,9 @@ import com.moneat.workflows.models.ALERT_LAST_SEEN_AT_REFERENCE
 import com.moneat.workflows.models.ALERT_NOTIFICATION_KIND_REFERENCE
 import com.moneat.workflows.models.ALERT_NOTIFICATION_SEQUENCE_REFERENCE
 import com.moneat.workflows.models.ALERT_OPENED_AT_REFERENCE
+import com.moneat.workflows.models.INCIDENT_ASSIGNEE_REFERENCE
+import com.moneat.workflows.models.INCIDENT_ROLE_ACTION_REFERENCE
+import com.moneat.workflows.models.INCIDENT_ROLE_REFERENCE
 import com.moneat.workflows.models.CreateWorkflowRequest
 import com.moneat.workflows.models.ManualWorkflowRunRequest
 import com.moneat.workflows.models.UpdateWorkflowRequest
@@ -128,9 +131,6 @@ private const val INCIDENT_KIND_REFERENCE = "incident.kind"
 private const val INCIDENT_TITLE_REFERENCE = "incident.title"
 private const val INCIDENT_STATUS_REFERENCE = "incident.status"
 private const val INCIDENT_SEVERITY_REFERENCE = "incident.severity"
-private const val INCIDENT_ROLE_REFERENCE = "incident.role"
-private const val INCIDENT_ASSIGNEE_REFERENCE = "incident.assignee"
-private const val INCIDENT_ROLE_ACTION_REFERENCE = "incident.role_action"
 private const val SECURITY_RULE_ID_REFERENCE = "security.rule_id"
 private const val SECURITY_RULE_NAME_REFERENCE = "security.rule_name"
 private const val SECURITY_SEVERITY_REFERENCE = "security.severity"

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowStepRenderer.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowStepRenderer.kt
@@ -182,19 +182,27 @@ class WorkflowStepRenderer {
     private fun incidentSampleScope(triggerName: String): Map<String, String> {
         val status = when (triggerName) {
             INCIDENT_RESOLVED_TRIGGER -> "resolved"
+            INCIDENT_ROLE_CHANGED_TRIGGER -> "role_changed"
             else -> "created"
         }
-        return mapOf(
+        val baseScope = mapOf(
             "incident.id" to SAMPLE_INCIDENT_ID,
             "incident.kind" to "native_incident",
             "incident.title" to "Checkout latency incident",
             "incident.status" to status,
             "incident.severity" to IncidentSeverity.SEV1.wire,
-            "incident.role" to "Incident Commander",
-            "incident.assignee" to SAMPLE_USER_ID,
-            "incident.role_action" to if (triggerName == INCIDENT_ROLE_CHANGED_TRIGGER) "assigned" else "",
             ORGANIZATION_ID_REFERENCE to SAMPLE_ORGANIZATION_ID
         )
+        return if (triggerName == INCIDENT_ROLE_CHANGED_TRIGGER) {
+            baseScope + mapOf(
+                "incident.role" to "Incident Commander",
+                "incident.assignee" to SAMPLE_USER_ID,
+                "incident.role_action" to "assign_role",
+                "incident.role_event_id" to "123e4567-e89b-12d3-a456-426614170006",
+            )
+        } else {
+            baseScope
+        }
     }
 
     private fun securitySampleScope(): Map<String, String> =

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowStepRenderer.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowStepRenderer.kt
@@ -58,6 +58,7 @@ internal const val API_TRIGGER = "api"
 internal const val WEBHOOK_TRIGGER = "webhook"
 internal const val INCIDENT_CREATED_TRIGGER = "incident.created"
 internal const val INCIDENT_RESOLVED_TRIGGER = "incident.resolved"
+internal const val INCIDENT_ROLE_CHANGED_TRIGGER = "incident.role_changed"
 internal const val SECURITY_SIGNAL_TRIGGER = "security.signal"
 internal const val ALERT_DESCRIPTION_TEMPLATE_BLOCK = "{{alert.description}}\n\n"
 internal const val ALERT_PRIORITY_TEMPLATE_LINE = "Priority: {{alert.priority}}\n"
@@ -108,7 +109,8 @@ class WorkflowStepRenderer {
             API_TRIGGER -> apiSampleScope()
             WEBHOOK_TRIGGER -> webhookSampleScope()
             INCIDENT_CREATED_TRIGGER,
-            INCIDENT_RESOLVED_TRIGGER -> incidentSampleScope(triggerName)
+            INCIDENT_RESOLVED_TRIGGER,
+            INCIDENT_ROLE_CHANGED_TRIGGER -> incidentSampleScope(triggerName)
             SECURITY_SIGNAL_TRIGGER -> securitySampleScope()
             else -> alertSampleScope(triggerName)
         }
@@ -188,6 +190,9 @@ class WorkflowStepRenderer {
             "incident.title" to "Checkout latency incident",
             "incident.status" to status,
             "incident.severity" to IncidentSeverity.SEV1.wire,
+            "incident.role" to "Incident Commander",
+            "incident.assignee" to SAMPLE_USER_ID,
+            "incident.role_action" to if (triggerName == INCIDENT_ROLE_CHANGED_TRIGGER) "assigned" else "",
             ORGANIZATION_ID_REFERENCE to SAMPLE_ORGANIZATION_ID
         )
     }

--- a/backend/src/test/kotlin/com/moneat/workflows/services/WorkflowStepRendererTest.kt
+++ b/backend/src/test/kotlin/com/moneat/workflows/services/WorkflowStepRendererTest.kt
@@ -53,6 +53,8 @@ class WorkflowStepRendererTest {
         assertTrue(renderer.sampleScopeForTrigger(WEBHOOK_TRIGGER).containsKey("webhook.payload"))
         assertEquals("created", renderer.sampleScopeForTrigger(INCIDENT_CREATED_TRIGGER)["incident.status"])
         assertEquals("resolved", renderer.sampleScopeForTrigger(INCIDENT_RESOLVED_TRIGGER)["incident.status"])
+        assertFalse(renderer.sampleScopeForTrigger(INCIDENT_CREATED_TRIGGER).containsKey("incident.role"))
+        assertFalse(renderer.sampleScopeForTrigger(INCIDENT_RESOLVED_TRIGGER).containsKey("incident.role"))
         assertTrue(renderer.sampleScopeForTrigger(SECURITY_SIGNAL_TRIGGER).containsKey("security.rule_id"))
     }
 
@@ -60,10 +62,11 @@ class WorkflowStepRendererTest {
     fun `role change incident sample scope exposes role context`() {
         val scope = renderer.sampleScopeForTrigger(INCIDENT_ROLE_CHANGED_TRIGGER)
 
-        assertEquals("created", scope["incident.status"])
+        assertEquals("role_changed", scope["incident.status"])
         assertEquals("Incident Commander", scope["incident.role"])
         assertEquals("123e4567-e89b-12d3-a456-426614170002", scope["incident.assignee"])
-        assertEquals("assigned", scope["incident.role_action"])
+        assertEquals("assign_role", scope["incident.role_action"])
+        assertEquals("123e4567-e89b-12d3-a456-426614170006", scope["incident.role_event_id"])
     }
 
     // ──── channelForStep / priorityLabel ────

--- a/backend/src/test/kotlin/com/moneat/workflows/services/WorkflowStepRendererTest.kt
+++ b/backend/src/test/kotlin/com/moneat/workflows/services/WorkflowStepRendererTest.kt
@@ -56,6 +56,16 @@ class WorkflowStepRendererTest {
         assertTrue(renderer.sampleScopeForTrigger(SECURITY_SIGNAL_TRIGGER).containsKey("security.rule_id"))
     }
 
+    @Test
+    fun `role change incident sample scope exposes role context`() {
+        val scope = renderer.sampleScopeForTrigger(INCIDENT_ROLE_CHANGED_TRIGGER)
+
+        assertEquals("created", scope["incident.status"])
+        assertEquals("Incident Commander", scope["incident.role"])
+        assertEquals("123e4567-e89b-12d3-a456-426614170002", scope["incident.assignee"])
+        assertEquals("assigned", scope["incident.role_action"])
+    }
+
     // ──── channelForStep / priorityLabel ────
 
     @Test

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/events/WorkflowIncidentEventConsumer.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/events/WorkflowIncidentEventConsumer.kt
@@ -52,6 +52,7 @@ class WorkflowIncidentEventConsumer(
                 role = payload["role"]?.jsonPrimitive?.contentOrNull ?: "Incident role",
                 assignee = payload["assigneeUserId"]?.jsonPrimitive?.contentOrNull,
                 action = eventType.removePrefix("INCIDENT_").lowercase(),
+                eventResourceId = resourceId,
             ),
         )
     }

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/events/WorkflowIncidentEventConsumer.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/events/WorkflowIncidentEventConsumer.kt
@@ -5,6 +5,7 @@
 package com.moneat.enterprise.incidents.events
 
 import com.moneat.alerts.models.IncidentSeverity
+import com.moneat.workflows.services.DeclaredIncidentRoleChange
 import com.moneat.workflows.services.WorkflowService
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
@@ -43,13 +44,15 @@ class WorkflowIncidentEventConsumer(
 
     private suspend fun NativeIncidentDomainEvent.publishRoleChangedWorkflow() {
         workflowService.publishDeclaredIncidentRoleChanged(
-            organizationId = organizationId,
-            incidentId = incidentId,
-            title = title(),
-            severity = severityOrNull(),
-            role = payload["role"]?.jsonPrimitive?.contentOrNull ?: "Incident role",
-            assignee = payload["assigneeUserId"]?.jsonPrimitive?.contentOrNull,
-            action = eventType.removePrefix("INCIDENT_").lowercase(),
+            DeclaredIncidentRoleChange(
+                organizationId = organizationId,
+                incidentId = incidentId,
+                title = title(),
+                severity = severityOrNull(),
+                role = payload["role"]?.jsonPrimitive?.contentOrNull ?: "Incident role",
+                assignee = payload["assigneeUserId"]?.jsonPrimitive?.contentOrNull,
+                action = eventType.removePrefix("INCIDENT_").lowercase(),
+            ),
         )
     }
 

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/events/WorkflowIncidentEventConsumer.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/events/WorkflowIncidentEventConsumer.kt
@@ -20,6 +20,7 @@ class WorkflowIncidentEventConsumer(
         when (event.eventType) {
             "INCIDENT_DECLARE" -> if (event.status() == ACCEPTED_STATUS) event.publishCreatedWorkflow()
             "INCIDENT_ACCEPT" -> event.publishCreatedWorkflow()
+            in ROLE_CHANGE_EVENTS -> event.publishRoleChangedWorkflow()
             "INCIDENT_RESOLVE" ->
                 workflowService.publishDeclaredIncidentResolved(
                     organizationId = event.organizationId,
@@ -40,6 +41,18 @@ class WorkflowIncidentEventConsumer(
         )
     }
 
+    private suspend fun NativeIncidentDomainEvent.publishRoleChangedWorkflow() {
+        workflowService.publishDeclaredIncidentRoleChanged(
+            organizationId = organizationId,
+            incidentId = incidentId,
+            title = title(),
+            severity = severityOrNull(),
+            role = payload["role"]?.jsonPrimitive?.contentOrNull ?: "Incident role",
+            assignee = payload["assigneeUserId"]?.jsonPrimitive?.contentOrNull,
+            action = eventType.removePrefix("INCIDENT_").lowercase(),
+        )
+    }
+
     private fun NativeIncidentDomainEvent.title(): String = payload.getValue("title").jsonPrimitive.content
 
     private fun NativeIncidentDomainEvent.severity(): IncidentSeverity {
@@ -48,10 +61,21 @@ class WorkflowIncidentEventConsumer(
         return requireNotNull(IncidentSeverity.fromString(raw)) { "Incident event has invalid severity" }
     }
 
+    private fun NativeIncidentDomainEvent.severityOrNull(): IncidentSeverity? {
+        val raw = (payload["severity"] as? JsonPrimitive)?.contentOrNull ?: return null
+        return IncidentSeverity.fromString(raw)
+    }
+
     private fun NativeIncidentDomainEvent.status(): String? =
         (payload["status"] as? JsonPrimitive)?.contentOrNull
 
     private companion object {
         private const val ACCEPTED_STATUS = "ACTIVE"
+        private val ROLE_CHANGE_EVENTS = setOf(
+            "INCIDENT_ASSIGN_ROLE",
+            "INCIDENT_CLAIM_ROLE",
+            "INCIDENT_UNASSIGN_ROLE",
+            "INCIDENT_HANDOVER_ROLE",
+        )
     }
 }

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/events/WorkflowIncidentEventConsumerTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/events/WorkflowIncidentEventConsumerTest.kt
@@ -70,6 +70,34 @@ class WorkflowIncidentEventConsumerTest {
         }
     }
 
+    @Test
+    fun `role changes publish the role workflow with incident context`() = runBlocking {
+        coEvery {
+            workflowService.publishDeclaredIncidentRoleChanged(any(), any(), any(), any(), any(), any(), any())
+        } returns Unit
+
+        consumer.consume(
+            event(
+                eventType = "INCIDENT_ASSIGN_ROLE",
+                status = "ACTIVE",
+                severity = "SEV-1",
+            ),
+            deliveryKey = "workflows:role-assignment",
+        )
+
+        coVerify(exactly = 1) {
+            workflowService.publishDeclaredIncidentRoleChanged(
+                7,
+                42,
+                "Checkout unavailable",
+                IncidentSeverity.SEV1,
+                "Incident role",
+                null,
+                "assign_role",
+            )
+        }
+    }
+
     private fun event(
         eventType: String,
         status: String,

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/events/WorkflowIncidentEventConsumerTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/events/WorkflowIncidentEventConsumerTest.kt
@@ -96,6 +96,7 @@ class WorkflowIncidentEventConsumerTest {
                     role = "Incident role",
                     assignee = null,
                     action = "assign_role",
+                    eventResourceId = "event-resource-id",
                 ),
             )
         }

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/events/WorkflowIncidentEventConsumerTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/events/WorkflowIncidentEventConsumerTest.kt
@@ -5,6 +5,7 @@
 package com.moneat.enterprise.incidents.events
 
 import com.moneat.alerts.models.IncidentSeverity
+import com.moneat.workflows.services.DeclaredIncidentRoleChange
 import com.moneat.workflows.services.WorkflowService
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -73,7 +74,7 @@ class WorkflowIncidentEventConsumerTest {
     @Test
     fun `role changes publish the role workflow with incident context`() = runBlocking {
         coEvery {
-            workflowService.publishDeclaredIncidentRoleChanged(any(), any(), any(), any(), any(), any(), any())
+            workflowService.publishDeclaredIncidentRoleChanged(any())
         } returns Unit
 
         consumer.consume(
@@ -87,13 +88,15 @@ class WorkflowIncidentEventConsumerTest {
 
         coVerify(exactly = 1) {
             workflowService.publishDeclaredIncidentRoleChanged(
-                7,
-                42,
-                "Checkout unavailable",
-                IncidentSeverity.SEV1,
-                "Incident role",
-                null,
-                "assign_role",
+                DeclaredIncidentRoleChange(
+                    organizationId = 7,
+                    incidentId = 42,
+                    title = "Checkout unavailable",
+                    severity = IncidentSeverity.SEV1,
+                    role = "Incident role",
+                    assignee = null,
+                    action = "assign_role",
+                ),
             )
         }
     }


### PR DESCRIPTION
## Summary
- emit an incident role-change workflow trigger for assign, claim, handover, and unassign events
- include incident role, assignee, and action context in workflow scopes and samples
- keep event consumer behavior covered by focused tests

## Validation
- ./gradlew :ee:compileKotlin :ee:test --tests com.moneat.enterprise.incidents.events.WorkflowIncidentEventConsumerTest :ee:detekt :compileKotlin --no-daemon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow support for incident role changes.
  * Workflows can now trigger when an incident role is assigned or changed.
  * Role-change workflows include incident, role, assignee, and action details.
  * Added role-change examples to workflow previews.

* **Bug Fixes**
  * Prevented duplicate workflow runs when the same role-change event is published repeatedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->