### PR TITLE
feat: wire Slack incident command actions

### DIFF
--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/announcements/IncidentAnnouncementService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/announcements/IncidentAnnouncementService.kt
@@ -26,6 +26,7 @@ import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
 import kotlinx.serialization.Serializable
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
@@ -398,6 +399,12 @@ class IncidentAnnouncementService(
                 put("channel", destination.channelId)
                 messageTs?.let { put("ts", it) }
                 put("text", "Incident: ${snapshot.title}")
+                putJsonObject("metadata") {
+                    put("event_type", "moneat_incident")
+                    putJsonObject("event_payload") {
+                        put("incident_id", snapshot.resourceId)
+                    }
+                }
                 put("blocks", buildJsonArray {
                     add(buildJsonObject {
                         put("type", "header")

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/slack/SlackIncidentCommandService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/slack/SlackIncidentCommandService.kt
@@ -1,0 +1,581 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.incidents.slack
+
+import com.moneat.enterprise.incidents.authorization.SlackIncidentAccessRequest
+import com.moneat.enterprise.incidents.authorization.SlackIncidentAccessStatus
+import com.moneat.enterprise.incidents.authorization.SlackIncidentAction
+import com.moneat.enterprise.incidents.authorization.SlackIncidentAuthorizationService
+import com.moneat.enterprise.incidents.commands.AcceptIncidentCommand
+import com.moneat.enterprise.incidents.commands.AddIncidentActionCommand
+import com.moneat.enterprise.incidents.commands.AddIncidentTimelineEventCommand
+import com.moneat.enterprise.incidents.commands.CancelIncidentCommand
+import com.moneat.enterprise.incidents.commands.DeclineIncidentCommand
+import com.moneat.enterprise.incidents.commands.IncidentCommandActor
+import com.moneat.enterprise.incidents.commands.IncidentCommandException
+import com.moneat.enterprise.incidents.commands.IncidentCommandService
+import com.moneat.enterprise.incidents.commands.LeaveIncidentCommand
+import com.moneat.enterprise.incidents.commands.ReopenIncidentCommand
+import com.moneat.enterprise.incidents.commands.ResolveIncidentCommand
+import com.moneat.enterprise.incidents.commands.SetIncidentParticipationCommand
+import com.moneat.enterprise.incidents.commands.UpdateIncidentCommand
+import com.moneat.enterprise.incidents.models.IncidentParticipationType
+import com.moneat.enterprise.incidents.models.NativeIncidentStatus
+import com.moneat.enterprise.incidents.models.NativeIncidentVisibility
+import com.moneat.enterprise.oncall.models.OnCallIncidents
+import com.moneat.notifications.services.SlackIdentityRequest
+import com.moneat.notifications.services.SlackIdentityResolution
+import com.moneat.notifications.services.SlackIdentityResolver
+import com.moneat.notifications.services.SlackInstallationService
+import com.moneat.notifications.services.SlackService
+import com.moneat.shared.services.toUuidOrNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.addJsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.uuid.Uuid
+
+private const val INCIDENT_ACTION_PREFIX = "incident_"
+private const val UPDATE_CALLBACK_ID = "moneat_incident_update"
+private const val ACTION_CALLBACK_ID = "moneat_incident_action"
+private const val TIMELINE_CALLBACK_ID = "moneat_incident_timeline"
+private const val FOLLOW_UP_CALLBACK_ID = "moneat_incident_follow_up"
+private const val DECISION_CALLBACK_ID = "moneat_incident_decision"
+private const val MAX_TEXT_LENGTH = 2_000
+private const val MODAL_TITLE_MAX_LENGTH = 24
+private const val MODAL_LABEL_MAX_LENGTH = 75
+
+private data class IncidentContext(
+    val id: Int,
+    val resourceId: String,
+    val title: String,
+    val status: NativeIncidentStatus,
+    val severity: String?,
+    val visibility: NativeIncidentVisibility,
+    val version: Int,
+)
+
+/**
+ * Handles incident-bound Slack interactions. The adapter only translates Slack payloads; all
+ * mutations are executed by [IncidentCommandService] so REST, dashboard, and Slack share policy,
+ * optimistic concurrency, idempotency, timeline, and outbox behavior.
+ */
+class SlackIncidentCommandService(
+    private val installationService: SlackInstallationService,
+    private val slackService: SlackService,
+    private val commandService: IncidentCommandService = IncidentCommandService(),
+) {
+    private val identityResolver = SlackIdentityResolver()
+    private val authorizationService = SlackIncidentAuthorizationService()
+
+    fun handlesAction(actionId: String?): Boolean =
+        actionId?.startsWith(INCIDENT_ACTION_PREFIX) == true && actionId != "incident_menu_declare"
+
+    suspend fun handleBlockAction(root: JsonObject, deliveryId: String?): String? {
+        val action = root["actions"]?.jsonArray?.firstOrNull()?.jsonObject ?: return response("No action was selected.")
+        val actionId = action["action_id"]?.jsonPrimitive?.contentOrNull
+        if (!handlesAction(actionId)) return null
+        val identity = resolveIdentity(root)
+        if (!identity.isMapped) return response(identity.message)
+        val actionName = actionId.orEmpty().substringBefore(':').removePrefix(INCIDENT_ACTION_PREFIX)
+        val resourceId = actionId.orEmpty().substringAfter(':', "").ifBlank {
+            action["value"]?.jsonPrimitive?.contentOrNull.orEmpty()
+        }
+        val context = context(identity, resourceId)
+            ?: return staleResponse(resourceId)
+        if (!authorize(identity, context, SlackIncidentAction.RESPOND)) {
+            return response("You are not authorized to respond to this incident in Slack.")
+        }
+        return handleAction(actionName, root, context, identity, deliveryId)
+    }
+
+    private suspend fun handleAction(
+        actionName: String,
+        root: JsonObject,
+        context: IncidentContext,
+        identity: SlackIdentityResolution,
+        deliveryId: String?,
+    ): String = when (actionName) {
+            "overview", "refresh" -> currentStateResponse(context)
+            "accept" -> execute(context, "accept") {
+                AcceptIncidentCommand(
+                    commandKey = commandKey(deliveryId, "accept"),
+                    actor = actor(identity),
+                    incidentId = context.id,
+                    expectedVersion = context.version,
+                    severity = context.severity ?: "SEV-3",
+                )
+            }
+            "decline" -> execute(context, "decline") {
+                DeclineIncidentCommand(
+                    commandKey = commandKey(deliveryId, "decline"),
+                    actor = actor(identity),
+                    incidentId = context.id,
+                    expectedVersion = context.version,
+                )
+            }
+            "resolve" -> execute(context, "resolve") {
+                ResolveIncidentCommand(
+                    commandKey = commandKey(deliveryId, "resolve"),
+                    actor = actor(identity),
+                    incidentId = context.id,
+                    expectedVersion = context.version,
+                )
+            }
+            "cancel" -> execute(context, "cancel") {
+                CancelIncidentCommand(
+                    commandKey = commandKey(deliveryId, "cancel"),
+                    actor = actor(identity),
+                    incidentId = context.id,
+                    expectedVersion = context.version,
+                )
+            }
+            "reopen" -> execute(context, "reopen") {
+                ReopenIncidentCommand(
+                    commandKey = commandKey(deliveryId, "reopen"),
+                    actor = actor(identity),
+                    incidentId = context.id,
+                    expectedVersion = context.version,
+                )
+            }
+            "join", "observe" -> execute(context, actionName) {
+                SetIncidentParticipationCommand(
+                    commandKey = commandKey(deliveryId, actionName),
+                    actor = actor(identity),
+                    incidentId = context.id,
+                    userId = requireNotNull(identity.userId),
+                    participationType = if (actionName == "join") {
+                        IncidentParticipationType.PARTICIPANT
+                    } else {
+                        IncidentParticipationType.OBSERVER
+                    },
+                    expectedVersion = context.version,
+                )
+            }
+            "leave" -> execute(context, "leave") {
+                LeaveIncidentCommand(
+                    commandKey = commandKey(deliveryId, "leave"),
+                    actor = actor(identity),
+                    incidentId = context.id,
+                    userId = requireNotNull(identity.userId),
+                    expectedVersion = context.version,
+                )
+            }
+            "update", "action", "timeline", "follow_up", "decision" -> openModal(
+                root = root,
+                context = context,
+                callbackId = callbackId(actionName),
+                title = actionName.replace('_', ' ').replaceFirstChar(Char::uppercase),
+            )
+        "merge" -> response("Choose the incident to merge from the incident homepage.")
+        else -> response("This incident action is not available.")
+    }
+
+    suspend fun handleShortcut(root: JsonObject, incidentResourceId: String?): String? {
+        val callbackId = root["callback_id"]?.jsonPrimitive?.contentOrNull ?: return null
+        val actionName = submissionAction(callbackId) ?: return null
+        val identity = resolveIdentity(root)
+        if (!identity.isMapped) return response(identity.message)
+        val resourceId = incidentResourceId
+            ?: root["private_metadata"]?.jsonPrimitive?.contentOrNull
+            ?: root["message"]?.jsonObject?.get("metadata")?.jsonObject
+                ?.get("event_payload")?.jsonObject?.get("incident_id")?.jsonPrimitive?.contentOrNull
+        val context = resourceId?.let { context(identity, it) }
+            ?: return staleResponse(resourceId)
+        if (!authorize(identity, context, SlackIncidentAction.RESPOND)) {
+            return response("You are not authorized to respond to this incident in Slack.")
+        }
+        return openModal(
+            root = root,
+            context = context,
+            callbackId = callbackId,
+            title = actionName.replace('_', ' ').replaceFirstChar(Char::uppercase),
+        )
+    }
+
+    fun handleReaction(root: JsonObject, incidentResourceId: String?, deliveryId: String?): String? {
+        val event = root["event"]?.jsonObject ?: return null
+        if (event["type"]?.jsonPrimitive?.contentOrNull != "reaction_added") return null
+        val reaction = event["reaction"]?.jsonPrimitive?.contentOrNull ?: return null
+        val identity = resolveIdentity(root, event)
+        if (!identity.isMapped) return null
+        val resourceId = incidentResourceId ?: return null
+        val context = context(identity, resourceId) ?: return null
+        if (!authorize(identity, context, SlackIncidentAction.RESPOND)) return null
+        val action = reactionAction(reaction) ?: return null
+        val key = commandKey(deliveryId, "reaction-$reaction")
+        try {
+            when (action) {
+                "action" -> commandService.execute(
+                    AddIncidentActionCommand(
+                        commandKey = key,
+                        actor = actor(identity),
+                        incidentId = context.id,
+                        title = "Follow up from :$reaction: reaction",
+                        expectedVersion = context.version,
+                    ),
+                )
+                "update" -> commandService.execute(
+                    UpdateIncidentCommand(
+                        commandKey = key,
+                        actor = actor(identity),
+                        incidentId = context.id,
+                        message = "Update requested from :$reaction: reaction",
+                        expectedVersion = context.version,
+                    ),
+                )
+                "timeline" -> commandService.execute(
+                    AddIncidentTimelineEventCommand(
+                        commandKey = key,
+                        actor = actor(identity),
+                        incidentId = context.id,
+                        eventType = "SLACK_REACTION",
+                        details = mapOf("reaction" to JsonPrimitive(reaction)),
+                        expectedVersion = context.version,
+                    ),
+                )
+            }
+        } catch (_: IncidentCommandException) {
+            // Slack events have no response channel. The durable delivery record provides retry
+            // semantics; a later reaction or menu interaction shows the current state.
+        }
+        return null
+    }
+
+    fun handleSubmission(root: JsonObject, deliveryId: String?): String? {
+        val view = root["view"]?.jsonObject ?: return null
+        val callbackId = view["callback_id"]?.jsonPrimitive?.contentOrNull ?: return null
+        val actionName = when (callbackId) {
+            UPDATE_CALLBACK_ID -> "update"
+            ACTION_CALLBACK_ID -> "action"
+            TIMELINE_CALLBACK_ID -> "timeline"
+            FOLLOW_UP_CALLBACK_ID -> "follow_up"
+            DECISION_CALLBACK_ID -> "decision"
+            else -> return null
+        }
+        val identity = resolveIdentity(root)
+        if (!identity.isMapped) return response(identity.message)
+        val resourceId = view["private_metadata"]?.jsonPrimitive?.contentOrNull
+        val context = resourceId?.let { context(identity, it) }
+            ?: return staleResponse(resourceId)
+        if (!authorize(identity, context, SlackIncidentAction.RESPOND)) {
+            return response("You are not authorized to respond to this incident in Slack.")
+        }
+        val values = view["state"]?.jsonObject?.get("values")?.jsonObject
+        val text = values?.let { value(it, "text") }?.trim().orEmpty()
+        return submitForm(actionName, identity, context, text, deliveryId)
+    }
+
+    private fun submitForm(
+        actionName: String,
+        identity: SlackIdentityResolution,
+        context: IncidentContext,
+        text: String,
+        deliveryId: String?,
+    ): String {
+        if (text.isBlank()) return submissionErrors()
+        return try {
+            commandService.execute(submissionCommand(actionName, identity, context, text, deliveryId))
+            buildJsonObject { put("response_action", "clear") }.toString()
+        } catch (error: IncidentCommandException) {
+            staleResponse(context, error.message)
+        }
+    }
+
+    private fun submissionCommand(
+        actionName: String,
+        identity: SlackIdentityResolution,
+        context: IncidentContext,
+        text: String,
+        deliveryId: String?,
+    ): com.moneat.enterprise.incidents.commands.IncidentCommand {
+        val actor = actor(identity)
+        val value = text.take(MAX_TEXT_LENGTH)
+        return when (actionName) {
+            "update" -> UpdateIncidentCommand(
+                commandKey = commandKey(deliveryId, "update"),
+                actor = actor,
+                incidentId = context.id,
+                message = value,
+                expectedVersion = context.version,
+            )
+            "action" -> AddIncidentActionCommand(
+                commandKey = commandKey(deliveryId, "action"),
+                actor = actor,
+                incidentId = context.id,
+                title = value,
+                expectedVersion = context.version,
+            )
+            "timeline" -> AddIncidentTimelineEventCommand(
+                commandKey = commandKey(deliveryId, "timeline"),
+                actor = actor,
+                incidentId = context.id,
+                eventType = "SLACK_NOTE",
+                details = mapOf("note" to JsonPrimitive(value)),
+                expectedVersion = context.version,
+            )
+            "follow_up", "decision" -> AddIncidentTimelineEventCommand(
+                commandKey = commandKey(deliveryId, actionName),
+                actor = actor,
+                incidentId = context.id,
+                eventType = if (actionName == "follow_up") "FOLLOW_UP_REQUESTED" else "DECISION_RECORDED",
+                details = mapOf("text" to JsonPrimitive(value)),
+                expectedVersion = context.version,
+            )
+            else -> error("Unsupported Slack incident form")
+        }
+    }
+
+    private fun submissionAction(callbackId: String): String? = when (callbackId) {
+        UPDATE_CALLBACK_ID -> "update"
+        ACTION_CALLBACK_ID -> "action"
+        TIMELINE_CALLBACK_ID -> "timeline"
+        FOLLOW_UP_CALLBACK_ID -> "follow_up"
+        DECISION_CALLBACK_ID -> "decision"
+        else -> null
+    }
+
+    private fun submissionErrors(): String = buildJsonObject {
+        put("response_action", "errors")
+        putJsonObject("errors") { put("text", "Add a value before submitting.") }
+    }.toString()
+
+    private fun execute(
+        context: IncidentContext,
+        action: String,
+        command: () -> com.moneat.enterprise.incidents.commands.IncidentCommand,
+    ): String {
+        return try {
+            commandService.execute(command())
+            response("Incident ${action.replace('_', ' ')} recorded.")
+        } catch (error: IncidentCommandException) {
+            staleResponse(context, error.message)
+        }
+    }
+
+    private suspend fun openModal(
+        root: JsonObject,
+        context: IncidentContext,
+        callbackId: String,
+        title: String,
+    ): String {
+        val triggerId = root["trigger_id"]?.jsonPrimitive?.contentOrNull
+            ?: return response("Slack did not provide a modal trigger. Open the incident homepage to continue.")
+        val teamId = root["team"]?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull
+            ?: root["team_id"]?.jsonPrimitive?.contentOrNull
+            ?: return response("Slack workspace context is required.")
+        val organizationId = installationService.organizationIdForTeam(teamId)
+            ?: return response("This Slack workspace is not connected to Moneat.")
+        val installationId = installationService.internalInstallationIdForTeam(organizationId, teamId)
+            ?: return response("This Slack workspace installation is disabled.")
+        val opened = slackService.openModal(
+            organizationId = organizationId,
+            installationId = installationId,
+            triggerId = triggerId,
+            view = buildJsonObject {
+                put("type", "modal")
+                put("callback_id", callbackId)
+                put("private_metadata", context.resourceId)
+                putJsonObject("title") { put("type", "plain_text"); put("text", title.take(MODAL_TITLE_MAX_LENGTH)) }
+                putJsonObject("submit") { put("type", "plain_text"); put("text", "Submit") }
+                putJsonArray("blocks") {
+                    add(buildJsonObject {
+                        put("type", "input")
+                        put("block_id", "text")
+                        putJsonObject("label") {
+                            put("type", "plain_text")
+                            put("text", title.take(MODAL_LABEL_MAX_LENGTH))
+                        }
+                        putJsonObject("element") {
+                            put("type", "plain_text_input")
+                            put("action_id", "value")
+                            put("multiline", true)
+                        }
+                    })
+                }
+            },
+        )
+        return if (opened) "{}" else response("Moneat could not open the incident form.")
+    }
+
+    private fun resolveIdentity(root: JsonObject, event: JsonObject? = null): SlackIdentityResolution {
+        val teamId = root["team"]?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull
+            ?: root["team_id"]?.jsonPrimitive?.contentOrNull
+            ?: event?.get("team")?.jsonPrimitive?.contentOrNull
+        val userId = root["user"]?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull
+            ?: root["user_id"]?.jsonPrimitive?.contentOrNull
+            ?: event?.get("user")?.jsonPrimitive?.contentOrNull
+        val organizationId = teamId?.let(installationService::organizationIdForTeam)
+        return identityResolver.resolve(
+            SlackIdentityRequest(teamId = teamId, userId = userId, organizationId = organizationId),
+        )
+    }
+
+    private fun context(identity: SlackIdentityResolution, resourceId: String): IncidentContext? {
+        val parsed = resourceId.toUuidOrNull() ?: return null
+        val organizationId = identity.organizationId ?: return null
+        return transaction {
+            OnCallIncidents.selectAll().where {
+                (OnCallIncidents.organizationId eq organizationId) and
+                    (OnCallIncidents.resourceId eq parsed)
+            }.singleOrNull()?.let { row ->
+                val status = NativeIncidentStatus.fromWire(row[OnCallIncidents.status]) ?: return@let null
+                val visibility = NativeIncidentVisibility.entries.firstOrNull {
+                    it.wire == row[OnCallIncidents.visibility]
+                } ?: return@let null
+                IncidentContext(
+                    id = row[OnCallIncidents.id].value,
+                    resourceId = row[OnCallIncidents.resourceId].toString(),
+                    title = row[OnCallIncidents.title],
+                    status = status,
+                    severity = row[OnCallIncidents.severity],
+                    visibility = visibility,
+                    version = row[OnCallIncidents.version],
+                )
+            }
+        }
+    }
+
+    private fun authorize(
+        identity: SlackIdentityResolution,
+        context: IncidentContext,
+        action: SlackIncidentAction,
+    ): Boolean = authorizationService.authorize(
+        SlackIncidentAccessRequest(
+            identity = identity,
+            organizationId = requireNotNull(identity.organizationId),
+            incidentId = context.id,
+            visibility = context.visibility,
+            action = action,
+        ),
+    ).status == SlackIncidentAccessStatus.ALLOWED
+
+    private fun actor(identity: SlackIdentityResolution): IncidentCommandActor = IncidentCommandActor(
+        organizationId = requireNotNull(identity.organizationId),
+        userId = requireNotNull(identity.userId),
+        origin = "SLACK",
+    )
+
+    private fun commandKey(deliveryId: String?, action: String): String =
+        "slack:${deliveryId ?: Uuid.random()}:$action"
+
+    private fun callbackId(actionName: String): String = when (actionName) {
+        "update" -> UPDATE_CALLBACK_ID
+        "action" -> ACTION_CALLBACK_ID
+        "timeline" -> TIMELINE_CALLBACK_ID
+        "follow_up" -> FOLLOW_UP_CALLBACK_ID
+        else -> DECISION_CALLBACK_ID
+    }
+
+    private fun reactionAction(reaction: String): String? = when (reaction) {
+        "white_check_mark", "heavy_check_mark" -> "action"
+        "eyes", "warning" -> "update"
+        "memo", "pushpin", "round_pushpin" -> "timeline"
+        else -> null
+    }
+
+    private fun value(values: JsonObject, blockId: String): String? {
+        val block = values[blockId]?.jsonObject ?: return null
+        val action = block.values.firstOrNull()?.jsonObject ?: return null
+        return action["value"]?.jsonPrimitive?.contentOrNull
+    }
+
+    private fun currentStateResponse(context: IncidentContext): String = buildJsonObject {
+        put("response_type", "ephemeral")
+        put("text", "Incident ${context.status.wire.lowercase()}: ${context.title}")
+        putJsonArray("blocks") {
+            addJsonObject {
+                put("type", "section")
+                putJsonObject("text") {
+                    put("type", "mrkdwn")
+                    put(
+                        "text",
+                        "*${context.title}*\nStatus: `${context.status.wire}` · " +
+                            "Severity: `${context.severity ?: "Unclassified"}`",
+                    )
+                }
+            }
+            addJsonObject {
+                put("type", "actions")
+                putJsonArray("elements") {
+                    add(button("incident_refresh:${context.resourceId}", "Refresh"))
+                    if (!context.status.terminal) add(button("incident_update:${context.resourceId}", "Add update"))
+                }
+            }
+        }
+    }.toString()
+
+    private fun staleResponse(resourceId: String?, reason: String? = null): String = buildJsonObject {
+        put("response_type", "ephemeral")
+        put("text", reason ?: "That incident action is no longer current.")
+        putJsonArray("blocks") {
+            addJsonObject {
+                put("type", "section")
+                putJsonObject("text") {
+                    put("type", "mrkdwn")
+                    put(
+                        "text",
+                        "The incident changed or is no longer available. " +
+                            "Refresh the incident menu to see its current state.",
+                    )
+                }
+            }
+            if (!resourceId.isNullOrBlank()) {
+                addJsonObject {
+                    put("type", "actions")
+                    putJsonArray("elements") { add(button("incident_overview:$resourceId", "Refresh incident")) }
+                }
+            }
+        }
+    }.toString()
+
+    private fun staleResponse(context: IncidentContext, reason: String?): String = buildJsonObject {
+        put("response_type", "ephemeral")
+        put("text", reason ?: "That incident action is no longer current.")
+        putJsonArray("blocks") {
+            addJsonObject {
+                put("type", "section")
+                putJsonObject("text") {
+                    put("type", "mrkdwn")
+                    put(
+                        "text",
+                        "*${context.title}* is currently `${context.status.wire}` " +
+                            "(${context.severity ?: "Unclassified"}). Refresh before trying that action again.",
+                    )
+                }
+            }
+            addJsonObject {
+                put("type", "actions")
+                putJsonArray("elements") {
+                    add(button("incident_overview:${context.resourceId}", "Refresh incident"))
+                    if (!context.status.terminal) add(button("incident_update:${context.resourceId}", "Add update"))
+                }
+            }
+        }
+    }.toString()
+
+    private fun button(actionId: String, label: String): JsonObject = buildJsonObject {
+        put("type", "button")
+        put("action_id", actionId)
+        put("value", actionId.substringAfter(':'))
+        putJsonObject("text") { put("type", "plain_text"); put("text", label) }
+    }
+
+    private fun response(message: String): String = buildJsonObject {
+        put("response_type", "ephemeral")
+        put("text", message)
+    }.toString()
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/slack/SlackIncidentCommandService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/slack/SlackIncidentCommandService.kt
@@ -54,6 +54,7 @@ private const val ACTION_CALLBACK_ID = "moneat_incident_action"
 private const val TIMELINE_CALLBACK_ID = "moneat_incident_timeline"
 private const val FOLLOW_UP_CALLBACK_ID = "moneat_incident_follow_up"
 private const val DECISION_CALLBACK_ID = "moneat_incident_decision"
+private const val UNAUTHORIZED_RESPONSE = "You are not authorized to respond to this incident in Slack."
 private const val MAX_TEXT_LENGTH = 2_000
 private const val MODAL_TITLE_MAX_LENGTH = 24
 private const val MODAL_LABEL_MAX_LENGTH = 75
@@ -97,7 +98,7 @@ class SlackIncidentCommandService(
         val context = context(identity, resourceId)
             ?: return staleResponse(resourceId)
         if (!authorize(identity, context, SlackIncidentAction.RESPOND)) {
-            return response("You are not authorized to respond to this incident in Slack.")
+            return response(UNAUTHORIZED_RESPONSE)
         }
         return handleAction(actionName, root, context, identity, deliveryId)
     }
@@ -189,14 +190,11 @@ class SlackIncidentCommandService(
         val actionName = submissionAction(callbackId) ?: return null
         val identity = resolveIdentity(root)
         if (!identity.isMapped) return response(identity.message)
-        val resourceId = incidentResourceId
-            ?: root["private_metadata"]?.jsonPrimitive?.contentOrNull
-            ?: root["message"]?.jsonObject?.get("metadata")?.jsonObject
-                ?.get("event_payload")?.jsonObject?.get("incident_id")?.jsonPrimitive?.contentOrNull
+        val resourceId = incidentResourceId ?: shortcutIncidentResourceId(root)
         val context = resourceId?.let { context(identity, it) }
             ?: return staleResponse(resourceId)
         if (!authorize(identity, context, SlackIncidentAction.RESPOND)) {
-            return response("You are not authorized to respond to this incident in Slack.")
+            return response(UNAUTHORIZED_RESPONSE)
         }
         return openModal(
             root = root,
@@ -272,7 +270,7 @@ class SlackIncidentCommandService(
         val context = resourceId?.let { context(identity, it) }
             ?: return staleResponse(resourceId)
         if (!authorize(identity, context, SlackIncidentAction.RESPOND)) {
-            return response("You are not authorized to respond to this incident in Slack.")
+            return response(UNAUTHORIZED_RESPONSE)
         }
         val values = view["state"]?.jsonObject?.get("values")?.jsonObject
         val text = values?.let { value(it, "text") }?.trim().orEmpty()
@@ -422,6 +420,15 @@ class SlackIncidentCommandService(
         return identityResolver.resolve(
             SlackIdentityRequest(teamId = teamId, userId = userId, organizationId = organizationId),
         )
+    }
+
+    private fun shortcutIncidentResourceId(root: JsonObject): String? {
+        val privateMetadata = (root["private_metadata"] as? JsonPrimitive)?.contentOrNull
+        if (privateMetadata != null) return privateMetadata
+        val message = root["message"] as? JsonObject ?: return null
+        val metadata = message["metadata"] as? JsonObject ?: return null
+        val eventPayload = metadata["event_payload"] as? JsonObject ?: return null
+        return (eventPayload["incident_id"] as? JsonPrimitive)?.contentOrNull
     }
 
     private fun context(identity: SlackIdentityResolution, resourceId: String): IncidentContext? {

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
@@ -39,8 +39,10 @@ import com.moneat.enterprise.incidents.models.IncidentCustomFieldValueType
 import com.moneat.enterprise.incidents.models.IncidentFormStage
 import com.moneat.enterprise.incidents.models.NativeIncidentMode
 import com.moneat.enterprise.incidents.models.NativeIncidentVisibility
+import com.moneat.enterprise.incidents.announcements.NativeIncidentAnnouncements
 import com.moneat.enterprise.incidents.slack.IncidentSlackChannelState
 import com.moneat.enterprise.incidents.slack.NativeIncidentSlackChannels
+import com.moneat.enterprise.incidents.slack.SlackIncidentCommandService
 import com.moneat.enterprise.oncall.models.OnCallIncidents
 import com.moneat.enterprise.oncall.routes.deviceRoutes
 import com.moneat.enterprise.oncall.routes.escalationRoutes
@@ -167,6 +169,12 @@ class OnCallModule :
         AlertRouteSlackActionService(
             slackInstallationService = slackInstallationService,
             onCallAlertServiceProvider = { onCallAlertService },
+        )
+    }
+    private val slackIncidentCommandService by lazy {
+        SlackIncidentCommandService(
+            installationService = slackInstallationService,
+            slackService = slackService,
         )
     }
     private val slackUserGroupSyncServiceDelegate =
@@ -375,23 +383,72 @@ class OnCallModule :
     ): String? {
         val form = parseQueryString(payload)
         val root = form["payload"]?.let { Json.parseToJsonElement(it).jsonObject }
+            ?: runCatching { Json.parseToJsonElement(payload).jsonObject }.getOrNull()
         val value: (String) -> String? = { key ->
             root?.get(key)?.jsonPrimitive?.contentOrNull ?: form[key]
         }
         val type = root?.get("type")?.jsonPrimitive?.contentOrNull
-        if (requestType == "interactions" && type == "block_actions") {
-            val actionId = root["actions"]?.jsonArray?.firstOrNull()
-                ?.jsonObject?.get("action_id")?.jsonPrimitive?.contentOrNull
-            if (actionId == "incident_menu_declare") return openSlackIncident(root, value)
-            return alertRouteSlackActionService.handle(payload, deliveryId)
+        return when {
+            requestType == "interactions" -> handleSlackInteraction(type, root, value, payload, deliveryId)
+            requestType == "events" -> handleSlackEvent(root, value, deliveryId)
+            requestType == "mentions" -> null
+            requestType == "shortcuts" -> handleSlackShortcut(root, value)
+            else -> slackCommandResponse(requestType, root, value) ?: openSlackIncident(root, value)
         }
-        if (requestType == "interactions" && type == "view_submission") {
-            return submitSlackIncident(root, value, deliveryId)
-        }
-        if (requestType == "events" || requestType == "mentions") return null
-        slackCommandResponse(requestType, root, value)?.let { return it }
+    }
 
-        return openSlackIncident(root, value)
+    private suspend fun handleSlackInteraction(
+        type: String?,
+        root: JsonObject?,
+        value: (String) -> String?,
+        payload: String,
+        deliveryId: String?,
+    ): String? {
+        if (root == null) return slackEphemeral("Slack workspace and user context are required.")
+        return when (type) {
+            "block_actions" -> handleSlackBlockActions(root, value, payload, deliveryId)
+            "view_submission" -> slackIncidentCommandService.handleSubmission(root, deliveryId)
+                ?: submitSlackIncident(root, value, deliveryId)
+            else -> null
+        }
+    }
+
+    private suspend fun handleSlackBlockActions(
+        root: JsonObject,
+        value: (String) -> String?,
+        payload: String,
+        deliveryId: String?,
+    ): String? {
+        val actionId = root["actions"]?.jsonArray?.firstOrNull()
+            ?.jsonObject?.get("action_id")?.jsonPrimitive?.contentOrNull
+        if (actionId == "incident_menu_declare") return openSlackIncident(root, value)
+        return slackIncidentCommandService.handleBlockAction(root, deliveryId)
+            ?: alertRouteSlackActionService.handle(payload, deliveryId)
+    }
+
+    private fun handleSlackEvent(
+        root: JsonObject?,
+        value: (String) -> String?,
+        deliveryId: String?,
+    ): String? {
+        if (root == null) return null
+        slackIncidentCommandService.handleReaction(
+            root = root,
+            incidentResourceId = incidentResourceIdForSlackChannel(root, value),
+            deliveryId = deliveryId,
+        )
+        return null
+    }
+
+    private suspend fun handleSlackShortcut(
+        root: JsonObject?,
+        value: (String) -> String?,
+    ): String? {
+        if (root == null) return slackEphemeral("Slack workspace and user context are required.")
+        return slackIncidentCommandService.handleShortcut(
+            root = root,
+            incidentResourceId = incidentResourceIdForSlackChannel(root, value),
+        ) ?: slackCommandResponse("shortcuts", root, value)
     }
 
     private fun slackCommandResponse(
@@ -414,12 +471,16 @@ class OnCallModule :
         root: JsonObject?,
         value: (String) -> String?,
     ): String? {
+        val event = root?.get("event")?.jsonObject
         val channelId = value("channel_id")
             ?: root?.get("channel")?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull
+            ?: event?.get("channel")?.jsonPrimitive?.contentOrNull
         if (channelId.isNullOrBlank()) return null
+        val messageTs = event?.get("item")?.jsonObject?.get("ts")?.jsonPrimitive?.contentOrNull
         val submitter = resolveSlackSubmitter(root, value, slackInstallationService) ?: return null
         val teamId = root?.get("team")?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull
             ?: value("team_id")
+            ?: event?.get("team")?.jsonPrimitive?.contentOrNull
             ?: return null
         return transaction {
             val channel = NativeIncidentSlackChannels
@@ -431,8 +492,22 @@ class OnCallModule :
                         (NativeIncidentSlackChannels.state eq IncidentSlackChannelState.ACTIVE.wire)
                 }
                 .firstOrNull()
+            val announcement = if (channel == null && !messageTs.isNullOrBlank()) {
+                NativeIncidentAnnouncements
+                    .selectAll()
+                    .where {
+                        (NativeIncidentAnnouncements.organizationId eq submitter.organizationId) and
+                            (NativeIncidentAnnouncements.teamId eq teamId) and
+                            (NativeIncidentAnnouncements.channelId eq channelId) and
+                            (NativeIncidentAnnouncements.providerMessageTs eq messageTs)
+                    }
+                    .firstOrNull()
+            } else {
+                null
+            }
+            val incidentId = channel?.get(NativeIncidentSlackChannels.incidentId)
+                ?: announcement?.get(NativeIncidentAnnouncements.incidentId)
                 ?: return@transaction null
-            val incidentId = channel[NativeIncidentSlackChannels.incidentId]
             OnCallIncidents
                 .selectAll()
                 .where {
@@ -631,6 +706,31 @@ internal fun slackIncidentCommandMenu(incidentResourceId: String? = null): Strin
                     }
                 }
             }
+            incidentResourceId?.let { resourceId ->
+                listOf(
+                    listOf("Overview" to "overview", "Update" to "update", "Actions" to "action"),
+                    listOf("Timeline" to "timeline", "Join" to "join", "Observe" to "observe", "Leave" to "leave"),
+                    listOf("Accept" to "accept", "Decline" to "decline", "Resolve" to "resolve", "Cancel" to "cancel"),
+                    listOf("Reopen" to "reopen", "Refresh" to "refresh"),
+                ).forEach { group ->
+                    addJsonObject {
+                        put("type", "actions")
+                        putJsonArray("elements") {
+                            group.forEach { (label, action) ->
+                                addJsonObject {
+                                    put("type", "button")
+                                    put("action_id", "incident_$action:$resourceId")
+                                    put("value", resourceId)
+                                    putJsonObject("text") {
+                                        put("type", "plain_text")
+                                        put("text", label)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }.toString()
 
@@ -676,10 +776,13 @@ private fun resolveSlackSubmitter(
     value: (String) -> String?,
     installationService: SlackInstallationService,
 ): SlackIncidentSubmitter? {
+    val event = root?.get("event")?.jsonObject
     val teamId = root?.get("team")?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull
         ?: value("team_id")
+        ?: event?.get("team")?.jsonPrimitive?.contentOrNull
     val slackUserId = root?.get("user")?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull
         ?: value("user_id")
+        ?: event?.get("user")?.jsonPrimitive?.contentOrNull
     val organizationId = teamId?.let(installationService::organizationIdForTeam) ?: return null
     val installationId = installationService.internalInstallationIdForTeam(organizationId, requireNotNull(teamId))
         ?: return null

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
@@ -476,6 +476,7 @@ class OnCallModule :
         val channelId = value("channel_id")
             ?: root?.get("channel")?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull
             ?: event?.get("channel")?.jsonPrimitive?.contentOrNull
+            ?: event?.get("item")?.jsonObject?.get("channel")?.jsonPrimitive?.contentOrNull
         if (channelId.isNullOrBlank()) return null
         val messageTs = event?.get("item")?.jsonObject?.get("ts")?.jsonPrimitive?.contentOrNull
         val submitter = resolveSlackSubmitter(root, value, slackInstallationService) ?: return null
@@ -493,33 +494,13 @@ class OnCallModule :
                         (NativeIncidentSlackChannels.state eq IncidentSlackChannelState.ACTIVE.wire)
                 }
                 .firstOrNull()
-            val announcement = if (channel == null && !messageTs.isNullOrBlank()) {
-                val deliveryResourceId = SlackOutboundDeliveries
-                    .selectAll()
-                    .where {
-                        (SlackOutboundDeliveries.organizationId eq submitter.organizationId) and
-                            (SlackOutboundDeliveries.teamId eq teamId) and
-                            (SlackOutboundDeliveries.channelId eq channelId) and
-                            (SlackOutboundDeliveries.providerMessageTs eq messageTs)
-                    }
-                    .firstOrNull()
-                    ?.get(SlackOutboundDeliveries.resourceId)
-                NativeIncidentAnnouncements
-                    .selectAll()
-                    .where {
-                        (NativeIncidentAnnouncements.organizationId eq submitter.organizationId) and
-                            (NativeIncidentAnnouncements.teamId eq teamId) and
-                            (NativeIncidentAnnouncements.channelId eq channelId)
-                    }
-                    .firstOrNull { row ->
-                        row[NativeIncidentAnnouncements.providerMessageTs] == messageTs ||
-                            row[NativeIncidentAnnouncements.deliveryResourceId] == deliveryResourceId
-                    }
+            val announcementIncidentId = if (channel == null) {
+                findAnnouncementIncidentId(submitter.organizationId, teamId, channelId, messageTs)
             } else {
                 null
             }
             val incidentId = channel?.get(NativeIncidentSlackChannels.incidentId)
-                ?: announcement?.get(NativeIncidentAnnouncements.incidentId)
+                ?: announcementIncidentId
                 ?: return@transaction null
             OnCallIncidents
                 .selectAll()
@@ -531,6 +512,38 @@ class OnCallModule :
                 ?.get(OnCallIncidents.resourceId)
                 ?.toString()
         }
+    }
+
+    private fun findAnnouncementIncidentId(
+        organizationId: Int,
+        teamId: String,
+        channelId: String,
+        messageTs: String?,
+    ): Int? {
+        if (messageTs.isNullOrBlank()) return null
+        val deliveryResourceId = SlackOutboundDeliveries
+            .selectAll()
+            .where {
+                (SlackOutboundDeliveries.organizationId eq organizationId) and
+                    (SlackOutboundDeliveries.teamId eq teamId) and
+                    (SlackOutboundDeliveries.channelId eq channelId) and
+                    (SlackOutboundDeliveries.providerMessageTs eq messageTs)
+            }
+            .firstOrNull()
+            ?.get(SlackOutboundDeliveries.resourceId)
+        return NativeIncidentAnnouncements
+            .selectAll()
+            .where {
+                (NativeIncidentAnnouncements.organizationId eq organizationId) and
+                    (NativeIncidentAnnouncements.teamId eq teamId) and
+                    (NativeIncidentAnnouncements.channelId eq channelId)
+            }
+            .firstOrNull { row ->
+                row[NativeIncidentAnnouncements.providerMessageTs] == messageTs ||
+                    (deliveryResourceId != null &&
+                        row[NativeIncidentAnnouncements.deliveryResourceId] == deliveryResourceId)
+            }
+            ?.get(NativeIncidentAnnouncements.incidentId)
     }
 
     private suspend fun openSlackIncident(

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
@@ -70,6 +70,7 @@ import com.moneat.mcp.McpToolContributor
 import com.moneat.mcp.protocol.McpToolRegistry
 import com.moneat.notifications.services.SlackService
 import com.moneat.notifications.services.SlackInstallationService
+import com.moneat.shared.models.SlackOutboundDeliveries
 import com.moneat.shared.models.SlackUserMappings
 import io.ktor.server.application.Application
 import io.ktor.http.parseQueryString
@@ -493,15 +494,27 @@ class OnCallModule :
                 }
                 .firstOrNull()
             val announcement = if (channel == null && !messageTs.isNullOrBlank()) {
+                val deliveryResourceId = SlackOutboundDeliveries
+                    .selectAll()
+                    .where {
+                        (SlackOutboundDeliveries.organizationId eq submitter.organizationId) and
+                            (SlackOutboundDeliveries.teamId eq teamId) and
+                            (SlackOutboundDeliveries.channelId eq channelId) and
+                            (SlackOutboundDeliveries.providerMessageTs eq messageTs)
+                    }
+                    .firstOrNull()
+                    ?.get(SlackOutboundDeliveries.resourceId)
                 NativeIncidentAnnouncements
                     .selectAll()
                     .where {
                         (NativeIncidentAnnouncements.organizationId eq submitter.organizationId) and
                             (NativeIncidentAnnouncements.teamId eq teamId) and
-                            (NativeIncidentAnnouncements.channelId eq channelId) and
-                            (NativeIncidentAnnouncements.providerMessageTs eq messageTs)
+                            (NativeIncidentAnnouncements.channelId eq channelId)
                     }
-                    .firstOrNull()
+                    .firstOrNull { row ->
+                        row[NativeIncidentAnnouncements.providerMessageTs] == messageTs ||
+                            row[NativeIncidentAnnouncements.deliveryResourceId] == deliveryResourceId
+                    }
             } else {
                 null
             }

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
@@ -79,6 +79,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
@@ -103,6 +104,7 @@ private const val SLACK_FORM_LABEL_MAX_CHARS = 75
 private const val SLACK_FORM_HINT_MAX_CHARS = 200
 private const val SLACK_FORM_OPTION_MAX_CHARS = 75
 private const val SLACK_INCIDENT_MENU_CALLBACK_ID = "moneat_incident_menu"
+private const val SLACK_CONTEXT_REQUIRED = "Slack workspace and user context are required."
 private val SLACK_INCIDENT_HELP_COMMANDS = setOf("help", "menu", "commands", "incident help", "incident menu")
 
 private data class SlackIncidentSubmitter(
@@ -405,7 +407,7 @@ class OnCallModule :
         payload: String,
         deliveryId: String?,
     ): String? {
-        if (root == null) return slackEphemeral("Slack workspace and user context are required.")
+        if (root == null) return slackEphemeral(SLACK_CONTEXT_REQUIRED)
         return when (type) {
             "block_actions" -> handleSlackBlockActions(root, value, payload, deliveryId)
             "view_submission" -> slackIncidentCommandService.handleSubmission(root, deliveryId)
@@ -445,7 +447,7 @@ class OnCallModule :
         root: JsonObject?,
         value: (String) -> String?,
     ): String? {
-        if (root == null) return slackEphemeral("Slack workspace and user context are required.")
+        if (root == null) return slackEphemeral(SLACK_CONTEXT_REQUIRED)
         return slackIncidentCommandService.handleShortcut(
             root = root,
             incidentResourceId = incidentResourceIdForSlackChannel(root, value),
@@ -473,10 +475,7 @@ class OnCallModule :
         value: (String) -> String?,
     ): String? {
         val event = root?.get("event")?.jsonObject
-        val channelId = value("channel_id")
-            ?: root?.get("channel")?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull
-            ?: event?.get("channel")?.jsonPrimitive?.contentOrNull
-            ?: event?.get("item")?.jsonObject?.get("channel")?.jsonPrimitive?.contentOrNull
+        val channelId = slackChannelId(root, event, value)
         if (channelId.isNullOrBlank()) return null
         val messageTs = event?.get("item")?.jsonObject?.get("ts")?.jsonPrimitive?.contentOrNull
         val submitter = resolveSlackSubmitter(root, value, slackInstallationService) ?: return null
@@ -512,6 +511,19 @@ class OnCallModule :
                 ?.get(OnCallIncidents.resourceId)
                 ?.toString()
         }
+    }
+
+    private fun slackChannelId(
+        root: JsonObject?,
+        event: JsonObject?,
+        value: (String) -> String?,
+    ): String? {
+        value("channel_id")?.let { return it }
+        val rootChannel = root?.get("channel") as? JsonObject
+        (rootChannel?.get("id") as? JsonPrimitive)?.contentOrNull?.let { return it }
+        (event?.get("channel") as? JsonPrimitive)?.contentOrNull?.let { return it }
+        val item = event?.get("item") as? JsonObject
+        return (item?.get("channel") as? JsonPrimitive)?.contentOrNull
     }
 
     private fun findAnnouncementIncidentId(
@@ -554,7 +566,7 @@ class OnCallModule :
         val slackUserId = value("user_id") ?: root?.get("user")?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull
         val triggerId = value("trigger_id") ?: root?.get("trigger_id")?.jsonPrimitive?.contentOrNull
         if (teamId.isNullOrBlank() || slackUserId.isNullOrBlank()) {
-            return slackEphemeral("Slack workspace and user context are required.")
+            return slackEphemeral(SLACK_CONTEXT_REQUIRED)
         }
         val organizationId = slackInstallationService.organizationIdForTeam(teamId)
             ?: return slackEphemeral("This Slack workspace is not connected to a Moneat organization.")

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/announcements/IncidentAnnouncementServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/announcements/IncidentAnnouncementServiceTest.kt
@@ -77,6 +77,8 @@ class IncidentAnnouncementServiceTest {
         assertEquals("MESSAGE", requests.single().operation.wire)
         assertTrue(requests.single().payload.contains("incident_accept"))
         assertTrue(requests.single().payload.contains("Incident summary"))
+        assertTrue(requests.single().payload.contains("moneat_incident"))
+        assertTrue(requests.single().payload.contains(incidentResourceId.toString()))
         assertEquals(1, transaction { NativeIncidentAnnouncements.selectAll().count() })
     }
 

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/SlackIncidentDeclarationViewTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/SlackIncidentDeclarationViewTest.kt
@@ -69,6 +69,9 @@ class SlackIncidentDeclarationViewTest {
         assertTrue(menu.contains("Incident menu"))
         assertTrue(menu.contains("incident-resource-123"))
         assertTrue(menu.contains("incident_menu_declare"))
+        listOf("overview", "update", "action", "timeline", "join", "observe", "leave", "accept", "decline",
+            "resolve", "cancel", "reopen", "refresh")
+            .forEach { action -> assertTrue(menu.contains("incident_$action:incident-resource-123")) }
     }
 
     @Test


### PR DESCRIPTION
Adds incident-bound Slack actions for existing incident commands, plus shortcut/reaction routing and stale-state refresh responses. Announcement payloads include incident metadata so shared-channel shortcuts resolve safely. Focused enterprise tests and Detekt pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Slack-based incident actions for shortcuts, buttons, reactions, and modal submissions.
  * Incident announcements now include metadata for reliable incident identification.
  * Expanded incident menus with actions for viewing, updating, participating, resolving, canceling, reopening, and refreshing incidents.
  * Improved incident lookup across announcement messages and active incident channels.

* **Bug Fixes**
  * Improved handling of nested Slack event data and stale or unauthorized actions.

* **Tests**
  * Added coverage for incident metadata and supported Slack incident actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->