### PR TITLE
feat: add incident integration timeline producers

### DIFF
--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/timeline/IncidentTimelineProducer.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/timeline/IncidentTimelineProducer.kt
@@ -1,0 +1,86 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.incidents.timeline
+
+import com.moneat.enterprise.incidents.models.IncidentTimelineProvenance
+import com.moneat.enterprise.incidents.models.IncidentTimelineVisibility
+import kotlinx.serialization.json.JsonElement
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.time.Instant
+
+/**
+ * Integration-owned event categories that can contribute evidence to a native incident.
+ * The timeline table intentionally keeps source types as strings so integrations can evolve
+ * without changing the canonical storage contract.
+ */
+enum class IncidentTimelineProducerSource(val wire: String) {
+    STATUS_PAGE("STATUS_PAGE"),
+    CALL("CALL"),
+    DEPLOY("DEPLOY"),
+    SLACK("SLACK_MESSAGE"),
+}
+
+data class IncidentTimelineProducerEvent(
+    val organizationId: Int,
+    val incidentId: Int,
+    val eventKey: String,
+    val eventType: String,
+    val originalOccurredAt: Instant,
+    val details: Map<String, JsonElement> = emptyMap(),
+    val actorUserId: Int? = null,
+    val sourceReference: String,
+    val sourceUrl: String? = null,
+    val observedAt: Instant = originalOccurredAt,
+    val visibility: IncidentTimelineVisibility = IncidentTimelineVisibility.ORGANIZATION,
+)
+
+/**
+ * Records integration activity using the same writer as first-party incident events.
+ * Callers provide a stable event key derived from the upstream event identity; the writer
+ * enforces per-incident idempotency and preserves the upstream occurrence time for late events.
+ */
+class IncidentTimelineProducer(
+    private val writer: IncidentTimelineWriter = IncidentTimelineWriter(),
+) {
+    fun recordStatusPageChange(event: IncidentTimelineProducerEvent): Int =
+        record(event, IncidentTimelineProducerSource.STATUS_PAGE)
+
+    fun recordCallActivity(event: IncidentTimelineProducerEvent): Int =
+        record(event, IncidentTimelineProducerSource.CALL)
+
+    fun recordDeployActivity(event: IncidentTimelineProducerEvent): Int =
+        record(event, IncidentTimelineProducerSource.DEPLOY)
+
+    fun recordSlackActivity(event: IncidentTimelineProducerEvent): Int =
+        record(event, IncidentTimelineProducerSource.SLACK)
+
+    private fun record(
+        event: IncidentTimelineProducerEvent,
+        source: IncidentTimelineProducerSource,
+    ): Int {
+        require(event.sourceReference.isNotBlank()) { "Incident timeline source reference is required" }
+        val pending = PendingIncidentTimelineEvent(
+            organizationId = event.organizationId,
+            incidentId = event.incidentId,
+            eventKey = event.eventKey,
+            eventType = event.eventType,
+            actorUserId = event.actorUserId,
+            details = event.details,
+            provenance = IncidentTimelineProvenance.INTEGRATION,
+            visibility = event.visibility,
+            originalOccurredAt = event.originalOccurredAt,
+            observedAt = event.observedAt,
+            sourceType = source.wire,
+            sourceReference = event.sourceReference,
+            sourceUrl = event.sourceUrl,
+        )
+        return if (TransactionManager.currentOrNull() == null) {
+            transaction { writer.record(pending) }
+        } else {
+            writer.record(pending)
+        }
+    }
+}

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/timeline/IncidentTimelineProducerTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/timeline/IncidentTimelineProducerTest.kt
@@ -1,0 +1,130 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.incidents.timeline
+
+import com.moneat.enterprise.incidents.IncidentTestDatabase
+import com.moneat.enterprise.incidents.SeededMember
+import com.moneat.enterprise.incidents.commands.DeclareIncidentCommand
+import com.moneat.enterprise.incidents.commands.IncidentCommandActor
+import com.moneat.enterprise.incidents.commands.IncidentCommandPolicy
+import com.moneat.enterprise.incidents.commands.IncidentCommandService
+import com.moneat.enterprise.oncall.models.OnCallIncidentTimeline
+import kotlinx.serialization.json.JsonPrimitive
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+
+class IncidentTimelineProducerTest {
+    private lateinit var member: SeededMember
+
+    @BeforeEach
+    fun setUp() {
+        IncidentTestDatabase.reset()
+        member = IncidentTestDatabase.seedMember()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        IncidentTestDatabase.clearReference()
+    }
+
+    @Test
+    fun `records each integration category with source metadata`() {
+        val incidentId = declareIncident()
+        val occurredAt = Instant.parse("2026-08-25T00:00:00Z")
+        val producer = IncidentTimelineProducer()
+
+        producer.recordStatusPageChange(event(incidentId, "status-page-1", "STATUS_PAGE_UPDATED", occurredAt))
+        producer.recordCallActivity(event(incidentId, "call-1", "CALL_STARTED", occurredAt))
+        producer.recordDeployActivity(event(incidentId, "deploy-1", "DEPLOY_STARTED", occurredAt))
+        producer.recordSlackActivity(event(incidentId, "slack-1", "SLACK_MESSAGE_POSTED", occurredAt))
+
+        transaction {
+            val rows = OnCallIncidentTimeline.selectAll().where {
+                OnCallIncidentTimeline.incidentId eq incidentId
+            }.toList().filter { it[OnCallIncidentTimeline.sourceType] != null }
+            assertEquals(4, rows.size)
+            assertEquals(
+                setOf("STATUS_PAGE", "CALL", "DEPLOY", "SLACK_MESSAGE"),
+                rows.mapNotNull { it[OnCallIncidentTimeline.sourceType] }.toSet(),
+            )
+            assertTrue(rows.all { it[OnCallIncidentTimeline.provenance] == "INTEGRATION" })
+            assertTrue(rows.all { it[OnCallIncidentTimeline.originalOccurredAt] == occurredAt })
+        }
+    }
+
+    @Test
+    fun `reuses the existing row for a duplicate upstream event key`() {
+        val incidentId = declareIncident()
+        val event = event(incidentId, "deploy-duplicate", "DEPLOY_FINISHED", Instant.parse("2026-08-25T00:02:00Z"))
+        val producer = IncidentTimelineProducer()
+
+        val firstId = producer.recordDeployActivity(event)
+        val secondId = producer.recordDeployActivity(event.copy(observedAt = Instant.parse("2026-08-25T00:03:00Z")))
+
+        assertEquals(firstId, secondId)
+        transaction {
+            assertEquals(
+                1,
+                OnCallIncidentTimeline.selectAll().where {
+                    (OnCallIncidentTimeline.incidentId eq incidentId) and
+                        (OnCallIncidentTimeline.eventKey eq "deploy-duplicate")
+                }.count(),
+            )
+        }
+    }
+
+    @Test
+    fun `keeps the original occurrence time when an event arrives late`() {
+        val incidentId = declareIncident()
+        val occurredAt = Instant.parse("2026-08-25T00:04:00Z")
+        val observedAt = Instant.parse("2026-08-25T00:09:00Z")
+
+        IncidentTimelineProducer().recordCallActivity(
+            event(incidentId, "call-late", "CALL_ENDED", occurredAt).copy(observedAt = observedAt),
+        )
+
+        transaction {
+            val row = OnCallIncidentTimeline.selectAll().where {
+                (OnCallIncidentTimeline.incidentId eq incidentId) and
+                    (OnCallIncidentTimeline.eventKey eq "call-late")
+            }.single()
+            assertEquals(occurredAt, row[OnCallIncidentTimeline.originalOccurredAt])
+            assertEquals(observedAt, row[OnCallIncidentTimeline.observedAt])
+            assertEquals(observedAt, row[OnCallIncidentTimeline.createdAt])
+        }
+    }
+
+    private fun event(incidentId: Int, key: String, type: String, occurredAt: Instant) =
+        IncidentTimelineProducerEvent(
+            organizationId = member.organizationId,
+            incidentId = incidentId,
+            eventKey = key,
+            eventType = type,
+            originalOccurredAt = occurredAt,
+            details = mapOf("source" to JsonPrimitive("integration-test")),
+            actorUserId = member.userId,
+            sourceReference = key,
+        )
+
+    private fun declareIncident(): Int {
+        return IncidentCommandService(policy = IncidentCommandPolicy.allowForTests()).execute(
+            DeclareIncidentCommand(
+                commandKey = "declare-producer-${System.nanoTime()}",
+                actor = IncidentCommandActor(member.organizationId, member.userId, "REST"),
+                title = "Producer test incident",
+                description = null,
+                severity = "SEV-2",
+            ),
+        ).incidentId
+    }
+}


### PR DESCRIPTION
Adds a shared enterprise producer adapter for status-page, call, deploy, and selected Slack timeline activity. Preserves source references, provenance, original and observed timestamps, and delegates idempotency to the canonical writer. Includes focused database-backed coverage for category metadata, duplicate keys, and late-arriving events.