### PR TITLE
fix: route Slack declaration message shortcuts

### DIFF
--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
@@ -104,6 +104,7 @@ private const val SLACK_FORM_LABEL_MAX_CHARS = 75
 private const val SLACK_FORM_HINT_MAX_CHARS = 200
 private const val SLACK_FORM_OPTION_MAX_CHARS = 75
 private const val SLACK_INCIDENT_MENU_CALLBACK_ID = "moneat_incident_menu"
+private const val SLACK_INCIDENT_DECLARATION_CALLBACK_ID = "moneat_incident_declaration"
 private const val SLACK_CONTEXT_REQUIRED = "Slack workspace and user context are required."
 private val SLACK_INCIDENT_HELP_COMMANDS = setOf("help", "menu", "commands", "incident help", "incident menu")
 
@@ -448,6 +449,9 @@ class OnCallModule :
         value: (String) -> String?,
     ): String? {
         if (root == null) return slackEphemeral(SLACK_CONTEXT_REQUIRED)
+        if (value("callback_id") == SLACK_INCIDENT_DECLARATION_CALLBACK_ID) {
+            return openSlackIncident(root, value)
+        }
         return slackIncidentCommandService.handleShortcut(
             root = root,
             incidentResourceId = incidentResourceIdForSlackChannel(root, value),
@@ -584,8 +588,7 @@ class OnCallModule :
         } != null
         if (!linkedUser) return slackEphemeral("Link your Slack identity in Moneat before declaring an incident.")
 
-        val contextText = value("text")
-            ?: root?.get("message")?.jsonObject?.get("text")?.jsonPrimitive?.contentOrNull
+        val contextText = slackMessageContextText(root, value)
         if (triggerId.isNullOrBlank()) return slackEphemeral("Slack did not provide a modal trigger.")
         val opened = slackService.openModal(
             organizationId = organizationId,
@@ -693,6 +696,15 @@ class OnCallModule :
         userId: Int,
     ): Boolean = onCallAlertService.acknowledge(alertId, userId)
 }
+
+internal fun slackMessageContextText(
+    root: JsonObject?,
+    value: (String) -> String?,
+): String? = sequenceOf(
+    value("text"),
+    root?.get("message")?.jsonObject?.get("text")?.jsonPrimitive?.contentOrNull,
+).mapNotNull { it?.trim()?.takeIf(String::isNotEmpty) }
+    .firstOrNull()
 
 private fun slackEphemeral(message: String): String =
     buildJsonObject {
@@ -845,7 +857,7 @@ internal fun slackIncidentDeclarationView(
 ): JsonObject =
     buildJsonObject {
         put("type", "modal")
-        put("callback_id", "moneat_incident_declaration")
+        put("callback_id", SLACK_INCIDENT_DECLARATION_CALLBACK_ID)
         putJsonObject("title") {
             put("type", "plain_text")
             put("text", "Declare incident")

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
@@ -702,7 +702,7 @@ internal fun slackMessageContextText(
     value: (String) -> String?,
 ): String? = sequenceOf(
     value("text"),
-    root?.get("message")?.jsonObject?.get("text")?.jsonPrimitive?.contentOrNull,
+    (root?.get("message") as? JsonObject)?.get("text")?.jsonPrimitive?.contentOrNull,
 ).mapNotNull { it?.trim()?.takeIf(String::isNotEmpty) }
     .firstOrNull()
 

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/SlackIncidentDeclarationViewTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/SlackIncidentDeclarationViewTest.kt
@@ -14,6 +14,8 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 import org.junit.jupiter.api.Test
 import kotlinx.coroutines.runBlocking
 import kotlin.test.assertEquals
@@ -44,6 +46,58 @@ class SlackIncidentDeclarationViewTest {
             blocks.get(4).jsonObject["element"]?.jsonObject?.get("initial_option")
                 ?.jsonObject?.get("value")?.toString()?.trim('"'),
         )
+    }
+
+    @Test
+    fun `message shortcut context is read from public dm and connect payloads`() {
+        val payloads = listOf(
+            """
+            {
+              "type": "message_action",
+              "channel": {"id": "C123", "name": "support"},
+              "message": {"text": "Public checkout failures"}
+            }
+            """ to "Public checkout failures",
+            """
+            {
+              "type": "message_action",
+              "channel": {"id": "D123"},
+              "message": {"text": "DM reports a failed payment"}
+            }
+            """ to "DM reports a failed payment",
+            """
+            {
+              "type": "message_action",
+              "team": {"id": "T-CONNECT"},
+              "channel": {"id": "C-CONNECT", "name": "partner"},
+              "text": "Partner workspace outage"
+            }
+            """ to "Partner workspace outage",
+        )
+
+        payloads.forEach { (payload, expected) ->
+            val root = Json.parseToJsonElement(payload).jsonObject
+            assertEquals(expected, slackMessageContextText(root) { key ->
+                root[key]?.jsonPrimitive?.contentOrNull
+            })
+            val view = slackIncidentDeclarationView(slackMessageContextText(root) { key ->
+                root[key]?.jsonPrimitive?.contentOrNull
+            })
+            assertEquals(expected, view["blocks"]?.jsonArray?.first()
+                ?.jsonObject?.get("element")?.jsonObject?.get("initial_value")?.toString()?.trim('"'))
+        }
+    }
+
+    @Test
+    fun `declaration message shortcut does not fall through to incident menu handling`() = runBlocking {
+        val response = OnCallModule().handleSlackInbound(
+            "shortcuts",
+            "payload=%7B%22type%22%3A%22message_action%22%2C%22callback_id%22%3A" +
+                "%22moneat_incident_declaration%22%7D",
+            null,
+        )
+
+        assertTrue(response?.contains("workspace and user context") == true)
     }
 
     @Test


### PR DESCRIPTION
Routes declaration shortcuts through the existing Slack incident form and preserves message context across supported conversation types. Adds focused regression coverage for shortcut dispatch and validation behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Slack shortcut that opens the incident declaration modal directly.
  * Prefills the modal using text from the selected shortcut or message context.
  * Supports incident declarations from public channels, direct messages, and connected workspaces.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->