### PR TITLE
feat: mirror alert events into incident timeline

### DIFF
--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommandService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommandService.kt
@@ -239,6 +239,7 @@ class IncidentCommandService(
         }
         command.onCallAlertId?.let { alertId ->
             linkAlertRecord(incidentId, alertId)
+            incidentAlertTimelineBridge.backfill(incidentId, alertId)
             val alert = requireAlert(command.actor.organizationId, alertId)
             insertSourceLink(
                 command.actor,
@@ -1037,8 +1038,11 @@ class IncidentCommandService(
 
         val now = Clock.System.now()
         when (source.sourceType) {
-            com.moneat.enterprise.incidents.models.IncidentSourceType.ON_CALL_ALERT ->
-                linkAlertRecord(command.incidentId, checkNotNull(source.onCallAlertId))
+            com.moneat.enterprise.incidents.models.IncidentSourceType.ON_CALL_ALERT -> {
+                val alertId = checkNotNull(source.onCallAlertId)
+                linkAlertRecord(command.incidentId, alertId)
+                incidentAlertTimelineBridge.backfill(command.incidentId, alertId)
+            }
             com.moneat.enterprise.incidents.models.IncidentSourceType.ALERT_EPISODE ->
                 linkAlertEpisodeRecord(command, checkNotNull(source.alertEpisodeId), now)
             else -> Unit

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommandService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommandService.kt
@@ -26,6 +26,7 @@ import com.moneat.enterprise.incidents.models.NativeIncidentStatus
 import com.moneat.enterprise.incidents.models.IncidentUpdateRequestStatus
 import com.moneat.enterprise.incidents.models.NativeIncidentUpdateRequests
 import com.moneat.enterprise.incidents.timeline.IncidentTimelineWriter
+import com.moneat.enterprise.incidents.timeline.IncidentAlertTimelineBridge
 import com.moneat.enterprise.incidents.timeline.PendingIncidentTimelineEvent
 import com.moneat.enterprise.incidents.timeline.toIncidentTimelineProvenance
 import com.moneat.enterprise.oncall.models.OnCallAlerts
@@ -59,6 +60,7 @@ class IncidentCommandService(
     private val policy: IncidentCommandPolicy = IncidentCommandPolicy(),
     private val outboxWriter: IncidentOutboxWriter = IncidentOutboxWriter(),
     private val timelineWriter: IncidentTimelineWriter = IncidentTimelineWriter(),
+    private val incidentAlertTimelineBridge: IncidentAlertTimelineBridge = IncidentAlertTimelineBridge(),
     private val configurationService: IncidentConfigurationService = IncidentConfigurationService(),
 ) {
     fun execute(command: IncidentCommand): IncidentCommandResult {
@@ -978,9 +980,11 @@ class IncidentCommandService(
             if (existing[OnCallIncidentAlerts.incidentId] != command.incidentId) {
                 throw IncidentCommandConflictException("On-call alert is already linked to another native incident")
             }
+            incidentAlertTimelineBridge.backfill(command.incidentId, command.alertId)
             return loadMutation(command.incidentId, changed = false)
         }
         linkAlertRecord(command.incidentId, command.alertId)
+        incidentAlertTimelineBridge.backfill(command.incidentId, command.alertId)
         val now = Clock.System.now()
         val nextVersion = current[OnCallIncidents.version] + 1
         val updated =

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/timeline/IncidentAlertTimelineBridge.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/timeline/IncidentAlertTimelineBridge.kt
@@ -9,9 +9,12 @@ import com.moneat.enterprise.incidents.models.IncidentTimelineProvenance
 import com.moneat.enterprise.oncall.models.OnCallAlertTimeline
 import com.moneat.enterprise.oncall.models.OnCallAlerts
 import com.moneat.enterprise.oncall.models.OnCallIncidentAlerts
+import com.moneat.enterprise.oncall.models.EscalationExecutionEvents
+import com.moneat.enterprise.oncall.models.EscalationExecutionStates
 import kotlinx.serialization.json.JsonPrimitive
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
@@ -53,7 +56,32 @@ class IncidentAlertTimelineBridge(
             .where { OnCallAlertTimeline.alertId eq alertId }
             .toList()
         events.forEach { record(linked[OnCallIncidentAlerts.incidentId], alert, it) }
-        events.size
+        val executionIds = EscalationExecutionStates.selectAll()
+            .where { EscalationExecutionStates.alertId eq alertId }
+            .map { it[EscalationExecutionStates.id].value }
+        val escalationEvents = EscalationExecutionEvents.selectAll()
+            .where { EscalationExecutionEvents.executionId inList executionIds }
+            .toList()
+        escalationEvents.forEach { record(linked[OnCallIncidentAlerts.incidentId], alert, it) }
+        events.size + escalationEvents.size
+    }
+
+    /** Records one escalation-path event when its alert is linked to a native incident. */
+    fun recordForEscalationEvent(eventId: Int): Boolean = inTransaction {
+        val event = EscalationExecutionEvents.selectAll()
+            .where { EscalationExecutionEvents.id eq eventId }
+            .singleOrNull() ?: return@inTransaction false
+        val execution = EscalationExecutionStates.selectAll()
+            .where { EscalationExecutionStates.id eq event[EscalationExecutionEvents.executionId] }
+            .singleOrNull() ?: return@inTransaction false
+        val alert = OnCallAlerts.selectAll()
+            .where { OnCallAlerts.id eq execution[EscalationExecutionStates.alertId] }
+            .singleOrNull() ?: return@inTransaction false
+        val link = OnCallIncidentAlerts.selectAll()
+            .where { OnCallIncidentAlerts.alertId eq execution[EscalationExecutionStates.alertId] }
+            .singleOrNull() ?: return@inTransaction false
+        record(link[OnCallIncidentAlerts.incidentId], alert, event, execution)
+        true
     }
 
     private fun <T> inTransaction(block: () -> T): T =
@@ -75,6 +103,35 @@ class IncidentAlertTimelineBridge(
                 details = (event[OnCallAlertTimeline.details] ?: emptyMap()) + mapOf(
                     "alertId" to JsonPrimitive(alert[OnCallAlerts.resourceId].toString()),
                     "alertTimelineEventId" to JsonPrimitive(event[OnCallAlertTimeline.resourceId].toString()),
+                ),
+                provenance = IncidentTimelineProvenance.INTEGRATION,
+                originalOccurredAt = occurredAt,
+                observedAt = clock.now(),
+                sourceType = IncidentSourceType.ON_CALL_ALERT.wire,
+                sourceReference = alert[OnCallAlerts.resourceId].toString(),
+            ),
+        )
+    }
+
+    private fun record(
+        incidentId: Int,
+        alert: org.jetbrains.exposed.v1.core.ResultRow,
+        event: org.jetbrains.exposed.v1.core.ResultRow,
+        execution: org.jetbrains.exposed.v1.core.ResultRow,
+    ) {
+        val occurredAt = event[EscalationExecutionEvents.createdAt]
+        timelineWriter.record(
+            PendingIncidentTimelineEvent(
+                organizationId = alert[OnCallAlerts.organizationId],
+                incidentId = incidentId,
+                eventKey = "on-call-escalation:${alert[OnCallAlerts.resourceId]}:" +
+                    event[EscalationExecutionEvents.resourceId],
+                eventType = "ESCALATION_${event[EscalationExecutionEvents.eventType]}",
+                actorUserId = event[EscalationExecutionEvents.actorUserId],
+                details = event[EscalationExecutionEvents.details] + mapOf(
+                    "alertId" to JsonPrimitive(alert[OnCallAlerts.resourceId].toString()),
+                    "executionId" to JsonPrimitive(execution[EscalationExecutionStates.resourceId].toString()),
+                    "executionEventId" to JsonPrimitive(event[EscalationExecutionEvents.resourceId].toString()),
                 ),
                 provenance = IncidentTimelineProvenance.INTEGRATION,
                 originalOccurredAt = occurredAt,

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/timeline/IncidentAlertTimelineBridge.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/timeline/IncidentAlertTimelineBridge.kt
@@ -1,0 +1,87 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.incidents.timeline
+
+import com.moneat.enterprise.incidents.models.IncidentSourceType
+import com.moneat.enterprise.incidents.models.IncidentTimelineProvenance
+import com.moneat.enterprise.oncall.models.OnCallAlertTimeline
+import com.moneat.enterprise.oncall.models.OnCallAlerts
+import com.moneat.enterprise.oncall.models.OnCallIncidentAlerts
+import kotlinx.serialization.json.JsonPrimitive
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.time.Clock
+
+/** Copies legacy escalation events into the canonical incident timeline. */
+class IncidentAlertTimelineBridge(
+    private val timelineWriter: IncidentTimelineWriter = IncidentTimelineWriter(),
+    private val clock: Clock = Clock.System,
+) {
+    /** Records one alert event when the alert is already linked to a native incident. */
+    fun recordForAlertTimeline(alertTimelineId: Int): Boolean = inTransaction {
+        val timeline = OnCallAlertTimeline.selectAll()
+            .where { OnCallAlertTimeline.id eq alertTimelineId }
+            .singleOrNull() ?: return@inTransaction false
+        val alertId = timeline[OnCallAlertTimeline.alertId]
+        val alert = OnCallAlerts.selectAll()
+            .where { OnCallAlerts.id eq alertId }
+            .singleOrNull() ?: return@inTransaction false
+        val link = OnCallIncidentAlerts.selectAll()
+            .where { OnCallIncidentAlerts.alertId eq alertId }
+            .singleOrNull() ?: return@inTransaction false
+        record(link[OnCallIncidentAlerts.incidentId], alert, timeline)
+        true
+    }
+
+    /** Replays all prior alert events after an alert is linked to an incident. */
+    fun backfill(incidentId: Int, alertId: Int): Int = inTransaction {
+        val linked = OnCallIncidentAlerts.selectAll()
+            .where {
+                (OnCallIncidentAlerts.incidentId eq incidentId) and
+                    (OnCallIncidentAlerts.alertId eq alertId)
+            }
+            .singleOrNull() ?: return@inTransaction 0
+        val alert = OnCallAlerts.selectAll()
+            .where { OnCallAlerts.id eq alertId }
+            .singleOrNull() ?: return@inTransaction 0
+        val events = OnCallAlertTimeline.selectAll()
+            .where { OnCallAlertTimeline.alertId eq alertId }
+            .toList()
+        events.forEach { record(linked[OnCallIncidentAlerts.incidentId], alert, it) }
+        events.size
+    }
+
+    private fun <T> inTransaction(block: () -> T): T =
+        if (TransactionManager.currentOrNull() == null) transaction { block() } else block()
+
+    private fun record(
+        incidentId: Int,
+        alert: org.jetbrains.exposed.v1.core.ResultRow,
+        event: org.jetbrains.exposed.v1.core.ResultRow,
+    ) {
+        val occurredAt = event[OnCallAlertTimeline.createdAt]
+        timelineWriter.record(
+            PendingIncidentTimelineEvent(
+                organizationId = alert[OnCallAlerts.organizationId],
+                incidentId = incidentId,
+                eventKey = "on-call-alert:${alert[OnCallAlerts.resourceId]}:${event[OnCallAlertTimeline.resourceId]}",
+                eventType = "ALERT_${event[OnCallAlertTimeline.eventType]}",
+                actorUserId = event[OnCallAlertTimeline.actorUserId],
+                details = (event[OnCallAlertTimeline.details] ?: emptyMap()) + mapOf(
+                    "alertId" to JsonPrimitive(alert[OnCallAlerts.resourceId].toString()),
+                    "alertTimelineEventId" to JsonPrimitive(event[OnCallAlertTimeline.resourceId].toString()),
+                ),
+                provenance = IncidentTimelineProvenance.INTEGRATION,
+                originalOccurredAt = occurredAt,
+                observedAt = clock.now(),
+                sourceType = IncidentSourceType.ON_CALL_ALERT.wire,
+                sourceReference = alert[OnCallAlerts.resourceId].toString(),
+            ),
+        )
+    }
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/timeline/IncidentAlertTimelineBridge.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/timeline/IncidentAlertTimelineBridge.kt
@@ -56,13 +56,25 @@ class IncidentAlertTimelineBridge(
             .where { OnCallAlertTimeline.alertId eq alertId }
             .toList()
         events.forEach { record(linked[OnCallIncidentAlerts.incidentId], alert, it) }
-        val executionIds = EscalationExecutionStates.selectAll()
+        val executions = EscalationExecutionStates.selectAll()
             .where { EscalationExecutionStates.alertId eq alertId }
-            .map { it[EscalationExecutionStates.id].value }
-        val escalationEvents = EscalationExecutionEvents.selectAll()
-            .where { EscalationExecutionEvents.executionId inList executionIds }
             .toList()
-        escalationEvents.forEach { record(linked[OnCallIncidentAlerts.incidentId], alert, it) }
+        val executionsById = executions.associateBy { it[EscalationExecutionStates.id].value }
+        val escalationEvents = if (executionsById.isEmpty()) {
+            emptyList()
+        } else {
+            EscalationExecutionEvents.selectAll()
+                .where { EscalationExecutionEvents.executionId inList executionsById.keys }
+                .toList()
+        }
+        escalationEvents.forEach { event ->
+            record(
+                linked[OnCallIncidentAlerts.incidentId],
+                alert,
+                event,
+                executionsById.getValue(event[EscalationExecutionEvents.executionId]),
+            )
+        }
         events.size + escalationEvents.size
     }
 

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/EscalationEngine.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/EscalationEngine.kt
@@ -9,6 +9,7 @@ import com.moneat.enterprise.oncall.alertResourceId
 import com.moneat.enterprise.oncall.incidentResourceIdOrNull
 import com.moneat.enterprise.oncall.organizationResourceId
 import com.moneat.enterprise.oncall.userResourceIdOrNull
+import com.moneat.enterprise.incidents.timeline.IncidentAlertTimelineBridge
 import com.moneat.shared.services.TaskLock
 import com.moneat.config.RedisClient
 import com.moneat.enterprise.oncall.models.EscalationStepTarget
@@ -33,7 +34,6 @@ import org.jetbrains.exposed.v1.core.JoinType
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.inList
-import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
@@ -63,6 +63,7 @@ class EscalationEngine(
     private var timeoutPollingJob: Job? = null
     private val twilioService = TwilioService()
     private val notificationPrefsService = UserNotificationPreferencesService()
+    private val incidentAlertTimelineBridge = IncidentAlertTimelineBridge()
 
     companion object {
         private const val TIMEOUT_KEY_PREFIX = "escalation:timeout:"
@@ -877,13 +878,14 @@ class EscalationEngine(
         actorUserId: Int?,
         details: Map<String, JsonElement>?,
     ) {
-        OnCallAlertTimeline.insert {
+        val timelineId = OnCallAlertTimeline.insertAndGetId {
             it[OnCallAlertTimeline.alertId] = incidentId
             it[OnCallAlertTimeline.eventType] = eventType
             it[OnCallAlertTimeline.actorUserId] = actorUserId
             it[OnCallAlertTimeline.details] = details
             it[createdAt] = Clock.System.now()
-        }
+        }.value
+        incidentAlertTimelineBridge.recordForAlertTimeline(timelineId)
     }
 
     fun getNextEscalationTimes(): Map<Int, String> {

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/EscalationPathService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/EscalationPathService.kt
@@ -4,6 +4,7 @@
 
 package com.moneat.enterprise.oncall.services
 
+import com.moneat.enterprise.incidents.timeline.IncidentAlertTimelineBridge
 import com.moneat.enterprise.oncall.models.EscalationExecutionEvents
 import com.moneat.enterprise.oncall.models.EscalationExecutionStates
 import com.moneat.enterprise.oncall.models.EscalationPath
@@ -25,7 +26,6 @@ import kotlinx.serialization.json.put
 import kotlinx.serialization.SerialName
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
-import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
@@ -65,6 +65,8 @@ data class EscalationExecutionTransition(
 )
 
 class EscalationPathService {
+    private val incidentAlertTimelineBridge = IncidentAlertTimelineBridge()
+
     companion object {
         const val STATUS_DRAFT = "DRAFT"
         const val STATUS_PUBLISHED = "PUBLISHED"
@@ -260,7 +262,7 @@ class EscalationPathService {
         executionId: Int,
         event: EscalationExecutionEvent,
     ) {
-        EscalationExecutionEvents.insert {
+        val eventId = EscalationExecutionEvents.insertAndGetId {
             it[EscalationExecutionEvents.organizationId] = organizationId
             it[EscalationExecutionEvents.executionId] = executionId
             it[EscalationExecutionEvents.eventType] = event.type
@@ -268,7 +270,8 @@ class EscalationPathService {
             it[EscalationExecutionEvents.nodeId] = event.nodeId
             it[EscalationExecutionEvents.details] = event.details
             it[createdAt] = Clock.System.now()
-        }
+        }.value
+        incidentAlertTimelineBridge.recordForEscalationEvent(eventId)
     }
 
     private fun getExecutionInTransaction(executionId: Int): EscalationExecution? =

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/IncidentTestDatabase.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/IncidentTestDatabase.kt
@@ -45,6 +45,9 @@ import com.moneat.enterprise.oncall.models.OnCallAlertTimeline
 import com.moneat.enterprise.oncall.models.OnCallIncidentAlerts
 import com.moneat.enterprise.oncall.models.OnCallIncidentTimeline
 import com.moneat.enterprise.oncall.models.OnCallIncidents
+import com.moneat.enterprise.oncall.models.EscalationExecutionEvents
+import com.moneat.enterprise.oncall.models.EscalationExecutionStates
+import com.moneat.enterprise.oncall.models.EscalationPolicyVersions
 import com.moneat.enterprise.sso.support.EnterpriseTestDatabaseHelper
 import com.moneat.shared.models.EscalationPolicies
 import com.moneat.shared.models.Memberships
@@ -91,6 +94,9 @@ object IncidentTestDatabase {
             OnCallAlertTimeline,
             OnCallIncidentAlerts,
             OnCallIncidentTimeline,
+            EscalationPolicyVersions,
+            EscalationExecutionStates,
+            EscalationExecutionEvents,
             NativeIncidentTimelineRevisions,
             NativeIncidentFormSubmissions,
             NativeIncidentAlertEpisodeLinks,

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/IncidentTestDatabase.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/IncidentTestDatabase.kt
@@ -41,6 +41,7 @@ import com.moneat.enterprise.incidents.models.NativeIncidentSourceLinks
 import com.moneat.enterprise.incidents.models.NativeIncidentTimelineRevisions
 import com.moneat.enterprise.incidents.models.NativeIncidentTypes
 import com.moneat.enterprise.oncall.models.OnCallAlerts
+import com.moneat.enterprise.oncall.models.OnCallAlertTimeline
 import com.moneat.enterprise.oncall.models.OnCallIncidentAlerts
 import com.moneat.enterprise.oncall.models.OnCallIncidentTimeline
 import com.moneat.enterprise.oncall.models.OnCallIncidents
@@ -87,6 +88,7 @@ object IncidentTestDatabase {
             NativeIncidentFormFields,
             OnCallIncidents,
             OnCallAlerts,
+            OnCallAlertTimeline,
             OnCallIncidentAlerts,
             OnCallIncidentTimeline,
             NativeIncidentTimelineRevisions,

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/timeline/IncidentAlertTimelineBridgeTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/timeline/IncidentAlertTimelineBridgeTest.kt
@@ -1,0 +1,161 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.incidents.timeline
+
+import com.moneat.enterprise.incidents.IncidentTestDatabase
+import com.moneat.enterprise.incidents.SeededMember
+import com.moneat.enterprise.incidents.commands.DeclareIncidentCommand
+import com.moneat.enterprise.incidents.commands.IncidentCommandActor
+import com.moneat.enterprise.incidents.commands.IncidentCommandPolicy
+import com.moneat.enterprise.incidents.commands.IncidentCommandService
+import com.moneat.enterprise.incidents.commands.LinkOnCallAlertCommand
+import com.moneat.enterprise.oncall.models.OnCallAlertTimeline
+import com.moneat.enterprise.oncall.models.OnCallAlerts
+import com.moneat.enterprise.oncall.models.OnCallIncidentTimeline
+import kotlinx.serialization.json.JsonPrimitive
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Instant
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+
+class IncidentAlertTimelineBridgeTest {
+    private lateinit var member: SeededMember
+
+    @BeforeEach
+    fun setUp() {
+        IncidentTestDatabase.reset()
+        member = IncidentTestDatabase.seedMember()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        IncidentTestDatabase.clearReference()
+    }
+
+    @Test
+    fun `backfills legacy alert events once when an alert is linked`() {
+        val alertId = seedAlert()
+        val occurredAt = Instant.parse("2026-08-25T00:00:00Z")
+        seedAlertTimeline(alertId, "ACKNOWLEDGED", occurredAt)
+        val incident = declareIncident()
+        val service = IncidentCommandService(policy = IncidentCommandPolicy.allowForTests())
+
+        service.execute(
+            LinkOnCallAlertCommand(
+                commandKey = "link-alert-timeline",
+                actor = actor(),
+                incidentId = incident,
+                alertId = alertId,
+                expectedVersion = 1,
+            ),
+        )
+
+        val bridge = IncidentAlertTimelineBridge(clock = FixedClock(Instant.parse("2026-08-25T00:01:00Z")))
+        assertEquals(1, bridge.backfill(incident, alertId))
+        assertEquals(1, bridge.backfill(incident, alertId))
+        transaction {
+            val entries = OnCallIncidentTimeline.selectAll().where {
+                (OnCallIncidentTimeline.incidentId eq incident) and
+                    (OnCallIncidentTimeline.eventType eq "ALERT_ACKNOWLEDGED")
+            }.toList()
+            assertEquals(1, entries.size)
+            assertEquals(occurredAt, entries.single()[OnCallIncidentTimeline.originalOccurredAt])
+            assertEquals("INTEGRATION", entries.single()[OnCallIncidentTimeline.provenance])
+            assertTrue(entries.single()[OnCallIncidentTimeline.eventKey].startsWith("on-call-alert:"))
+        }
+    }
+
+    @Test
+    fun `records new alert events for an already linked incident`() {
+        val alertId = seedAlert()
+        val incident = declareIncident()
+        val service = IncidentCommandService(policy = IncidentCommandPolicy.allowForTests())
+        service.execute(
+            LinkOnCallAlertCommand(
+                commandKey = "link-new-alert-event",
+                actor = actor(),
+                incidentId = incident,
+                alertId = alertId,
+                expectedVersion = 1,
+            ),
+        )
+        val timelineId = seedAlertTimeline(
+            alertId,
+            "RESOLVED",
+            Instant.parse("2026-08-25T00:02:00Z"),
+        )
+
+        assertTrue(IncidentAlertTimelineBridge().recordForAlertTimeline(timelineId))
+        transaction {
+            assertEquals(
+                1,
+                OnCallIncidentTimeline.selectAll().where {
+                    (OnCallIncidentTimeline.incidentId eq incident) and
+                        (OnCallIncidentTimeline.eventType eq "ALERT_RESOLVED")
+                }.count(),
+            )
+        }
+    }
+
+    private fun actor() = IncidentCommandActor(member.organizationId, member.userId, "REST")
+
+    private fun declareIncident(): Int =
+        IncidentCommandService(policy = IncidentCommandPolicy.allowForTests()).execute(
+            DeclareIncidentCommand(
+                commandKey = "declare-alert-timeline",
+                actor = actor(),
+                title = "Checkout unavailable",
+                description = null,
+                severity = "SEV-2",
+            ),
+        ).incidentId
+
+    private fun seedAlert(): Int = transaction {
+        val now = Clock.System.now()
+        OnCallAlerts.insertAndGetId {
+            it[organizationId] = member.organizationId
+            it[declaredIncidentId] = null
+            it[escalationPolicyId] = null
+            it[title] = "Checkout alert"
+            it[description] = null
+            it[priority] = "P1"
+            it[status] = "TRIGGERED"
+            it[alertSource] = "TEST"
+            it[deduplicationKey] = "alert-timeline"
+            it[currentStep] = 0
+            it[repeatIteration] = 0
+            it[triggeredAt] = now
+            it[acknowledgedAt] = null
+            it[acknowledgedBy] = null
+            it[resolvedAt] = null
+            it[resolvedBy] = null
+            it[metadata] = null
+            it[createdAt] = now
+            it[updatedAt] = now
+        }.value
+    }
+
+    private fun seedAlertTimeline(alertId: Int, eventType: String, occurredAt: Instant): Int = transaction {
+        OnCallAlertTimeline.insertAndGetId {
+            it[OnCallAlertTimeline.alertId] = alertId
+            it[OnCallAlertTimeline.eventType] = eventType
+            it[OnCallAlertTimeline.actorUserId] = member.userId
+            it[OnCallAlertTimeline.details] = mapOf("channel" to JsonPrimitive("push"))
+            it[OnCallAlertTimeline.createdAt] = occurredAt
+        }.value
+    }
+
+    private class FixedClock(private val instant: Instant) : Clock {
+        override fun now(): Instant = instant
+    }
+}

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/timeline/IncidentAlertTimelineBridgeTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/timeline/IncidentAlertTimelineBridgeTest.kt
@@ -10,7 +10,10 @@ import com.moneat.enterprise.incidents.commands.DeclareIncidentCommand
 import com.moneat.enterprise.incidents.commands.IncidentCommandActor
 import com.moneat.enterprise.incidents.commands.IncidentCommandPolicy
 import com.moneat.enterprise.incidents.commands.IncidentCommandService
+import com.moneat.enterprise.incidents.commands.IncidentSourceReference
 import com.moneat.enterprise.incidents.commands.LinkOnCallAlertCommand
+import com.moneat.enterprise.incidents.commands.LinkIncidentSourceCommand
+import com.moneat.enterprise.incidents.models.IncidentSourceType
 import com.moneat.enterprise.oncall.models.OnCallAlertTimeline
 import com.moneat.enterprise.oncall.models.OnCallAlerts
 import com.moneat.enterprise.oncall.models.OnCallIncidentTimeline
@@ -135,6 +138,67 @@ class IncidentAlertTimelineBridgeTest {
             assertEquals(1, entries.size)
             assertEquals("INTEGRATION", entries.single()[OnCallIncidentTimeline.provenance])
             assertTrue(entries.single()[OnCallIncidentTimeline.eventKey].startsWith("on-call-escalation:"))
+        }
+    }
+
+    @Test
+    fun `backfills alert events when declaration links the alert`() {
+        val alertId = seedAlert()
+        seedAlertTimeline(alertId, "ACKNOWLEDGED", Instant.parse("2026-08-25T00:03:00Z"))
+
+        val incident = IncidentCommandService(policy = IncidentCommandPolicy.allowForTests()).execute(
+            DeclareIncidentCommand(
+                commandKey = "declare-linked-alert",
+                actor = actor(),
+                title = "Checkout unavailable",
+                description = null,
+                severity = "SEV-2",
+                onCallAlertId = alertId,
+            ),
+        ).incidentId
+
+        transaction {
+            assertEquals(
+                1,
+                OnCallIncidentTimeline.selectAll().where {
+                    (OnCallIncidentTimeline.incidentId eq incident) and
+                        (OnCallIncidentTimeline.eventType eq "ALERT_ACKNOWLEDGED")
+                }.count(),
+            )
+        }
+    }
+
+    @Test
+    fun `backfills alert events when a source link links the alert`() {
+        val alertId = seedAlert()
+        seedAlertTimeline(alertId, "RESOLVED", Instant.parse("2026-08-25T00:04:00Z"))
+        val incident = declareIncident()
+        val alertResourceId = transaction {
+            OnCallAlerts.selectAll().where { OnCallAlerts.id eq alertId }.single()[OnCallAlerts.resourceId].toString()
+        }
+
+        IncidentCommandService(policy = IncidentCommandPolicy.allowForTests()).execute(
+            LinkIncidentSourceCommand(
+                commandKey = "link-source-alert",
+                actor = actor(),
+                incidentId = incident,
+                source = IncidentSourceReference(
+                    sourceType = IncidentSourceType.ON_CALL_ALERT,
+                    sourceKey = alertResourceId,
+                    onCallAlertId = alertId,
+                ),
+                expectedVersion = 1,
+            ),
+        )
+
+        transaction {
+            assertEquals(
+                1,
+                OnCallIncidentTimeline.selectAll().where {
+                    (OnCallIncidentTimeline.incidentId eq incident) and
+                        (OnCallIncidentTimeline.eventType eq "ALERT_RESOLVED")
+                }.count(),
+            )
         }
     }
 

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/timeline/IncidentAlertTimelineBridgeTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/timeline/IncidentAlertTimelineBridgeTest.kt
@@ -14,6 +14,9 @@ import com.moneat.enterprise.incidents.commands.LinkOnCallAlertCommand
 import com.moneat.enterprise.oncall.models.OnCallAlertTimeline
 import com.moneat.enterprise.oncall.models.OnCallAlerts
 import com.moneat.enterprise.oncall.models.OnCallIncidentTimeline
+import com.moneat.enterprise.oncall.models.EscalationPolicyVersions
+import com.moneat.enterprise.oncall.services.EscalationPathService
+import com.moneat.shared.models.EscalationPolicies
 import kotlinx.serialization.json.JsonPrimitive
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
 import org.jetbrains.exposed.v1.jdbc.selectAll
@@ -107,6 +110,34 @@ class IncidentAlertTimelineBridgeTest {
         }
     }
 
+    @Test
+    fun `records escalation events for an already linked incident`() {
+        val alertId = seedAlert()
+        val incident = declareIncident()
+        val service = IncidentCommandService(policy = IncidentCommandPolicy.allowForTests())
+        service.execute(
+            LinkOnCallAlertCommand(
+                commandKey = "link-escalation-event",
+                actor = actor(),
+                incidentId = incident,
+                alertId = alertId,
+                expectedVersion = 1,
+            ),
+        )
+
+        EscalationPathService().createExecution(member.organizationId, alertId, seedPolicyVersion(), "root")
+
+        transaction {
+            val entries = OnCallIncidentTimeline.selectAll().where {
+                (OnCallIncidentTimeline.incidentId eq incident) and
+                    (OnCallIncidentTimeline.eventType eq "ESCALATION_STARTED")
+            }.toList()
+            assertEquals(1, entries.size)
+            assertEquals("INTEGRATION", entries.single()[OnCallIncidentTimeline.provenance])
+            assertTrue(entries.single()[OnCallIncidentTimeline.eventKey].startsWith("on-call-escalation:"))
+        }
+    }
+
     private fun actor() = IncidentCommandActor(member.organizationId, member.userId, "REST")
 
     private fun declareIncident(): Int =
@@ -142,6 +173,28 @@ class IncidentAlertTimelineBridgeTest {
             it[metadata] = null
             it[createdAt] = now
             it[updatedAt] = now
+        }.value
+    }
+
+    private fun seedPolicyVersion(): Int = transaction {
+        val now = Clock.System.now()
+        val policyId = EscalationPolicies.insertAndGetId {
+            it[organizationId] = member.organizationId
+            it[name] = "Incident escalation"
+            it[description] = null
+            it[repeatCount] = 1
+            it[createdAt] = now
+            it[updatedAt] = now
+        }.value
+        EscalationPolicyVersions.insertAndGetId {
+            it[organizationId] = member.organizationId
+            it[escalationPolicyId] = policyId
+            it[version] = 1
+            it[status] = "PUBLISHED"
+            it[path] = emptyMap()
+            it[createdBy] = member.userId
+            it[createdAt] = now
+            it[publishedAt] = now
         }.value
     }
 


### PR DESCRIPTION
Adds canonical timeline producer coverage for on-call alert events, including link-time backfill, source references, original and observed timestamps, and idempotent deduplication. Includes focused enterprise tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - On-call alert escalation events are now recorded in the incident timeline.
  - Historical alert and escalation activity is backfilled when an alert is linked to an incident.
  - Timeline entries include relevant alert, escalation, execution, and source details.

- **Bug Fixes**
  - Prevented duplicate incident timeline entries during repeated backfills or event recording.
  - Alert resolution events now appear correctly in the associated incident timeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->