### PR TITLE
fix(slack): execute alert grouping actions

### DIFF
--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertGroupCommandService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertGroupCommandService.kt
@@ -5,6 +5,7 @@
 package com.moneat.enterprise.alertroutes.services
 
 import com.moneat.alerts.models.AlertEpisodes
+import com.moneat.enterprise.alertroutes.commands.AlertGroupActor
 import com.moneat.enterprise.alertroutes.commands.AlertGroupCommand
 import com.moneat.enterprise.alertroutes.commands.AlertGroupPolicy
 import com.moneat.enterprise.alertroutes.commands.AttachAlertGroupIncidentCommand
@@ -26,9 +27,14 @@ import com.moneat.enterprise.incidents.commands.IncidentCommandNotFoundException
 import com.moneat.enterprise.incidents.commands.IncidentCommandService
 import com.moneat.enterprise.incidents.commands.IncidentSourceReference
 import com.moneat.enterprise.incidents.commands.LinkIncidentSourceCommand
+import com.moneat.enterprise.incidents.models.IncidentParticipationType
+import com.moneat.enterprise.incidents.models.NativeIncidentParticipants
+import com.moneat.enterprise.incidents.models.NativeIncidentRoleAssignments
 import com.moneat.enterprise.incidents.models.IncidentSourceType
 import com.moneat.enterprise.incidents.models.NativeIncidentStatus
+import com.moneat.enterprise.incidents.models.NativeIncidentVisibility
 import com.moneat.enterprise.oncall.models.OnCallIncidents
+import com.moneat.org.services.OrgRole
 import com.moneat.shared.models.Memberships
 import com.moneat.shared.models.Organizations
 import java.security.MessageDigest
