### PR TITLE
fix: warn when alert routes skip incident creation

### DIFF
--- a/dashboard/src/components/on-call/alert-routes/AlertRouteIncidentSection.tsx
+++ b/dashboard/src/components/on-call/alert-routes/AlertRouteIncidentSection.tsx
@@ -82,13 +82,12 @@ export function AlertRouteIncidentSection({
       </label>
 
       {!incident.create && (
-        <p
+        <output
           className="rounded-md border border-warning-border bg-warning-bg px-3 py-2 text-xs text-warning-fg"
-          role="status"
         >
           This route will not create incidents while this option is off. Matching alerts may still
           be grouped or paged.
-        </p>
+        </output>
       )}
 
       {incident.create && (

--- a/dashboard/src/components/on-call/alert-routes/AlertRouteIncidentSection.tsx
+++ b/dashboard/src/components/on-call/alert-routes/AlertRouteIncidentSection.tsx
@@ -71,7 +71,7 @@ export function AlertRouteIncidentSection({
         <span className="min-w-0">
           <span className="block text-sm font-medium">Create an incident for matched alerts</span>
           <span className="mt-0.5 block text-xs text-muted-foreground">
-            When off, matched alerts still page and group but no incident is opened.
+            Enable this on an enabled, matching route to open incidents automatically.
           </span>
         </span>
         <Switch
@@ -80,6 +80,16 @@ export function AlertRouteIncidentSection({
           aria-label="Create an incident for matched alerts"
         />
       </label>
+
+      {!incident.create && (
+        <p
+          className="rounded-md border border-warning-border bg-warning-bg px-3 py-2 text-xs text-warning-fg"
+          role="status"
+        >
+          This route will not create incidents while this option is off. Matching alerts may still
+          be grouped or paged.
+        </p>
+      )}
 
       {incident.create && (
         <div className="space-y-4 border-l-2 border-muted pl-4">

--- a/dashboard/src/components/on-call/alert-routes/__tests__/AlertRouteSections.test.tsx
+++ b/dashboard/src/components/on-call/alert-routes/__tests__/AlertRouteSections.test.tsx
@@ -131,6 +131,7 @@ describe('alert route editor sections', () => {
         onRecoveryChange={onRecoveryChange}
       />
     )
+    expect(screen.getByRole('status')).toHaveTextContent('will not create incidents while this option is off')
     fireEvent.click(screen.getByLabelText('Create an incident for matched alerts'))
     fireEvent.click(screen.getByLabelText('Cancel active escalations when the group recovers'))
     fireEvent.click(screen.getByLabelText('Decline triage incidents that were never accepted'))
@@ -153,6 +154,7 @@ describe('alert route editor sections', () => {
         onRecoveryChange={onRecoveryChange}
       />
     )
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
     fireEvent.change(screen.getByLabelText('Title template (optional)'), {target: {value: 'New title'}})
     fireEvent.change(screen.getByLabelText('Summary template (optional)'), {target: {value: 'New summary'}})
     expect(screen.getByText('Active incidents require a severity.')).toBeInTheDocument()


### PR DESCRIPTION
Clarifies the alert-route editor when incident creation is disabled.

- explains that the route must be enabled and matched to open incidents
- adds an accessible warning when incident creation is off
- covers the state transition in the focused component test

Task: TASK-1.14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience**
  * Updated incident-creation guidance to clearly explain the enabled behavior.
  * Added a warning when incident creation is turned off, clarifying that matching alerts may still be grouped or paged but won’t create incidents.

* **Tests**
  * Added coverage to verify the warning appears when incident creation is disabled and disappears when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->