### PR TITLE
feat: link incidents to status pages

### DIFF
--- a/backend/src/main/kotlin/com/moneat/statuspage/services/StatusPageService.kt
+++ b/backend/src/main/kotlin/com/moneat/statuspage/services/StatusPageService.kt
@@ -397,6 +397,25 @@ class StatusPageService(
         }
     }
 
+    fun getIncident(
+        pageId: UUID,
+        organizationId: Int,
+        incidentId: UUID,
+    ): IncidentResponse? {
+        return transaction {
+            StatusPageIncidents
+                .innerJoin(StatusPages, { statusPageId }, { StatusPages.id })
+                .selectAll()
+                .where {
+                    (StatusPageIncidents.id eq incidentId) and
+                        (StatusPageIncidents.statusPageId eq pageId) and
+                        (StatusPages.organizationId eq organizationId)
+                }
+                .firstOrNull()
+                ?.toIncidentResponse()
+        }
+    }
+
     fun updateIncident(
         pageId: UUID,
         organizationId: Int,

--- a/backend/src/main/kotlin/com/moneat/statuspage/services/StatusPageService.kt
+++ b/backend/src/main/kotlin/com/moneat/statuspage/services/StatusPageService.kt
@@ -355,7 +355,15 @@ class StatusPageService(
         organizationId: Int,
         request: CreateIncidentRequest
     ): IncidentResponse {
-        val incidentId = UUID.randomUUID()
+        return createIncidentWithId(pageId, organizationId, UUID.randomUUID(), request)
+    }
+
+    fun createIncidentWithId(
+        pageId: UUID,
+        organizationId: Int,
+        incidentId: UUID,
+        request: CreateIncidentRequest,
+    ): IncidentResponse {
         val now = Clock.System.now()
 
         return transaction {

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/statuspage/IncidentStatusPageLinkService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/statuspage/IncidentStatusPageLinkService.kt
@@ -1,0 +1,363 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.incidents.statuspage
+
+import com.moneat.enterprise.incidents.commands.IncidentCommandActor
+import com.moneat.enterprise.incidents.commands.IncidentCommandDeniedException
+import com.moneat.enterprise.incidents.commands.IncidentCommandNotFoundException
+import com.moneat.enterprise.incidents.commands.IncidentCommandService
+import com.moneat.enterprise.incidents.commands.IncidentSourceReference
+import com.moneat.enterprise.incidents.commands.LinkIncidentSourceCommand
+import com.moneat.enterprise.incidents.models.IncidentParticipationType
+import com.moneat.enterprise.incidents.models.IncidentSourceType
+import com.moneat.enterprise.incidents.models.NativeIncidentParticipants
+import com.moneat.enterprise.incidents.models.NativeIncidentRoleAssignments
+import com.moneat.enterprise.incidents.models.NativeIncidentSourceLinks
+import com.moneat.enterprise.incidents.models.NativeIncidentVisibility
+import com.moneat.enterprise.incidents.timeline.IncidentTimelineProducer
+import com.moneat.enterprise.incidents.timeline.IncidentTimelineProducerEvent
+import com.moneat.enterprise.oncall.models.OnCallIncidents
+import com.moneat.org.services.OrgRole
+import com.moneat.shared.models.Memberships
+import com.moneat.statuspage.models.CreateIncidentRequest
+import com.moneat.statuspage.models.CreateIncidentUpdateRequest
+import com.moneat.statuspage.models.IncidentResponse
+import com.moneat.statuspage.models.UpdateIncidentRequest
+import com.moneat.statuspage.services.StatusPageService
+import kotlinx.serialization.json.JsonPrimitive
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.isNull
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.net.URI
+import java.util.UUID
+import kotlin.time.Clock
+
+data class CreateLinkedStatusPageIncidentRequest(
+    val title: String,
+    val status: String,
+    val impact: String,
+    val message: String,
+    val sourceUrl: String,
+    val correlationKey: String,
+)
+
+data class UpdateLinkedStatusPageIncidentRequest(
+    val title: String? = null,
+    val status: String? = null,
+    val impact: String? = null,
+    val message: String? = null,
+)
+
+data class IncidentStatusPageLinkTarget(
+    val organizationId: Int,
+    val actorUserId: Int,
+    val incidentId: Int,
+    val statusPageId: UUID,
+    val statusPageIncidentId: UUID? = null,
+)
+
+class IncidentStatusPageLinkService(
+    private val statusPageService: StatusPageService = StatusPageService(),
+    private val incidentCommandService: IncidentCommandService = IncidentCommandService(),
+    private val timelineProducer: IncidentTimelineProducer = IncidentTimelineProducer(),
+) {
+    fun create(
+        target: IncidentStatusPageLinkTarget,
+        request: CreateLinkedStatusPageIncidentRequest,
+        commandKey: String,
+    ): IncidentResponse {
+        requireIncidentAccess(target.organizationId, target.actorUserId, target.incidentId)
+        validateCustomerContent(request.title, request.message)
+        requireSafeSourceUrl(request.sourceUrl)
+        requireCorrelationKey(request.correlationKey)
+
+        val sourceKey = sourceKey(target.statusPageId, request.correlationKey)
+        existingLinkedIncident(target.organizationId, target.incidentId, sourceKey)?.let { linkedId ->
+            return statusPageService.getIncident(target.statusPageId, target.organizationId, linkedId)
+                ?: throw IncidentCommandNotFoundException("Linked status-page incident not found")
+        }
+
+        val created = statusPageService.createIncident(
+            target.statusPageId,
+            target.organizationId,
+            CreateIncidentRequest(
+                title = request.title.trim(),
+                status = request.status.trim(),
+                impact = request.impact.trim(),
+                message = request.message.trim(),
+            ),
+        )
+        linkAndRecord(
+            LinkRecordRequest(
+                target = target,
+                statusPageIncident = created,
+                sourceKey = sourceKey,
+                sourceUrl = request.sourceUrl,
+                commandKey = commandKey,
+                eventType = "STATUS_PAGE_INCIDENT_CREATED",
+                details = mapOf(
+                    "statusPageIncidentId" to JsonPrimitive(created.id),
+                    "status" to JsonPrimitive(created.status),
+                    "impact" to JsonPrimitive(created.impact),
+                ),
+            ),
+        )
+        return created
+    }
+
+    fun update(
+        target: IncidentStatusPageLinkTarget,
+        request: UpdateLinkedStatusPageIncidentRequest,
+        commandKey: String,
+    ): IncidentResponse {
+        val statusPageIncidentId = checkNotNull(target.statusPageIncidentId) {
+            "Status-page incident ID is required"
+        }
+        requireIncidentAccess(target.organizationId, target.actorUserId, target.incidentId)
+        request.title?.let { validateCustomerContent(it, null) }
+        request.message?.let { validateCustomerContent(null, it) }
+
+        val current = statusPageService.getIncident(target.statusPageId, target.organizationId, statusPageIncidentId)
+            ?: throw IncidentCommandNotFoundException("Status-page incident not found")
+        val updated = if (request.message != null) {
+            val base = if (request.title != null || request.impact != null) {
+                statusPageService.updateIncident(
+                    target.statusPageId,
+                    target.organizationId,
+                    statusPageIncidentId,
+                    UpdateIncidentRequest(
+                        title = request.title?.trim(),
+                        status = request.status?.trim(),
+                        impact = request.impact?.trim(),
+                    ),
+                ) ?: throw IncidentCommandNotFoundException("Status-page incident not found")
+            } else {
+                current
+            }
+            statusPageService.createIncidentUpdate(
+                target.statusPageId,
+                target.organizationId,
+                statusPageIncidentId,
+                CreateIncidentUpdateRequest(
+                    status = (request.status ?: base.status).trim(),
+                    message = request.message.trim(),
+                ),
+            )
+        } else {
+            statusPageService.updateIncident(
+                target.statusPageId,
+                target.organizationId,
+                statusPageIncidentId,
+                UpdateIncidentRequest(
+                    title = request.title?.trim(),
+                    status = request.status?.trim(),
+                    impact = request.impact?.trim(),
+                ),
+            )
+        } ?: throw IncidentCommandNotFoundException("Status-page incident not found")
+
+        val source = linkedSource(target.organizationId, target.incidentId, statusPageIncidentId)
+        timelineProducer.recordStatusPageChange(
+            IncidentTimelineProducerEvent(
+                organizationId = target.organizationId,
+                incidentId = target.incidentId,
+                eventKey = "status-page:$statusPageIncidentId:$commandKey",
+                eventType = "STATUS_PAGE_INCIDENT_UPDATED",
+                originalOccurredAt = Clock.System.now(),
+                actorUserId = target.actorUserId,
+                sourceReference = source?.sourceKey ?: "status-page:$statusPageIncidentId",
+                sourceUrl = source?.sourceUrl,
+                details = mapOf(
+                    "statusPageIncidentId" to JsonPrimitive(updated.id),
+                    "status" to JsonPrimitive(updated.status),
+                    "impact" to JsonPrimitive(updated.impact),
+                ),
+            ),
+        )
+        return updated
+    }
+
+    private fun linkAndRecord(request: LinkRecordRequest) {
+        incidentCommandService.execute(
+            LinkIncidentSourceCommand(
+                commandKey = request.commandKey,
+                actor = IncidentCommandActor(request.target.organizationId, request.target.actorUserId, "STATUS_PAGE"),
+                incidentId = request.target.incidentId,
+                source = IncidentSourceReference(
+                    sourceType = IncidentSourceType.URL,
+                    sourceKey = request.sourceKey,
+                    label = request.statusPageIncident.title,
+            sourceUrl = request.sourceUrl.trim(),
+                    metadata = mapOf(
+                        "statusPageId" to JsonPrimitive(request.target.statusPageId.toString()),
+                        "statusPageIncidentId" to JsonPrimitive(request.statusPageIncident.id),
+                    ),
+                ),
+            ),
+        )
+        timelineProducer.recordStatusPageChange(
+            IncidentTimelineProducerEvent(
+                organizationId = request.target.organizationId,
+                incidentId = request.target.incidentId,
+                eventKey = "status-page:${request.statusPageIncident.id}:${request.eventType}",
+                eventType = request.eventType,
+                originalOccurredAt = Clock.System.now(),
+                actorUserId = request.target.actorUserId,
+                sourceReference = request.sourceKey,
+                sourceUrl = request.sourceUrl,
+                details = request.details,
+            ),
+        )
+    }
+
+    private fun existingLinkedIncident(
+        organizationId: Int,
+        incidentId: Int,
+        sourceKey: String,
+    ): UUID? = transaction {
+        NativeIncidentSourceLinks
+            .selectAll()
+            .where {
+                (NativeIncidentSourceLinks.organizationId eq organizationId) and
+                    (NativeIncidentSourceLinks.incidentId eq incidentId) and
+                    (NativeIncidentSourceLinks.sourceType eq IncidentSourceType.URL.wire) and
+                    (NativeIncidentSourceLinks.sourceKey eq sourceKey)
+            }
+            .firstOrNull()
+            ?.get(NativeIncidentSourceLinks.metadata)
+            ?.get("statusPageIncidentId")
+            ?.let { (it as? JsonPrimitive)?.content }
+            ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+    }
+
+    private fun linkedSource(
+        organizationId: Int,
+        incidentId: Int,
+        statusPageIncidentId: UUID,
+    ): LinkedSource? = transaction {
+        NativeIncidentSourceLinks
+            .selectAll()
+            .where {
+                (NativeIncidentSourceLinks.organizationId eq organizationId) and
+                    (NativeIncidentSourceLinks.incidentId eq incidentId) and
+                    (NativeIncidentSourceLinks.sourceType eq IncidentSourceType.URL.wire)
+            }
+            .mapNotNull { row ->
+                val linkedId = row[NativeIncidentSourceLinks.metadata]["statusPageIncidentId"]
+                    ?.let { (it as? JsonPrimitive)?.content }
+                    ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+                if (linkedId == statusPageIncidentId) {
+                    LinkedSource(row[NativeIncidentSourceLinks.sourceKey], row[NativeIncidentSourceLinks.sourceUrl])
+                } else {
+                    null
+                }
+            }
+            .firstOrNull()
+    }
+
+    private fun requireIncidentAccess(
+        organizationId: Int,
+        actorUserId: Int,
+        incidentId: Int,
+    ) {
+        val allowed = transaction {
+            val incident = OnCallIncidents
+                .selectAll()
+                .where {
+                    (OnCallIncidents.id eq incidentId) and
+                        (OnCallIncidents.organizationId eq organizationId)
+                }
+                .firstOrNull() ?: throw IncidentCommandNotFoundException("Native incident not found")
+            val role = Memberships
+                .selectAll()
+                .where {
+                    (Memberships.organization_id eq organizationId) and
+                        (Memberships.user_id eq actorUserId)
+                }
+                .firstOrNull()
+                ?.get(Memberships.role)
+                ?.let(OrgRole::fromString)
+                ?: throw IncidentCommandDeniedException("Actor is not a member of the incident organization")
+            if (incident[OnCallIncidents.visibility] != NativeIncidentVisibility.PRIVATE.wire ||
+                role.level >= OrgRole.ADMIN.level
+            ) {
+                return@transaction true
+            }
+            val assigned = NativeIncidentRoleAssignments
+                .selectAll()
+                .where {
+                    (NativeIncidentRoleAssignments.organizationId eq organizationId) and
+                        (NativeIncidentRoleAssignments.incidentId eq incidentId) and
+                        (NativeIncidentRoleAssignments.assigneeUserId eq actorUserId) and
+                        NativeIncidentRoleAssignments.endedAt.isNull()
+                }
+                .limit(1)
+                .firstOrNull() != null
+            val participant = NativeIncidentParticipants
+                .selectAll()
+                .where {
+                    (NativeIncidentParticipants.organizationId eq organizationId) and
+                        (NativeIncidentParticipants.incidentId eq incidentId) and
+                        (NativeIncidentParticipants.userId eq actorUserId) and
+                        (NativeIncidentParticipants.participationType eq IncidentParticipationType.PARTICIPANT.wire) and
+                        NativeIncidentParticipants.leftAt.isNull()
+                }
+                .limit(1)
+                .firstOrNull() != null
+            assigned || participant
+        }
+        if (!allowed) throw IncidentCommandDeniedException("Actor is not authorized to update this incident")
+    }
+
+    private fun validateCustomerContent(title: String?, message: String?) {
+        title?.let {
+            require(it.trim().isNotEmpty()) { "Status-page title is required" }
+            require(it.length <= MAX_TITLE_LENGTH) { "Status-page title is too long" }
+        }
+        message?.let {
+            require(it.trim().isNotEmpty()) { "Status-page message is required" }
+            require(it.length <= MAX_MESSAGE_LENGTH) { "Status-page message is too long" }
+        }
+    }
+
+    private fun requireSafeSourceUrl(value: String) {
+        val uri = runCatching { URI(value.trim()) }.getOrNull()
+        require(
+            uri != null && uri.isAbsolute && uri.rawAuthority?.isNotBlank() == true &&
+                uri.scheme.lowercase() in setOf("http", "https"),
+        ) { "Status-page source URL must use HTTP or HTTPS" }
+    }
+
+    private fun requireCorrelationKey(value: String) {
+        require(value.trim().isNotEmpty()) { "Status-page correlation key is required" }
+        require(value.length <= MAX_CORRELATION_KEY_LENGTH) { "Status-page correlation key is too long" }
+    }
+
+    private fun sourceKey(statusPageId: UUID, correlationKey: String): String =
+        "status-page:$statusPageId:${correlationKey.trim()}"
+
+    private data class LinkedSource(
+        val sourceKey: String,
+        val sourceUrl: String?,
+    )
+
+    private data class LinkRecordRequest(
+        val target: IncidentStatusPageLinkTarget,
+        val statusPageIncident: IncidentResponse,
+        val sourceKey: String,
+        val sourceUrl: String,
+        val commandKey: String,
+        val eventType: String,
+        val details: Map<String, JsonPrimitive>,
+    )
+
+    private companion object {
+        const val MAX_TITLE_LENGTH = 255
+        const val MAX_MESSAGE_LENGTH = 10_000
+        const val MAX_CORRELATION_KEY_LENGTH = 160
+    }
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/statuspage/IncidentStatusPageLinkService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/statuspage/IncidentStatusPageLinkService.kt
@@ -5,6 +5,7 @@
 package com.moneat.enterprise.incidents.statuspage
 
 import com.moneat.enterprise.incidents.commands.IncidentCommandActor
+import com.moneat.enterprise.incidents.commands.IncidentCommandConflictException
 import com.moneat.enterprise.incidents.commands.IncidentCommandDeniedException
 import com.moneat.enterprise.incidents.commands.IncidentCommandNotFoundException
 import com.moneat.enterprise.incidents.commands.IncidentCommandService
@@ -76,37 +77,52 @@ class IncidentStatusPageLinkService(
         requireCorrelationKey(request.correlationKey)
 
         val sourceKey = sourceKey(target.statusPageId, request.correlationKey)
-        existingLinkedIncident(target.organizationId, target.incidentId, sourceKey)?.let { linkedId ->
-            return statusPageService.getIncident(target.statusPageId, target.organizationId, linkedId)
-                ?: throw IncidentCommandNotFoundException("Linked status-page incident not found")
-        }
+        return try {
+            transaction {
+                existingLinkedIncident(target.organizationId, target.incidentId, sourceKey)?.let { linkedId ->
+                    return@transaction statusPageService.getIncident(
+                        target.statusPageId,
+                        target.organizationId,
+                        linkedId,
+                    )
+                        ?: throw IncidentCommandNotFoundException("Linked status-page incident not found")
+                }
 
-        val created = statusPageService.createIncident(
-            target.statusPageId,
-            target.organizationId,
-            CreateIncidentRequest(
-                title = request.title.trim(),
-                status = request.status.trim(),
-                impact = request.impact.trim(),
-                message = request.message.trim(),
-            ),
-        )
-        linkAndRecord(
-            LinkRecordRequest(
-                target = target,
-                statusPageIncident = created,
-                sourceKey = sourceKey,
-                sourceUrl = request.sourceUrl,
-                commandKey = commandKey,
-                eventType = "STATUS_PAGE_INCIDENT_CREATED",
-                details = mapOf(
-                    "statusPageIncidentId" to JsonPrimitive(created.id),
-                    "status" to JsonPrimitive(created.status),
-                    "impact" to JsonPrimitive(created.impact),
-                ),
-            ),
-        )
-        return created
+                val statusPageIncidentId = UUID.randomUUID()
+                val created = statusPageService.createIncidentWithId(
+                    target.statusPageId,
+                    target.organizationId,
+                    statusPageIncidentId,
+                    CreateIncidentRequest(
+                        title = request.title.trim(),
+                        status = request.status.trim(),
+                        impact = request.impact.trim(),
+                        message = request.message.trim(),
+                    ),
+                )
+                linkAndRecord(
+                    LinkRecordRequest(
+                        target = target,
+                        statusPageIncident = created,
+                        sourceKey = sourceKey,
+                        sourceUrl = request.sourceUrl,
+                        commandKey = commandKey,
+                        eventType = "STATUS_PAGE_INCIDENT_CREATED",
+                        details = mapOf(
+                            "statusPageIncidentId" to JsonPrimitive(created.id),
+                            "status" to JsonPrimitive(created.status),
+                            "impact" to JsonPrimitive(created.impact),
+                        ),
+                    ),
+                )
+                created
+            }
+        } catch (exception: IncidentCommandConflictException) {
+            existingLinkedIncident(target.organizationId, target.incidentId, sourceKey)?.let { linkedId ->
+                statusPageService.getIncident(target.statusPageId, target.organizationId, linkedId)
+                    ?: throw IncidentCommandNotFoundException("Linked status-page incident not found")
+            } ?: throw exception
+        }
     }
 
     fun update(
@@ -120,6 +136,9 @@ class IncidentStatusPageLinkService(
         requireIncidentAccess(target.organizationId, target.actorUserId, target.incidentId)
         request.title?.let { validateCustomerContent(it, null) }
         request.message?.let { validateCustomerContent(null, it) }
+
+        val source = linkedSource(target.organizationId, target.incidentId, target.statusPageId, statusPageIncidentId)
+            ?: throw IncidentCommandNotFoundException("Status-page incident is not linked to this incident")
 
         val current = statusPageService.getIncident(target.statusPageId, target.organizationId, statusPageIncidentId)
             ?: throw IncidentCommandNotFoundException("Status-page incident not found")
@@ -160,7 +179,6 @@ class IncidentStatusPageLinkService(
             )
         } ?: throw IncidentCommandNotFoundException("Status-page incident not found")
 
-        val source = linkedSource(target.organizationId, target.incidentId, statusPageIncidentId)
         timelineProducer.recordStatusPageChange(
             IncidentTimelineProducerEvent(
                 organizationId = target.organizationId,
@@ -169,8 +187,8 @@ class IncidentStatusPageLinkService(
                 eventType = "STATUS_PAGE_INCIDENT_UPDATED",
                 originalOccurredAt = Clock.System.now(),
                 actorUserId = target.actorUserId,
-                sourceReference = source?.sourceKey ?: "status-page:$statusPageIncidentId",
-                sourceUrl = source?.sourceUrl,
+                sourceReference = source.sourceKey,
+                sourceUrl = source.sourceUrl,
                 details = mapOf(
                     "statusPageIncidentId" to JsonPrimitive(updated.id),
                     "status" to JsonPrimitive(updated.status),
@@ -237,6 +255,7 @@ class IncidentStatusPageLinkService(
     private fun linkedSource(
         organizationId: Int,
         incidentId: Int,
+        statusPageId: UUID,
         statusPageIncidentId: UUID,
     ): LinkedSource? = transaction {
         NativeIncidentSourceLinks
@@ -251,7 +270,14 @@ class IncidentStatusPageLinkService(
                     ?.let { (it as? JsonPrimitive)?.content }
                     ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
                 if (linkedId == statusPageIncidentId) {
-                    LinkedSource(row[NativeIncidentSourceLinks.sourceKey], row[NativeIncidentSourceLinks.sourceUrl])
+                    val linkedPageId = row[NativeIncidentSourceLinks.metadata]["statusPageId"]
+                        ?.let { (it as? JsonPrimitive)?.content }
+                        ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+                    if (linkedPageId == statusPageId) {
+                        LinkedSource(row[NativeIncidentSourceLinks.sourceKey], row[NativeIncidentSourceLinks.sourceUrl])
+                    } else {
+                        null
+                    }
                 } else {
                     null
                 }

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutes.kt
@@ -41,6 +41,10 @@ import com.moneat.enterprise.incidents.config.IncidentConfigurationService
 import com.moneat.enterprise.incidents.responders.IncidentResponderService
 import com.moneat.enterprise.incidents.response.IncidentResponseActivationService
 import com.moneat.enterprise.incidents.response.IncidentResponsePolicyInput
+import com.moneat.enterprise.incidents.statuspage.CreateLinkedStatusPageIncidentRequest
+import com.moneat.enterprise.incidents.statuspage.IncidentStatusPageLinkService
+import com.moneat.enterprise.incidents.statuspage.IncidentStatusPageLinkTarget
+import com.moneat.enterprise.incidents.statuspage.UpdateLinkedStatusPageIncidentRequest
 import com.moneat.enterprise.incidents.timeline.IncidentTimelineService
 import com.moneat.enterprise.incidents.models.IncidentFormStage
 import com.moneat.enterprise.incidents.models.IncidentParticipationType
@@ -77,6 +81,7 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.delete
+import io.ktor.server.routing.patch
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import kotlinx.serialization.Serializable
@@ -88,6 +93,7 @@ import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import kotlin.uuid.Uuid
 import kotlin.time.Instant
+import java.util.UUID
 
 private const val JWT_AUTH_PROVIDER = "auth-jwt"
 
@@ -287,6 +293,30 @@ data class IncidentResponsePolicyRequest(
     val pageRetrospectiveIncidents: Boolean = false,
 )
 
+@Serializable
+data class CreateStatusPageIncidentRouteRequest(
+    val statusPageId: String,
+    val title: String,
+    val status: String,
+    val impact: String = "none",
+    val message: String,
+    val sourceUrl: String,
+    val correlationKey: String,
+)
+
+@Serializable
+data class UpdateStatusPageIncidentRouteRequest(
+    val title: String? = null,
+    val status: String? = null,
+    val impact: String? = null,
+    val message: String? = null,
+)
+
+@Serializable
+data class ResolveStatusPageIncidentRouteRequest(
+    val message: String? = null,
+)
+
 private data class IncidentRouteServices(
     val alertServiceProvider: () -> OnCallAlertService,
     val incidentService: OnCallIncidentService,
@@ -295,6 +325,7 @@ private data class IncidentRouteServices(
     val responderService: IncidentResponderService,
     val timelineService: IncidentTimelineService,
     val actionService: IncidentActionService,
+    val statusPageLinkService: IncidentStatusPageLinkService,
     val responseService: IncidentResponseActivationService?,
 )
 
@@ -317,6 +348,7 @@ fun Route.incidentRoutes(
             responderService = IncidentResponderService(),
             timelineService = IncidentTimelineService(),
             actionService = IncidentActionService(),
+            statusPageLinkService = IncidentStatusPageLinkService(),
             responseService = incidentResponseActivationService,
         )
     registerIncidentCapabilitiesRoute(entitlementStatusProvider)
@@ -401,6 +433,7 @@ private fun Route.registerDeclaredIncidentRoutes(
             registerTriageCommandRoutes(services.incidentService)
             registerAddAlertToIncidentRoute(services.alertServiceProvider, services.incidentService)
             registerIncidentSourceRoutes(services.incidentService)
+            registerIncidentStatusPageRoutes(services.statusPageLinkService)
             registerIncidentResponderRoutes(services.incidentService, services.responderService)
             services.responseService?.let { registerIncidentResponseIncidentRoutes(it) }
             registerIncidentTimelineRoutes(services.timelineService)
@@ -545,6 +578,135 @@ private fun Route.registerIncidentSourceRoutes(onCallIncidentService: OnCallInci
         }
     }
 }
+
+private fun Route.registerIncidentStatusPageRoutes(
+    linkService: IncidentStatusPageLinkService,
+) {
+    route("/{id}/status-page-incidents") {
+        registerCreateStatusPageIncidentRoute(linkService)
+        registerUpdateStatusPageIncidentRoute(linkService)
+        registerResolveStatusPageIncidentRoute(linkService)
+    }
+}
+
+private fun Route.registerCreateStatusPageIncidentRoute(linkService: IncidentStatusPageLinkService) {
+    post {
+        val context = call.requireUserContext() ?: return@post
+        val incidentId = call.requireIncidentId(context.organizationId) ?: return@post
+        if (!call.requireIncidentResponderOrAdmin(context, incidentId)) return@post
+        val request = call.receive<CreateStatusPageIncidentRouteRequest>()
+        val statusPageId = parseStatusPageId(request.statusPageId)
+        if (statusPageId == null) {
+            call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid status page ID"))
+            return@post
+        }
+        try {
+            call.respond(
+                HttpStatusCode.Created,
+                linkService.create(
+                    target = IncidentStatusPageLinkTarget(
+                        organizationId = context.organizationId,
+                        actorUserId = context.userId,
+                        incidentId = incidentId,
+                        statusPageId = statusPageId,
+                    ),
+                    request = CreateLinkedStatusPageIncidentRequest(
+                        title = request.title,
+                        status = request.status,
+                        impact = request.impact,
+                        message = request.message,
+                        sourceUrl = request.sourceUrl,
+                        correlationKey = request.correlationKey,
+                    ),
+                    commandKey = call.incidentCommandKey("status-page-create"),
+                ),
+            )
+        } catch (error: IncidentCommandException) {
+            call.respondIncidentCommandFailure(error)
+        } catch (error: IllegalArgumentException) {
+            call.respond(HttpStatusCode.BadRequest, ErrorResponse(error.message))
+        }
+    }
+}
+
+private fun Route.registerUpdateStatusPageIncidentRoute(linkService: IncidentStatusPageLinkService) {
+    patch("/{statusPageId}/{statusPageIncidentId}") {
+        val context = call.requireUserContext() ?: return@patch
+        val incidentId = call.requireIncidentId(context.organizationId) ?: return@patch
+        if (!call.requireIncidentResponderOrAdmin(context, incidentId)) return@patch
+        val statusPageId = parseStatusPageId(call.parameters["statusPageId"])
+        val statusPageIncidentId = parseStatusPageId(call.parameters["statusPageIncidentId"])
+        if (statusPageId == null || statusPageIncidentId == null) {
+            call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid status-page incident ID"))
+            return@patch
+        }
+        val request = call.receive<UpdateStatusPageIncidentRouteRequest>()
+        try {
+            call.respond(
+                linkService.update(
+                    target = IncidentStatusPageLinkTarget(
+                        organizationId = context.organizationId,
+                        actorUserId = context.userId,
+                        incidentId = incidentId,
+                        statusPageId = statusPageId,
+                        statusPageIncidentId = statusPageIncidentId,
+                    ),
+                    request = UpdateLinkedStatusPageIncidentRequest(
+                        title = request.title,
+                        status = request.status,
+                        impact = request.impact,
+                        message = request.message,
+                    ),
+                    commandKey = call.incidentCommandKey("status-page-update"),
+                ),
+            )
+        } catch (error: IncidentCommandException) {
+            call.respondIncidentCommandFailure(error)
+        } catch (error: IllegalArgumentException) {
+            call.respond(HttpStatusCode.BadRequest, ErrorResponse(error.message))
+        }
+    }
+}
+
+private fun Route.registerResolveStatusPageIncidentRoute(linkService: IncidentStatusPageLinkService) {
+    post("/{statusPageId}/{statusPageIncidentId}/resolve") {
+        val context = call.requireUserContext() ?: return@post
+        val incidentId = call.requireIncidentId(context.organizationId) ?: return@post
+        if (!call.requireIncidentResponderOrAdmin(context, incidentId)) return@post
+        val statusPageId = parseStatusPageId(call.parameters["statusPageId"])
+        val statusPageIncidentId = parseStatusPageId(call.parameters["statusPageIncidentId"])
+        if (statusPageId == null || statusPageIncidentId == null) {
+            call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid status-page incident ID"))
+            return@post
+        }
+        val request = call.receiveNullable<ResolveStatusPageIncidentRouteRequest>()
+        try {
+            call.respond(
+                linkService.update(
+                    target = IncidentStatusPageLinkTarget(
+                        organizationId = context.organizationId,
+                        actorUserId = context.userId,
+                        incidentId = incidentId,
+                        statusPageId = statusPageId,
+                        statusPageIncidentId = statusPageIncidentId,
+                    ),
+                    request = UpdateLinkedStatusPageIncidentRequest(
+                        status = "resolved",
+                        message = request?.message,
+                    ),
+                    commandKey = call.incidentCommandKey("status-page-resolve"),
+                ),
+            )
+        } catch (error: IncidentCommandException) {
+            call.respondIncidentCommandFailure(error)
+        } catch (error: IllegalArgumentException) {
+            call.respond(HttpStatusCode.BadRequest, ErrorResponse(error.message))
+        }
+    }
+}
+
+private fun parseStatusPageId(raw: String?): UUID? =
+    raw?.let { value -> runCatching { UUID.fromString(value) }.getOrNull() }
 
 private suspend fun ApplicationCall.resolveIncidentSource(
     organizationId: Int,

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/IncidentTestDatabase.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/IncidentTestDatabase.kt
@@ -60,6 +60,9 @@ import com.moneat.shared.models.OrganizationTeams
 import com.moneat.shared.models.Organizations
 import com.moneat.monitor.repositories.ResourceOwnership
 import com.moneat.shared.models.Users
+import com.moneat.statuspage.models.StatusPageIncidentUpdates
+import com.moneat.statuspage.models.StatusPageIncidents
+import com.moneat.statuspage.models.StatusPages
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
@@ -80,6 +83,9 @@ object IncidentTestDatabase {
         EnterpriseTestDatabaseHelper.resetSchema(
             Users,
             Organizations,
+            StatusPages,
+            StatusPageIncidents,
+            StatusPageIncidentUpdates,
             OrganizationIntegrations,
             Memberships,
             OnCallSchedules,

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/statuspage/IncidentStatusPageLinkServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/statuspage/IncidentStatusPageLinkServiceTest.kt
@@ -8,6 +8,7 @@ import com.moneat.enterprise.incidents.IncidentTestDatabase
 import com.moneat.enterprise.incidents.SeededMember
 import com.moneat.enterprise.incidents.commands.DeclareIncidentCommand
 import com.moneat.enterprise.incidents.commands.IncidentCommandActor
+import com.moneat.enterprise.incidents.commands.IncidentCommandNotFoundException
 import com.moneat.enterprise.incidents.commands.IncidentCommandPolicy
 import com.moneat.enterprise.incidents.commands.IncidentCommandService
 import com.moneat.enterprise.incidents.models.NativeIncidentMode
@@ -16,6 +17,8 @@ import com.moneat.enterprise.incidents.models.NativeIncidentVisibility
 import com.moneat.enterprise.incidents.models.NativeIncidentSourceLinks
 import com.moneat.enterprise.oncall.models.OnCallIncidentTimeline
 import com.moneat.statuspage.models.CreateStatusPageRequest
+import com.moneat.statuspage.models.IncidentResponse
+import com.moneat.statuspage.models.StatusPageIncidents
 import com.moneat.statuspage.services.StatusPageService
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
@@ -25,6 +28,9 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
@@ -92,6 +98,37 @@ class IncidentStatusPageLinkServiceTest {
     }
 
     @Test
+    fun `concurrent creates with the same correlation key return one incident`() {
+        val executor = Executors.newFixedThreadPool(2)
+        val ready = CountDownLatch(2)
+        val start = CountDownLatch(1)
+        try {
+            val futures = (1..2).map { index ->
+                executor.submit<IncidentResponse> {
+                    ready.countDown()
+                    check(start.await(10, TimeUnit.SECONDS)) { "Concurrent create did not start" }
+                    service.create(target(), createRequest(), "concurrent-create-$index")
+                }
+            }
+            check(ready.await(10, TimeUnit.SECONDS)) { "Concurrent create workers did not become ready" }
+            start.countDown()
+
+            val results = futures.map { it.get(10, TimeUnit.SECONDS) }
+            assertEquals(1, results.map(IncidentResponse::id).distinct().size)
+            assertEquals(
+                1,
+                transaction {
+                    StatusPageIncidents.selectAll().where {
+                        StatusPageIncidents.statusPageId eq statusPageId
+                    }.count()
+                },
+            )
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
     fun `update with a message publishes a status-page update and resolve changes status`() {
         val created = service.create(target(), createRequest(), "create")
         val updated = service.update(
@@ -107,6 +144,34 @@ class IncidentStatusPageLinkServiceTest {
 
         assertEquals("investigating", updated.status)
         assertEquals("resolved", resolved.status)
+    }
+
+    @Test
+    fun `update rejects a status-page incident linked to another native incident`() {
+        val otherIncidentId = IncidentCommandService(policy = IncidentCommandPolicy.allowForTests()).execute(
+            DeclareIncidentCommand(
+                commandKey = "declare-other-status-page",
+                actor = actor(),
+                title = "Other incident",
+                description = null,
+                severity = "SEV-2",
+                mode = NativeIncidentMode.TEST,
+                visibility = NativeIncidentVisibility.ORGANIZATION,
+                initialStatus = NativeIncidentStatus.ACTIVE,
+            ),
+        ).incidentId
+        val created = service.create(target(), createRequest(), "create-linked-other")
+
+        assertFailsWith<IncidentCommandNotFoundException> {
+            service.update(
+                target().copy(
+                    incidentId = otherIncidentId,
+                    statusPageIncidentId = UUID.fromString(created.id),
+                ),
+                UpdateLinkedStatusPageIncidentRequest(status = "resolved"),
+                "cross-incident-update",
+            )
+        }
     }
 
     @Test

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/statuspage/IncidentStatusPageLinkServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/statuspage/IncidentStatusPageLinkServiceTest.kt
@@ -1,0 +1,154 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.incidents.statuspage
+
+import com.moneat.enterprise.incidents.IncidentTestDatabase
+import com.moneat.enterprise.incidents.SeededMember
+import com.moneat.enterprise.incidents.commands.DeclareIncidentCommand
+import com.moneat.enterprise.incidents.commands.IncidentCommandActor
+import com.moneat.enterprise.incidents.commands.IncidentCommandPolicy
+import com.moneat.enterprise.incidents.commands.IncidentCommandService
+import com.moneat.enterprise.incidents.models.NativeIncidentMode
+import com.moneat.enterprise.incidents.models.NativeIncidentStatus
+import com.moneat.enterprise.incidents.models.NativeIncidentVisibility
+import com.moneat.enterprise.incidents.models.NativeIncidentSourceLinks
+import com.moneat.enterprise.oncall.models.OnCallIncidentTimeline
+import com.moneat.statuspage.models.CreateStatusPageRequest
+import com.moneat.statuspage.services.StatusPageService
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+
+class IncidentStatusPageLinkServiceTest {
+    private lateinit var member: SeededMember
+    private var incidentId: Int = 0
+    private lateinit var statusPageId: UUID
+    private lateinit var service: IncidentStatusPageLinkService
+
+    @BeforeEach
+    fun setUp() {
+        IncidentTestDatabase.reset()
+        member = IncidentTestDatabase.seedMember("status-page-link")
+        val commandService = IncidentCommandService(policy = IncidentCommandPolicy.allowForTests())
+        incidentId = commandService.execute(
+            DeclareIncidentCommand(
+                commandKey = "declare-status-page",
+                actor = actor(),
+                title = "Checkout degraded",
+                description = "Checkout requests are slow",
+                severity = "SEV-2",
+                mode = NativeIncidentMode.TEST,
+                visibility = NativeIncidentVisibility.ORGANIZATION,
+                initialStatus = NativeIncidentStatus.ACTIVE,
+            ),
+        ).incidentId
+        statusPageId = StatusPageService().createStatusPage(
+            member.organizationId,
+            CreateStatusPageRequest("Public status", "public-status"),
+        ).id.let(UUID::fromString)
+        service = IncidentStatusPageLinkService(incidentCommandService = commandService)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        IncidentTestDatabase.clearReference()
+    }
+
+    @Test
+    fun `create is linked and idempotent by correlation key`() {
+        val request = createRequest()
+        val target = target()
+        val first = service.create(target, request, "create-1")
+        val second = service.create(target, request, "create-2")
+
+        assertEquals(first.id, second.id)
+        assertEquals(
+            1,
+            transaction {
+                NativeIncidentSourceLinks.selectAll().where {
+                    (NativeIncidentSourceLinks.incidentId eq incidentId) and
+                        (NativeIncidentSourceLinks.sourceType eq "URL")
+                }.count()
+            },
+        )
+        assertNotNull(
+            transaction {
+                OnCallIncidentTimeline.selectAll().where {
+                    (OnCallIncidentTimeline.incidentId eq incidentId) and
+                        (OnCallIncidentTimeline.eventType eq "STATUS_PAGE_INCIDENT_CREATED")
+                }.singleOrNull()
+            },
+        )
+    }
+
+    @Test
+    fun `update with a message publishes a status-page update and resolve changes status`() {
+        val created = service.create(target(), createRequest(), "create")
+        val updated = service.update(
+            target().copy(statusPageIncidentId = UUID.fromString(created.id)),
+            UpdateLinkedStatusPageIncidentRequest(message = "We are monitoring recovery"),
+            "update",
+        )
+        val resolved = service.update(
+            target().copy(statusPageIncidentId = UUID.fromString(created.id)),
+            UpdateLinkedStatusPageIncidentRequest(status = "resolved"),
+            "resolve",
+        )
+
+        assertEquals("investigating", updated.status)
+        assertEquals("resolved", resolved.status)
+    }
+
+    @Test
+    fun `private incidents require an active responder`() {
+        val privateIncident = IncidentCommandService(policy = IncidentCommandPolicy.allowForTests()).execute(
+            DeclareIncidentCommand(
+                commandKey = "declare-private-status-page",
+                actor = actor(),
+                title = "Private incident",
+                description = null,
+                severity = "SEV-2",
+                mode = NativeIncidentMode.TEST,
+                visibility = NativeIncidentVisibility.PRIVATE,
+                initialStatus = NativeIncidentStatus.ACTIVE,
+            ),
+        )
+        val outsiderUserId = IncidentTestDatabase.seedUserInOrganization(member.organizationId, "status-page-outsider")
+
+        assertFailsWith<com.moneat.enterprise.incidents.commands.IncidentCommandDeniedException> {
+            service.create(
+                target().copy(actorUserId = outsiderUserId, incidentId = privateIncident.incidentId),
+                createRequest(),
+                "private-create",
+            )
+        }
+    }
+
+    private fun createRequest() = CreateLinkedStatusPageIncidentRequest(
+        title = "Checkout degraded",
+        status = "investigating",
+        impact = "minor",
+        message = "We are investigating elevated checkout latency.",
+        sourceUrl = "https://status.example.test/incidents/checkout",
+        correlationKey = "checkout-degraded",
+    )
+
+    private fun target() = IncidentStatusPageLinkTarget(
+        organizationId = member.organizationId,
+        actorUserId = member.userId,
+        incidentId = incidentId,
+        statusPageId = statusPageId,
+    )
+
+    private fun actor() = IncidentCommandActor(member.organizationId, member.userId, "TEST")
+}


### PR DESCRIPTION
Adds authenticated status-page incident create, update, and resolve operations under the canonical incident routes.

- enforces organization membership and private-incident responder access
- links status-page incidents as source records with stable correlation keys
- records status-page activity in the canonical timeline
- covers idempotency and authorization with focused enterprise tests

Validation: :ee:test --tests com.moneat.enterprise.incidents.statuspage.IncidentStatusPageLinkServiceTest; :ee:detekt; git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added integration between incidents and status pages.
  - Create, update, and resolve linked status-page incidents directly from incident workflows.
  - Incident updates can include status, impact, title, and messages.
  - Duplicate create requests are safely handled without creating duplicate status-page incidents.
  - Added access controls and validation for linked incident operations.
- **Tests**
  - Added coverage for linking, updating, resolving, authorization, and duplicate request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->