### PR TITLE
fix: persist incident response nudge state

### DIFF
--- a/backend/src/main/resources/db/migration/V173__incident_announcement_nudge_state.sql
+++ b/backend/src/main/resources/db/migration/V173__incident_announcement_nudge_state.sql
@@ -1,0 +1,24 @@
+-- Durable Slack incident nudge dismissal, activity, and rate-limit state.
+CREATE TABLE native_incident_announcement_nudges (
+    id SERIAL PRIMARY KEY,
+    resource_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    incident_id INTEGER NOT NULL REFERENCES on_call_incidents(id) ON DELETE CASCADE,
+    rule_key VARCHAR(160) NOT NULL,
+    team_id VARCHAR(255) NOT NULL,
+    channel_id VARCHAR(255) NOT NULL,
+    nudge_key VARCHAR(64) NOT NULL,
+    dismissed_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    dismissed_at TIMESTAMP,
+    last_shown_at TIMESTAMP,
+    last_shown_version INTEGER,
+    last_activity_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_native_incident_announcement_nudge_resource UNIQUE (organization_id, resource_id),
+    CONSTRAINT uq_native_incident_announcement_nudge_key
+        UNIQUE (organization_id, incident_id, rule_key, team_id, channel_id, nudge_key)
+);
+
+CREATE INDEX idx_native_incident_announcement_nudge_incident
+    ON native_incident_announcement_nudges(organization_id, incident_id, updated_at);

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/announcements/IncidentAnnouncementNudgeService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/announcements/IncidentAnnouncementNudgeService.kt
@@ -1,0 +1,147 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.incidents.announcements
+
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+/** Persists nudge visibility, dismissal, and activity state for Slack announcement cards. */
+class IncidentAnnouncementNudgeService(
+    private val clock: Clock = Clock.System,
+) {
+    data class Scope(
+        val organizationId: Int,
+        val incidentId: Int,
+        val ruleKey: String,
+        val teamId: String,
+        val channelId: String,
+    )
+
+    fun visibleKeys(
+        scope: Scope,
+        applicableKeys: Set<String>,
+    ): Set<String> = transaction {
+        resetSatisfied(
+            scope = scope,
+            applicableKeys = applicableKeys,
+        )
+        val now = clock.now()
+        val rows = NativeIncidentAnnouncementNudges
+            .selectAll()
+            .where {
+                (NativeIncidentAnnouncementNudges.organizationId eq scope.organizationId) and
+                    (NativeIncidentAnnouncementNudges.incidentId eq scope.incidentId) and
+                    (NativeIncidentAnnouncementNudges.ruleKey eq scope.ruleKey) and
+                    (NativeIncidentAnnouncementNudges.teamId eq scope.teamId) and
+                    (NativeIncidentAnnouncementNudges.channelId eq scope.channelId)
+            }
+            .toList()
+        val existingKeys = rows.map { it[NativeIncidentAnnouncementNudges.nudgeKey] }.toSet()
+        rows.filter { row ->
+                row[NativeIncidentAnnouncementNudges.nudgeKey] in applicableKeys &&
+                    row[NativeIncidentAnnouncementNudges.dismissedAt] == null &&
+                    ready(row[NativeIncidentAnnouncementNudges.lastShownAt], now) &&
+                    ready(row[NativeIncidentAnnouncementNudges.lastActivityAt], now)
+        }.map { it[NativeIncidentAnnouncementNudges.nudgeKey] }.toSet() + (applicableKeys - existingKeys)
+    }
+
+    fun recordShown(
+        scope: Scope,
+        keys: Set<String>,
+        version: Int,
+    ) {
+        if (keys.isEmpty()) return
+        transaction {
+            val now = clock.now()
+            keys.forEach { key ->
+                val predicate = nudgePredicate(scope, key)
+                val updated = NativeIncidentAnnouncementNudges.update({ predicate }) {
+                    it[lastShownAt] = now
+                    it[lastShownVersion] = version
+                    it[lastActivityAt] = now
+                    it[updatedAt] = now
+                }
+                if (updated == 0) {
+                    NativeIncidentAnnouncementNudges.insert {
+                        it[resourceId] = Uuid.random()
+                        it[NativeIncidentAnnouncementNudges.organizationId] = scope.organizationId
+                        it[NativeIncidentAnnouncementNudges.incidentId] = scope.incidentId
+                        it[NativeIncidentAnnouncementNudges.ruleKey] = scope.ruleKey
+                        it[NativeIncidentAnnouncementNudges.teamId] = scope.teamId
+                        it[NativeIncidentAnnouncementNudges.channelId] = scope.channelId
+                        it[nudgeKey] = key
+                        it[dismissedBy] = null
+                        it[dismissedAt] = null
+                        it[lastShownAt] = now
+                        it[lastShownVersion] = version
+                        it[lastActivityAt] = now
+                        it[createdAt] = now
+                        it[updatedAt] = now
+                    }
+                }
+            }
+        }
+    }
+
+    fun dismiss(organizationId: Int, incidentId: Int, nudgeKey: String, userId: Int): Boolean = transaction {
+        val now = clock.now()
+        NativeIncidentAnnouncementNudges.update({
+            (NativeIncidentAnnouncementNudges.organizationId eq organizationId) and
+                (NativeIncidentAnnouncementNudges.incidentId eq incidentId) and
+                (NativeIncidentAnnouncementNudges.nudgeKey eq nudgeKey)
+        }) {
+            it[dismissedBy] = userId
+            it[dismissedAt] = now
+            it[updatedAt] = now
+        } > 0
+    }
+
+    private fun resetSatisfied(scope: Scope, applicableKeys: Set<String>) {
+        val predicate = (NativeIncidentAnnouncementNudges.organizationId eq scope.organizationId) and
+            (NativeIncidentAnnouncementNudges.incidentId eq scope.incidentId) and
+            (NativeIncidentAnnouncementNudges.ruleKey eq scope.ruleKey) and
+            (NativeIncidentAnnouncementNudges.teamId eq scope.teamId) and
+            (NativeIncidentAnnouncementNudges.channelId eq scope.channelId)
+        NativeIncidentAnnouncementNudges
+            .selectAll()
+            .where { predicate }
+            .filter { row -> row[NativeIncidentAnnouncementNudges.nudgeKey] !in applicableKeys }
+            .forEach { row ->
+                NativeIncidentAnnouncementNudges.update({
+                    NativeIncidentAnnouncementNudges.id eq row[NativeIncidentAnnouncementNudges.id]
+                }) {
+                    it[dismissedBy] = null
+                    it[dismissedAt] = null
+                    it[lastShownAt] = null
+                    it[lastShownVersion] = null
+                    it[lastActivityAt] = null
+                    it[updatedAt] = clock.now()
+                }
+            }
+    }
+
+    private fun nudgePredicate(scope: Scope, nudgeKey: String) =
+        (NativeIncidentAnnouncementNudges.organizationId eq scope.organizationId) and
+            (NativeIncidentAnnouncementNudges.incidentId eq scope.incidentId) and
+            (NativeIncidentAnnouncementNudges.ruleKey eq scope.ruleKey) and
+            (NativeIncidentAnnouncementNudges.teamId eq scope.teamId) and
+            (NativeIncidentAnnouncementNudges.channelId eq scope.channelId) and
+            (NativeIncidentAnnouncementNudges.nudgeKey eq nudgeKey)
+
+    private fun ready(lastAt: Instant?, now: Instant): Boolean =
+        lastAt == null || now - lastAt >= NUDGE_COOLDOWN
+
+    companion object {
+        private val NUDGE_COOLDOWN = 5.minutes
+    }
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/announcements/IncidentAnnouncementNudgeState.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/announcements/IncidentAnnouncementNudgeState.kt
@@ -1,0 +1,38 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.incidents.announcements
+
+import com.moneat.enterprise.oncall.models.OnCallIncidents
+import com.moneat.shared.models.Organizations
+import com.moneat.shared.models.Users
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
+import org.jetbrains.exposed.v1.datetime.timestamp
+import kotlin.time.Clock
+import kotlin.uuid.Uuid
+
+/** Durable per-destination state for activity-aware incident response nudges. */
+object NativeIncidentAnnouncementNudges : IntIdTable("native_incident_announcement_nudges") {
+    val resourceId = uuid("resource_id").clientDefault { Uuid.random() }
+    val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
+    val incidentId = integer("incident_id").references(OnCallIncidents.id, onDelete = ReferenceOption.CASCADE)
+    val ruleKey = varchar("rule_key", 160)
+    val teamId = varchar("team_id", 255)
+    val channelId = varchar("channel_id", 255)
+    val nudgeKey = varchar("nudge_key", 64)
+    val dismissedBy = integer("dismissed_by").references(Users.id, onDelete = ReferenceOption.SET_NULL).nullable()
+    val dismissedAt = timestamp("dismissed_at").nullable()
+    val lastShownAt = timestamp("last_shown_at").nullable()
+    val lastShownVersion = integer("last_shown_version").nullable()
+    val lastActivityAt = timestamp("last_activity_at").nullable()
+    val createdAt = timestamp("created_at").clientDefault { Clock.System.now() }
+    val updatedAt = timestamp("updated_at").clientDefault { Clock.System.now() }
+
+    init {
+        uniqueIndex(organizationId, resourceId)
+        uniqueIndex(organizationId, incidentId, ruleKey, teamId, channelId, nudgeKey)
+        index(false, organizationId, incidentId, updatedAt)
+    }
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/announcements/IncidentAnnouncementService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/announcements/IncidentAnnouncementService.kt
@@ -26,6 +26,7 @@ import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
 import kotlinx.serialization.Serializable
 import org.jetbrains.exposed.v1.core.and
@@ -44,6 +45,7 @@ class IncidentAnnouncementService(
     private val outboundDeliveryService: SlackOutboundDeliveryService = SlackOutboundDeliveryService(),
     private val enqueue: ((SlackOutboundEnqueueRequest) -> String)? = null,
     private val clock: Clock = Clock.System,
+    private val nudgeStateService: IncidentAnnouncementNudgeService = IncidentAnnouncementNudgeService(clock),
 ) {
     private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
 
@@ -150,7 +152,17 @@ class IncidentAnnouncementService(
                 outboundDeliveryService.find(id)?.providerMessageTs
             }
         val isUpdate = previousTs != null
-        val cardPayload = cardPayload(snapshot, destination, previousTs)
+        val visibleNudgeKeys = nudgeStateService.visibleKeys(
+            scope = IncidentAnnouncementNudgeService.Scope(
+                organizationId = event.organizationId,
+                incidentId = event.incidentId,
+                ruleKey = destination.ruleKey,
+                teamId = destination.teamId,
+                channelId = destination.channelId,
+            ),
+            applicableKeys = applicableNudgeKeys(snapshot, destination.conditions.nudges),
+        )
+        val cardPayload = cardPayload(snapshot, destination, previousTs, visibleNudgeKeys)
         val idempotencyKey =
             "incident:${snapshot.resourceId}:announcement:${destination.ruleKey}:${destination.teamId}" +
                 ":${destination.channelId}:card"
@@ -166,6 +178,17 @@ class IncidentAnnouncementService(
         try {
             val deliveryId = enqueue(request)
             persistAnnouncement(event, destination, cardPayload, previousTs, deliveryId)
+            nudgeStateService.recordShown(
+                scope = IncidentAnnouncementNudgeService.Scope(
+                    organizationId = event.organizationId,
+                    incidentId = event.incidentId,
+                    ruleKey = destination.ruleKey,
+                    teamId = destination.teamId,
+                    channelId = destination.channelId,
+                ),
+                keys = visibleNudgeKeys,
+                version = event.aggregateVersion,
+            )
             if (previousTs != null && isMaterialUpdate(event.eventType)) {
                 enqueueThread(event, snapshot, destination, previousTs)
             }
@@ -393,6 +416,7 @@ class IncidentAnnouncementService(
         snapshot: IncidentSnapshot,
         destination: AnnouncementDestination,
         messageTs: String?,
+        visibleNudgeKeys: Set<String>,
     ): String =
         json.encodeToString(
             buildJsonObject {
@@ -448,7 +472,7 @@ class IncidentAnnouncementService(
                             })
                         })
                     }
-                    nudgeBlock(snapshot, destination.conditions.nudges)?.let(::add)
+                    nudgeBlocks(snapshot, destination.conditions.nudges, visibleNudgeKeys).forEach(::add)
                     add(buildJsonObject {
                         put("type", "context")
                         put("elements", buildJsonArray {
@@ -505,41 +529,66 @@ class IncidentAnnouncementService(
         put("value", value)
     }
 
-    private fun nudgeBlock(
+    private fun nudgeBlocks(
         snapshot: IncidentSnapshot,
         policy: IncidentAnnouncementNudgePolicy,
-    ): JsonObject? {
-        if (!policy.enabled || snapshot.status in TERMINAL_STATUSES) return null
-        val nudges = nudgeMessages(snapshot, policy)
-        if (nudges.isEmpty()) return null
-        return buildJsonObject {
-            put("type", "section")
-            put("text", buildJsonObject {
-                put("type", "mrkdwn")
-                put("text", "*Response nudges*\n" + nudges.take(MAX_NUDGES).joinToString("\n") { "• $it" })
+        visibleNudgeKeys: Set<String>,
+    ): List<JsonObject> {
+        if (!policy.enabled || snapshot.status in TERMINAL_STATUSES) return emptyList()
+        val nudges = nudgeMessages(snapshot, policy).filter { it.key in visibleNudgeKeys }.take(MAX_NUDGES)
+        if (nudges.isEmpty()) return emptyList()
+        return buildList {
+            add(buildJsonObject {
+                put("type", "section")
+                put("text", buildJsonObject {
+                    put("type", "mrkdwn")
+                    put("text", "*Response nudges*\n" + nudges.joinToString("\n") { "• ${it.text}" })
+                })
             })
+            nudges.forEach { nudge ->
+                add(buildJsonObject {
+                    put("type", "actions")
+                    putJsonArray("elements") {
+                        add(action("Dismiss ${nudge.text}", "incident_nudge_dismiss:${snapshot.resourceId}", nudge.key))
+                        if (nudge.key == NUDGE_TRIAGE_DECISION) {
+                            add(action("Accept", "incident_accept:${snapshot.resourceId}"))
+                            add(action("Merge", "incident_merge:${snapshot.resourceId}"))
+                            add(action("Decline", "incident_decline:${snapshot.resourceId}"))
+                        }
+                    }
+                })
+            }
         }
     }
+
+    private fun applicableNudgeKeys(
+        snapshot: IncidentSnapshot,
+        policy: IncidentAnnouncementNudgePolicy,
+    ): Set<String> = nudgeMessages(snapshot, policy).map { it.key }.toSet()
 
     private fun nudgeMessages(
         snapshot: IncidentSnapshot,
         policy: IncidentAnnouncementNudgePolicy,
-    ): List<String> = listOfNotNull(
-        "Assign an incident lead".takeIf {
+    ): List<IncidentNudge> = listOfNotNull(
+        IncidentNudge(NUDGE_MISSING_LEAD, "Assign an incident lead").takeIf {
             policy.missingLead && snapshot.roles.none { it.startsWith("Incident Commander:") }
         },
-        "Add an incident summary".takeIf { policy.missingSummary && snapshot.summary.isNullOrBlank() },
-        "Set the next update time".takeIf {
+        IncidentNudge(NUDGE_MISSING_SUMMARY, "Add an incident summary").takeIf {
+            policy.missingSummary && snapshot.summary.isNullOrBlank()
+        },
+        IncidentNudge(NUDGE_MISSING_UPDATE, "Set the next update time").takeIf {
             policy.missingUpdate && snapshot.fields["next_update_at"].isNullOrBlank()
         },
-        "Publish a status page update".takeIf {
+        IncidentNudge(NUDGE_MISSING_STATUS_PAGE, "Publish a status page update").takeIf {
             policy.missingStatusPage && snapshot.fields["status_page_url"].isNullOrBlank()
         },
-        "Make the triage decision".takeIf {
+        IncidentNudge(NUDGE_TRIAGE_DECISION, "Make the triage decision").takeIf {
             policy.missingTriageDecision && snapshot.status == NativeIncidentStatus.TRIAGE.wire
         },
-        "Activate the response escalation".takeIf { policy.missingEscalation && snapshot.escalation == null },
-        "Keep the closure checklist current".takeIf { policy.missingClosure },
+        IncidentNudge(NUDGE_MISSING_ESCALATION, "Activate the response escalation").takeIf {
+            policy.missingEscalation && snapshot.escalation == null
+        },
+        IncidentNudge(NUDGE_MISSING_CLOSURE, "Keep the closure checklist current").takeIf { policy.missingClosure },
     )
 
     private fun JsonElement.asText(): String = (this as? JsonPrimitive)?.contentOrNull.orEmpty()
@@ -641,6 +690,8 @@ class IncidentAnnouncementService(
         }
     }
 
+    private data class IncidentNudge(val key: String, val text: String)
+
     private fun isHttpUrl(url: String): Boolean = url.startsWith("https://") || url.startsWith("http://")
 
     companion object {
@@ -663,6 +714,13 @@ class IncidentAnnouncementService(
         private const val MAX_ACTION_LABEL_LENGTH = 75
         private const val MAX_ACTION_VALUE_LENGTH = 2_000
         private const val MAX_NUDGES = 7
+        private const val NUDGE_MISSING_LEAD = "missing_lead"
+        private const val NUDGE_MISSING_SUMMARY = "missing_summary"
+        private const val NUDGE_MISSING_UPDATE = "missing_update"
+        private const val NUDGE_MISSING_STATUS_PAGE = "missing_status_page"
+        private const val NUDGE_TRIAGE_DECISION = "triage_decision"
+        private const val NUDGE_MISSING_ESCALATION = "missing_escalation"
+        private const val NUDGE_MISSING_CLOSURE = "missing_closure"
         private val ACTION_ID_PATTERN = Regex("^[a-z][a-z0-9_:-]{1,63}$")
         private val RESERVED_ACTION_PREFIXES = setOf("incident_accept:", "incident_merge:", "incident_decline:")
         private val TERMINAL_STATUSES = setOf("RESOLVED", "CLOSED", "CANCELLED", "DECLINED", "MERGED")

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/slack/SlackIncidentCommandService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/slack/SlackIncidentCommandService.kt
@@ -8,6 +8,7 @@ import com.moneat.enterprise.incidents.authorization.SlackIncidentAccessRequest
 import com.moneat.enterprise.incidents.authorization.SlackIncidentAccessStatus
 import com.moneat.enterprise.incidents.authorization.SlackIncidentAction
 import com.moneat.enterprise.incidents.authorization.SlackIncidentAuthorizationService
+import com.moneat.enterprise.incidents.announcements.IncidentAnnouncementNudgeService
 import com.moneat.enterprise.incidents.commands.AcceptIncidentCommand
 import com.moneat.enterprise.incidents.commands.AddIncidentActionCommand
 import com.moneat.enterprise.incidents.commands.AddIncidentTimelineEventCommand
@@ -58,6 +59,7 @@ private const val UNAUTHORIZED_RESPONSE = "You are not authorized to respond to 
 private const val MAX_TEXT_LENGTH = 2_000
 private const val MODAL_TITLE_MAX_LENGTH = 24
 private const val MODAL_LABEL_MAX_LENGTH = 75
+private const val NUDGE_DISMISS_ACTION = "nudge_dismiss"
 
 private data class IncidentContext(
     val id: Int,
@@ -78,6 +80,7 @@ class SlackIncidentCommandService(
     private val installationService: SlackInstallationService,
     private val slackService: SlackService,
     private val commandService: IncidentCommandService = IncidentCommandService(),
+    private val nudgeService: IncidentAnnouncementNudgeService = IncidentAnnouncementNudgeService(),
 ) {
     private val identityResolver = SlackIdentityResolver()
     private val authorizationService = SlackIncidentAuthorizationService()
@@ -104,6 +107,18 @@ class SlackIncidentCommandService(
     }
 
     private suspend fun handleAction(
+        actionName: String,
+        root: JsonObject,
+        context: IncidentContext,
+        identity: SlackIdentityResolution,
+        deliveryId: String?,
+    ): String = if (actionName == NUDGE_DISMISS_ACTION) {
+        dismissNudge(root, context, identity)
+    } else {
+        handleStandardAction(actionName, root, context, identity, deliveryId)
+    }
+
+    private suspend fun handleStandardAction(
         actionName: String,
         root: JsonObject,
         context: IncidentContext,
@@ -291,6 +306,23 @@ class SlackIncidentCommandService(
         } catch (error: IncidentCommandException) {
             staleResponse(context, error.message)
         }
+    }
+
+    private fun dismissNudge(
+        root: JsonObject,
+        context: IncidentContext,
+        identity: SlackIdentityResolution,
+    ): String {
+        val nudgeKey = root["actions"]?.jsonArray?.firstOrNull()?.jsonObject
+            ?.get("value")?.jsonPrimitive?.contentOrNull
+        if (nudgeKey.isNullOrBlank()) return response("That nudge is no longer active.")
+        val dismissed = nudgeService.dismiss(
+            organizationId = requireNotNull(identity.organizationId),
+            incidentId = context.id,
+            nudgeKey = nudgeKey,
+            userId = requireNotNull(identity.userId),
+        )
+        return response(if (dismissed) "Nudge dismissed." else "That nudge is no longer active.")
     }
 
     private fun submissionCommand(

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/IncidentTestDatabase.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/IncidentTestDatabase.kt
@@ -20,6 +20,7 @@ import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRoutes
 import com.moneat.enterprise.incidents.models.NativeIncidentAlertEpisodeLinks
 import com.moneat.enterprise.incidents.announcements.NativeIncidentAnnouncementRules
 import com.moneat.enterprise.incidents.announcements.NativeIncidentAnnouncements
+import com.moneat.enterprise.incidents.announcements.NativeIncidentAnnouncementNudges
 import com.moneat.enterprise.incidents.models.NativeIncidentCommands
 import com.moneat.enterprise.incidents.models.NativeIncidentUpdateRequests
 import com.moneat.enterprise.incidents.models.NativeIncidentCustomFieldOptions
@@ -115,6 +116,7 @@ object IncidentTestDatabase {
             NativeIncidentSlackChannels,
             NativeIncidentAnnouncementRules,
             NativeIncidentAnnouncements,
+            NativeIncidentAnnouncementNudges,
             EnterpriseAlertRoutes,
             EnterpriseAlertRouteConditionGroups,
             EnterpriseAlertRouteConditions,

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/announcements/IncidentAnnouncementServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/announcements/IncidentAnnouncementServiceTest.kt
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Instant
 import kotlin.uuid.Uuid
 
@@ -278,6 +280,7 @@ class IncidentAnnouncementServiceTest {
         assertTrue(payload.contains("Response nudges"))
         assertTrue(payload.contains("Assign an incident lead"))
         assertTrue(payload.contains("Activate the response escalation"))
+        assertTrue(payload.contains("incident_nudge_dismiss"))
     }
 
     @Test
@@ -330,6 +333,44 @@ class IncidentAnnouncementServiceTest {
         assertTrue(payload.contains("Make the triage decision"))
         assertTrue(payload.contains("Activate the response escalation"))
         assertTrue(payload.contains("Keep the closure checklist current"))
+        assertTrue(payload.contains("incident_accept"))
+        assertTrue(payload.contains("incident_merge"))
+        assertTrue(payload.contains("incident_decline"))
+    }
+
+    @Test
+    fun `nudge state is rate limited activity aware and dismissible`() {
+        val clock = MutableAnnouncementClock(now)
+        val service = IncidentAnnouncementNudgeService(clock)
+        val incidentId = incidentId()
+        val scope = IncidentAnnouncementNudgeService.Scope(
+            organizationId = member.organizationId,
+            incidentId = incidentId,
+            ruleKey = "rule-key",
+            teamId = "T-announcements",
+            channelId = "C-announcements",
+        )
+
+        assertEquals(
+            setOf("missing_summary"),
+            service.visibleKeys(scope, setOf("missing_summary")),
+        )
+        service.recordShown(scope, setOf("missing_summary"), 1)
+        assertTrue(service.visibleKeys(scope, setOf("missing_summary")).isEmpty())
+
+        clock.current = now + 5.minutes
+        assertEquals(
+            setOf("missing_summary"),
+            service.visibleKeys(scope, setOf("missing_summary")),
+        )
+        assertTrue(service.dismiss(member.organizationId, incidentId, "missing_summary", member.userId))
+        assertTrue(service.visibleKeys(scope, setOf("missing_summary")).isEmpty())
+
+        service.visibleKeys(scope, emptySet())
+        assertEquals(
+            setOf("missing_summary"),
+            service.visibleKeys(scope, setOf("missing_summary")),
+        )
     }
 
     @Test
@@ -461,4 +502,8 @@ class IncidentAnnouncementServiceTest {
         ),
         createdAt = now.toString(),
     )
+
+    private class MutableAnnouncementClock(var current: Instant) : Clock {
+        override fun now(): Instant = current
+    }
 }


### PR DESCRIPTION
Persist incident announcement nudge state per destination so response nudges can be dismissed, rate-limited, and reset when the underlying condition clears. Adds Slack dismissal handling, triage decision actions, focused coverage, and the durable state migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent state for Slack incident announcement nudges.
  * Nudges now account for recent activity and display frequency.
  * Added individual dismiss actions for incident nudges in Slack.
  * Dismissed nudges remain hidden and can be acknowledged with confirmation.

* **Bug Fixes**
  * Prevented repeated display of recently shown or dismissed nudges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->