@@ -37,6 +43,7 @@ import kotlinx.serialization.json.JsonPrimitive
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.isNull
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
@@ -112,7 +119,7 @@ class AlertGroupCommandService(
     }
 
     private fun attach(command: AttachAlertGroupIncidentCommand, group: ResultRow) {
-        val incident = requireEligibleIncident(command.actor.organizationId, command.incidentId)
+        val incident = requireEligibleIncident(command)
         val internalIncidentId = incident[OnCallIncidents.id].value
         val existing = group[EnterpriseAlertGroups.incidentId]
         if (existing != null && existing != internalIncidentId) {
@@ -236,15 +243,49 @@ class AlertGroupCommandService(
                     (AlertEpisodes.resourceId eq episodeId)
             }.singleOrNull() ?: throw IncidentCommandNotFoundException("Alert group episode not found")
 
-    private fun requireEligibleIncident(organizationId: Int, incidentId: Uuid): ResultRow {
+    private fun requireEligibleIncident(command: AttachAlertGroupIncidentCommand): ResultRow {
         val incident = OnCallIncidents.selectAll().where {
-            (OnCallIncidents.organizationId eq organizationId) and (OnCallIncidents.resourceId eq incidentId)
+            (OnCallIncidents.organizationId eq command.actor.organizationId) and
+                (OnCallIncidents.resourceId eq command.incidentId)
         }.singleOrNull() ?: throw IncidentCommandNotFoundException("Incident not found")
         val status = NativeIncidentStatus.fromWire(incident[OnCallIncidents.status])
         if (status !in ELIGIBLE_INCIDENT_STATUSES) {
             throw IncidentCommandConflictException("Only triage or active incidents can receive an alert group")
         }
+        if (!command.automatic && incident[OnCallIncidents.visibility] == NativeIncidentVisibility.PRIVATE.wire) {
+            requirePrivateIncidentAccess(command.actor, incident[OnCallIncidents.id].value)
+        }
         return incident
+    }
+
+    private fun requirePrivateIncidentAccess(actor: AlertGroupActor, incidentId: Int) {
+        val membership = Memberships.selectAll().where {
+            (Memberships.organization_id eq actor.organizationId) and
+                (Memberships.user_id eq actor.userId)
+        }.singleOrNull()
+        val role = membership?.get(Memberships.role)?.let { value ->
+            runCatching { OrgRole.fromString(value) }.getOrNull()
+        }
+        if (role?.level ?: -1 >= OrgRole.ADMIN.level) return
+
+        val hasIncidentRole = NativeIncidentRoleAssignments.selectAll().where {
+            (NativeIncidentRoleAssignments.organizationId eq actor.organizationId) and
+                (NativeIncidentRoleAssignments.incidentId eq incidentId) and
+                (NativeIncidentRoleAssignments.assigneeUserId eq actor.userId) and
+                NativeIncidentRoleAssignments.endedAt.isNull()
+        }.limit(1).firstOrNull() != null
+        val isParticipant = NativeIncidentParticipants.selectAll().where {
+            (NativeIncidentParticipants.organizationId eq actor.organizationId) and
+                (NativeIncidentParticipants.incidentId eq incidentId) and
+                (NativeIncidentParticipants.userId eq actor.userId) and
+                (NativeIncidentParticipants.participationType eq IncidentParticipationType.PARTICIPANT.wire) and
+                NativeIncidentParticipants.leftAt.isNull()
+        }.limit(1).firstOrNull() != null
+        if (!hasIncidentRole && !isParticipant) {
+            throw IncidentCommandDeniedException(
+                "Actor is not authorized to attach an alert group to this private incident",
+            )
+        }
     }
 
     private fun replay(command: AlertGroupCommand): AlertGroupCommandResult? {

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteSlackActionService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteSlackActionService.kt
@@ -7,7 +7,9 @@ package com.moneat.enterprise.alertroutes.services
 import com.moneat.alerts.models.AlertEpisodes
 import com.moneat.alerts.services.AlertEpisodeService
 import com.moneat.enterprise.alertroutes.commands.AlertGroupActor
+import com.moneat.enterprise.alertroutes.commands.AttachAlertGroupIncidentCommand
 import com.moneat.enterprise.alertroutes.commands.CreateAlertGroupTriageCommand
+import com.moneat.enterprise.alertroutes.commands.MarkAlertGroupEpisodeUnrelatedCommand
 import com.moneat.enterprise.alertroutes.models.EnterpriseAlertGroupEscalations
 import com.moneat.enterprise.alertroutes.models.EnterpriseAlertGroupMembers
 import com.moneat.enterprise.alertroutes.models.EnterpriseAlertGroups
@@ -16,6 +18,7 @@ import com.moneat.enterprise.incidents.authorization.SlackIncidentAccessStatus
 import com.moneat.enterprise.incidents.authorization.SlackIncidentAction
 import com.moneat.enterprise.incidents.authorization.SlackIncidentAuthorizationService
 import com.moneat.enterprise.incidents.commands.IncidentCommandActor
+import com.moneat.enterprise.incidents.commands.IncidentCommandException
 import com.moneat.enterprise.incidents.commands.IncidentCommandService
 import com.moneat.enterprise.incidents.commands.SetIncidentParticipationCommand
 import com.moneat.enterprise.incidents.models.IncidentParticipationType
@@ -48,8 +51,10 @@ private data class AlertActionContext(
     val groupId: Uuid,
     val groupVersion: Int,
     val episodeId: Int,
+    val episodeResourceId: Uuid,
     val episodeTitle: String,
     val incidentId: Int?,
+    val candidateIncidentId: Uuid?,
     val onCallAlertId: Int?,
 )
 
@@ -105,19 +110,79 @@ class AlertRouteSlackActionService(
             "acknowledge_alert" -> acknowledge(identity, context, deliveryId)
             "silence_alert" -> silence(identity, context, deliveryId)
             "resolve_alert" -> resolve(identity, context, deliveryId)
-            "confirm_grouping" -> response("This alert is already grouped by the matched route.")
-            "unrelated_alert", "merge_alert_group" ->
-                response("Use the alert group view to review this grouping decision.")
+            "confirm_grouping", "merge_alert_group" -> confirmGrouping(identity, context, deliveryId)
+            "unrelated_alert" -> markUnrelated(identity, context, deliveryId)
             else -> response("This alert action is not supported.")
         }
     }
 
     private fun actionContext(actionId: String, value: String?, organizationId: Int): AlertActionContext? =
         when (actionId) {
-            "declare_incident", "acknowledge_alert", "silence_alert", "resolve_alert" ->
+            "declare_incident", "acknowledge_alert", "silence_alert", "resolve_alert",
+            "confirm_grouping", "merge_alert_group", "unrelated_alert" ->
                 value?.let { findByEpisode(organizationId, it) }
             else -> null
         }
+
+    private fun confirmGrouping(
+        identity: SlackIdentityResolution,
+        context: AlertActionContext?,
+        deliveryId: String?,
+    ): String {
+        if (context == null) return response("The alert group is no longer available.")
+        val candidateIncidentId = context.candidateIncidentId
+            ?: return response(
+                if (context.incidentId != null) {
+                    "This alert group is already linked to an incident."
+                } else {
+                    "No suggested incident is available for this alert group."
+                },
+            )
+        return try {
+            alertGroupCommands.execute(
+                AttachAlertGroupIncidentCommand(
+                    commandKey = "slack-alert-group-confirm:${deliveryId ?: Uuid.random()}",
+                    actor = AlertGroupActor(
+                        requireNotNull(identity.organizationId),
+                        requireNotNull(identity.userId),
+                        "SLACK",
+                    ),
+                    groupId = context.groupId,
+                    expectedVersion = context.groupVersion,
+                    incidentId = candidateIncidentId,
+                ),
+            )
+            response("Alert group linked to the suggested incident.")
+        } catch (_: IncidentCommandException) {
+            response("This alert group changed. Open it in Moneat to review the current state.")
+        }
+    }
+
+    private fun markUnrelated(
+        identity: SlackIdentityResolution,
+        context: AlertActionContext?,
+        deliveryId: String?,
+    ): String {
+        if (context == null) return response("The alert group is no longer available.")
+        return try {
+            alertGroupCommands.execute(
+                MarkAlertGroupEpisodeUnrelatedCommand(
+                    commandKey = "slack-alert-group-unrelated:${deliveryId ?: Uuid.random()}",
+                    actor = AlertGroupActor(
+                        requireNotNull(identity.organizationId),
+                        requireNotNull(identity.userId),
+                        "SLACK",
+                    ),
+                    groupId = context.groupId,
+                    expectedVersion = context.groupVersion,
+                    episodeId = context.episodeResourceId,
+                ),
+            )
+            response("Alert marked unrelated to this group.")
+        } catch (_: IncidentCommandException) {
+            response("This alert group changed. Open it in Moneat to review the current state.")
+        }
+    }
 
     private fun organizationIdForTeam(teamId: String): Int? = transaction {
         OrganizationIntegrations.selectAll().where {
@@ -304,12 +369,20 @@ class AlertRouteSlackActionService(
                 (EnterpriseAlertGroupEscalations.organizationId eq organizationId) and
                     (EnterpriseAlertGroupEscalations.groupId eq group[EnterpriseAlertGroups.id].value)
             }.firstOrNull()
+            val candidateIncidentId = group[EnterpriseAlertGroups.candidateIncidentId]?.let { candidateId ->
+                OnCallIncidents.selectAll().where {
+                    (OnCallIncidents.organizationId eq organizationId) and
+                        (OnCallIncidents.id eq candidateId)
+                }.singleOrNull()?.get(OnCallIncidents.resourceId)
+            }
             AlertActionContext(
                 groupId = group[EnterpriseAlertGroups.resourceId],
                 groupVersion = group[EnterpriseAlertGroups.version],
                 episodeId = episodeId,
+                episodeResourceId = episodeResourceId,
                 episodeTitle = episode[AlertEpisodes.title].orEmpty(),
                 incidentId = group[EnterpriseAlertGroups.incidentId],
+                candidateIncidentId = candidateIncidentId,
                 onCallAlertId = escalation?.get(EnterpriseAlertGroupEscalations.onCallAlertId),
             )
         }

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteSlackActionService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteSlackActionService.kt
@@ -58,6 +58,9 @@ private data class AlertActionContext(
     val onCallAlertId: Int?,
 )
 
+private const val ALERT_GROUP_UNAVAILABLE_MESSAGE = "The alert group is no longer available."
+private const val NO_PAGE_ATTACHED_MESSAGE = "No page is attached to this alert group."
+
 /** Executes Slack alert-card actions through the canonical alert and incident commands. */
 class AlertRouteSlackActionService(
     private val slackInstallationService: SlackInstallationService,
@@ -129,7 +132,7 @@ class AlertRouteSlackActionService(
         context: AlertActionContext?,
         deliveryId: String?,
     ): String {
-        if (context == null) return response("The alert group is no longer available.")
+        if (context == null) return response(ALERT_GROUP_UNAVAILABLE_MESSAGE)
         val candidateIncidentId = context.candidateIncidentId
             ?: return response(
                 if (context.incidentId != null) {
@@ -163,7 +166,7 @@ class AlertRouteSlackActionService(
         context: AlertActionContext?,
         deliveryId: String?,
     ): String {
-        if (context == null) return response("The alert group is no longer available.")
+        if (context == null) return response(ALERT_GROUP_UNAVAILABLE_MESSAGE)
         return try {
             alertGroupCommands.execute(
                 MarkAlertGroupEpisodeUnrelatedCommand(
@@ -198,7 +201,7 @@ class AlertRouteSlackActionService(
         context: AlertActionContext?,
         deliveryId: String?,
     ): String {
-        if (context == null) return response("The alert group is no longer available.")
+        if (context == null) return response(ALERT_GROUP_UNAVAILABLE_MESSAGE)
         if (context.incidentId != null) return response("This alert group is already linked to an incident.")
         val result = alertGroupCommands.execute(
             CreateAlertGroupTriageCommand(
@@ -261,7 +264,7 @@ class AlertRouteSlackActionService(
         deliveryId: String?,
     ): String {
         if (context == null || context.onCallAlertId == null) {
-            return response("No page is attached to this alert group.")
+            return response(NO_PAGE_ATTACHED_MESSAGE)
         }
         if (!canRespondToIncident(identity, context)) {
             return response("You are not authorized to acknowledge this alert.")
@@ -294,7 +297,7 @@ class AlertRouteSlackActionService(
         deliveryId: String?,
     ): String {
         if (context == null || context.onCallAlertId == null) {
-            return response("No page is attached to this alert group.")
+            return response(NO_PAGE_ATTACHED_MESSAGE)
         }
         if (!canRespondToIncident(identity, context)) {
             return response("You are not authorized to resolve this alert.")

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteSlackCardService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteSlackCardService.kt
@@ -157,9 +157,9 @@ class AlertRouteSlackCardService(
                             add(action("acknowledge_alert", "Acknowledge", null, episode.resourceId.toString()))
                             add(action("silence_alert", "Silence", null, episode.resourceId.toString()))
                             add(action("resolve_alert", "Resolve", null, episode.resourceId.toString()))
-                            add(action("confirm_grouping", "Confirm grouping", null, outcome.groupId))
-                            add(action("unrelated_alert", "Unrelated", "danger", outcome.groupId))
-                            add(action("merge_alert_group", "Merge", null, outcome.groupId))
+                            add(action("confirm_grouping", "Confirm grouping", null, episode.resourceId.toString()))
+                            add(action("unrelated_alert", "Unrelated", "danger", episode.resourceId.toString()))
+                            add(action("merge_alert_group", "Merge", null, episode.resourceId.toString()))
                         }
                     }
                     addJsonObject {

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/AlertRouteTestDatabase.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/AlertRouteTestDatabase.kt
@@ -27,6 +27,8 @@ import com.moneat.enterprise.incidents.models.NativeIncidentFormSubmissions
 import com.moneat.enterprise.incidents.models.NativeIncidentOutboxDeliveries
 import com.moneat.enterprise.incidents.models.NativeIncidentOutboxEvents
 import com.moneat.enterprise.incidents.models.NativeIncidentUpdateRequests
+import com.moneat.enterprise.incidents.models.NativeIncidentParticipants
+import com.moneat.enterprise.incidents.models.NativeIncidentRoleAssignments
 import com.moneat.enterprise.incidents.response.NativeIncidentResponseActivations
 import com.moneat.enterprise.incidents.response.NativeIncidentResponsePolicies
 import com.moneat.enterprise.incidents.response.NativeIncidentResponseTargets
@@ -101,6 +103,8 @@ object AlertRouteTestDatabase {
             NativeIncidentFormSubmissions,
             NativeIncidentAlertEpisodeLinks,
             NativeIncidentSourceLinks,
+            NativeIncidentRoleAssignments,
+            NativeIncidentParticipants,
             NativeIncidentCommands,
             NativeIncidentOutboxEvents,
             NativeIncidentOutboxDeliveries,

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertGroupCommandServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertGroupCommandServiceTest.kt
@@ -26,11 +26,13 @@ import com.moneat.enterprise.alertroutes.models.AlertRouteGroupingBehavior
 import com.moneat.enterprise.incidents.commands.DeclareIncidentCommand
 import com.moneat.enterprise.incidents.commands.IncidentCommandActor
 import com.moneat.enterprise.incidents.commands.IncidentCommandConflictException
+import com.moneat.enterprise.incidents.commands.IncidentCommandDeniedException
 import com.moneat.enterprise.incidents.commands.IncidentCommandNotFoundException
 import com.moneat.enterprise.incidents.commands.IncidentCommandPolicy
 import com.moneat.enterprise.incidents.commands.IncidentCommandService
 import com.moneat.enterprise.incidents.models.NativeIncidentSourceLinks
 import com.moneat.enterprise.incidents.models.NativeIncidentStatus
+import com.moneat.enterprise.incidents.models.NativeIncidentVisibility
 import com.moneat.enterprise.oncall.models.OnCallIncidents
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.selectAll
@@ -212,6 +214,37 @@ class AlertGroupCommandServiceTest {
                     automaticGroup.version,
                     incidentId,
                     automatic = true,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `private incident attachment requires incident access`() {
+        val episode = AlertRouteTestDatabase.seedAlertEpisode(organization.organizationId, "HOST_ALERT", "private")
+        val group = createGroup(episode)
+        val incident = incidentService.execute(
+            DeclareIncidentCommand(
+                commandKey = "private-incident",
+                actor = IncidentCommandActor(organization.organizationId, organization.adminUserId, "TEST"),
+                title = "Private checkout incident",
+                description = null,
+                severity = "SEV-2",
+                visibility = NativeIncidentVisibility.PRIVATE,
+                initialStatus = NativeIncidentStatus.ACTIVE,
+            ),
+        )
+        val memberUserId = AlertRouteTestDatabase.seedUser(organization.organizationId, "private-member")
+        val actor = AlertGroupActor(organization.organizationId, memberUserId, "SLACK")
+
+        assertFailsWith<IncidentCommandDeniedException> {
+            commandService.execute(
+                AttachAlertGroupIncidentCommand(
+                    commandKey = "private-attach-denied",
+                    actor = actor,
+                    groupId = group.id,
+                    expectedVersion = group.version,
+                    incidentId = Uuid.parse(incident.incidentResourceId),
                 ),
             )
         }

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteSlackCardServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteSlackCardServiceTest.kt
@@ -74,14 +74,18 @@ class AlertRouteSlackCardServiceTest {
         val blocks = payload["blocks"]!!.jsonArray
         val actions = blocks.filter { it.jsonObject["type"]?.jsonPrimitive?.content == "actions" }
             .flatMap { it.jsonObject["elements"]!!.jsonArray }
-            .mapNotNull { it.jsonObject["action_id"]?.jsonPrimitive?.content }
+            .mapNotNull { element ->
+                element.jsonObject["action_id"]?.jsonPrimitive?.content?.let { actionId ->
+                    actionId to element.jsonObject["value"]?.jsonPrimitive?.content
+                }
+            }.toMap()
 
         assertEquals("C123", payload["channel"]?.jsonPrimitive?.content)
         assertTrue("declare_incident" in actions)
         assertTrue("acknowledge_alert" in actions)
-        assertTrue("confirm_grouping" in actions)
-        assertTrue("unrelated_alert" in actions)
-        assertTrue("merge_alert_group" in actions)
+        assertEquals(episodeId.toString(), actions["confirm_grouping"])
+        assertEquals(episodeId.toString(), actions["unrelated_alert"])
+        assertEquals(episodeId.toString(), actions["merge_alert_group"])
         assertTrue(payload.toString().contains("checkout:latency"))
     }
 }


### PR DESCRIPTION
Wires Slack alert-card grouping controls to the durable alert-group command service. Confirm and Merge attach suggested groups with optimistic version checks; Unrelated records the episode decision. The card carries the episode resource ID used by the canonical command path, and focused coverage verifies the action payload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Slack alert actions now support confirming suggested incident groupings.
  - Mark alerts as unrelated to their suggested incident group.
  - Merge alert groups using updated action handling.

- **Bug Fixes**
  - Alert actions now reliably reference the correct alert episode.
  - Prevented candidate incidents from being associated across organizations.
  - Restricted attaching private incidents to authorized personnel.
  - Improved validation and clearer messages for stale or unavailable alert groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->